### PR TITLE
External barcode support on HU-Unpack

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -476,12 +476,14 @@ public class HUQRCodesService
 			return (HUQRCode)huQRCode;
 		}
 
-		// Both values matter when diagnosing this: the raw code the operator scanned, and the concrete
-		// IHUQRCode implementation parse() recognized it as - the latter is what tells you WHY it was
-		// rejected (e.g. a GS1 or pick-on-the-fly code, which identifies no existing unit).
+		// huQRCodeType is the load-bearing parameter: it names WHY the code was rejected (a GS1,
+		// EAN13, LM, custom-format or pick-on-the-fly code identifies no existing unit). The instance
+		// alone would not convey that - every IHUQRCode reachable here renders via getAsString(),
+		// which echoes back the scanned string, so it would just duplicate scannedCode.
 		throw new AdempiereException("Invalid HU QR code")
 				.appendParametersToMessage()
 				.setParameter("scannedCode", scannedCode)
+				.setParameter("huQRCodeType", huQRCode.getClass().getSimpleName())
 				.setParameter("huQRCode", huQRCode);
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -450,14 +450,6 @@ public class HUQRCodesService
 	}
 
 	/**
-	 * Resolves any supported scanned code (metasfresh global QR code, {@code M_HU.Value}/ExternalBarcode label, ...)
-	 * to the {@link HUQRCode} of the handling unit it identifies.
-	 * <p>
-	 * Unlike {@link HUQRCode#fromGlobalQRCodeJsonString}, this accepts every code format {@link #parse(ScannedCode)}
-	 * understands, not only a metasfresh global QR code.
-	 */
-	@NonNull
-	/**
 	 * Resolves any scanned code that identifies an existing handling unit to that unit's {@link HUQRCode}.
 	 * <p>
 	 * {@link #parse(ScannedCode)} already covers every supported label kind — a metasfresh global QR code,
@@ -467,6 +459,7 @@ public class HUQRCodesService
 	 * resolved by a second lookup: silently mapping such a code onto whichever HU happens to share its value
 	 * would pick from the wrong unit.
 	 */
+	@NonNull
 	public HUQRCode getQRCodeByScannedCode(@NonNull final ScannedCode scannedCode)
 	{
 		final IHUQRCode huQRCode = parse(scannedCode);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -448,4 +448,33 @@ public class HUQRCodesService
 		}
 		throw MobileQRCodeMessages.newNotRecognizedException(scannedCode);
 	}
+
+	/**
+	 * Resolves any supported scanned code (metasfresh global QR code, {@code M_HU.Value}/ExternalBarcode label, ...)
+	 * to the {@link HUQRCode} of the handling unit it identifies.
+	 * <p>
+	 * Unlike {@link HUQRCode#fromGlobalQRCodeJsonString}, this accepts every code format {@link #parse(ScannedCode)}
+	 * understands, not only a metasfresh global QR code.
+	 */
+	@NonNull
+	/**
+	 * Resolves any scanned code that identifies an existing handling unit to that unit's {@link HUQRCode}.
+	 * <p>
+	 * {@link #parse(ScannedCode)} already covers every supported label kind — a metasfresh global QR code,
+	 * a configured scannable code format, and a plain {@code M_HU.Value} / {@code ExternalBarcode} attribute —
+	 * so this method only narrows its result. A code that parses to something other than an assigned HU QR code
+	 * (a pick-on-the-fly, LM, GS1 or EAN13 code) does NOT identify an existing HU and is rejected rather than
+	 * resolved by a second lookup: silently mapping such a code onto whichever HU happens to share its value
+	 * would pick from the wrong unit.
+	 */
+	public HUQRCode getQRCodeByScannedCode(@NonNull final ScannedCode scannedCode)
+	{
+		final IHUQRCode huQRCode = parse(scannedCode);
+		if (huQRCode instanceof HUQRCode)
+		{
+			return (HUQRCode)huQRCode;
+		}
+
+		throw new AdempiereException("Invalid HU QR code: " + scannedCode);
+	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -476,6 +476,12 @@ public class HUQRCodesService
 			return (HUQRCode)huQRCode;
 		}
 
-		throw new AdempiereException("Invalid HU QR code: " + scannedCode);
+		// Both values matter when diagnosing this: the raw code the operator scanned, and the concrete
+		// IHUQRCode implementation parse() recognized it as - the latter is what tells you WHY it was
+		// rejected (e.g. a GS1 or pick-on-the-fly code, which identifies no existing unit).
+		throw new AdempiereException("Invalid HU QR code")
+				.appendParametersToMessage()
+				.setParameter("scannedCode", scannedCode)
+				.setParameter("huQRCode", huQRCode);
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -452,14 +452,20 @@ public class HUQRCodesService
 	/**
 	 * Returns the {@link HUQRCode} of the handling unit that the scanned code refers to.
 	 * <p>
-	 * Every label kind that can appear on a unit is accepted: a metasfresh global QR code, a configured
-	 * scannable code format, or the plain {@code M_HU.Value} / {@code ExternalBarcode} printed on it.
-	 * {@link #parse(ScannedCode)} already resolves all of them, so this method only narrows its result.
+	 * Accepted are the two code kinds that identify one specific unit: a metasfresh global QR code, and
+	 * the plain {@code M_HU.Value} / {@code ExternalBarcode} printed on the unit (which
+	 * {@link #parse(ScannedCode)} resolves by looking the unit up and returning <em>its</em> QR code).
 	 * <p>
-	 * Some codes are recognized by {@code parse} but do not refer to an existing unit — a pick-on-the-fly,
-	 * LM, GS1 or EAN13 code. Those are rejected. They are deliberately not retried as an
-	 * {@code M_HU.Value} / {@code ExternalBarcode} lookup, because such a code could coincidentally equal
-	 * some unit's value; picking from the wrong unit would be worse than a clear rejection.
+	 * Every other {@link IHUQRCode} that {@code parse} can return describes goods or an intent rather
+	 * than a unit — {@code PickOnTheFlyQRCode}, {@code LMQRCode}, {@code CustomHUQRCode} (a configured
+	 * scannable code format), {@code GS1HUQRCode}, {@code EAN13HUQRCode} — and is rejected here. Such a
+	 * code is deliberately not retried as an {@code M_HU.Value} / {@code ExternalBarcode} lookup: it
+	 * could coincidentally equal some unit's value, and picking from the wrong unit would be worse than
+	 * a clear rejection.
+	 * <p>
+	 * Note that resolving a product-scoped code to a unit is possible where a product context exists —
+	 * {@code PickFromHUQRCodeResolveCommand} does it for the pick-from side — but that needs a
+	 * {@code ProductId}, which a caller identifying a bare target unit does not have.
 	 */
 	@NonNull
 	public HUQRCode getQRCodeByScannedCode(@NonNull final ScannedCode scannedCode)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -450,14 +450,16 @@ public class HUQRCodesService
 	}
 
 	/**
-	 * Resolves any scanned code that identifies an existing handling unit to that unit's {@link HUQRCode}.
+	 * Returns the {@link HUQRCode} of the handling unit that the scanned code refers to.
 	 * <p>
-	 * {@link #parse(ScannedCode)} already covers every supported label kind — a metasfresh global QR code,
-	 * a configured scannable code format, and a plain {@code M_HU.Value} / {@code ExternalBarcode} attribute —
-	 * so this method only narrows its result. A code that parses to something other than an assigned HU QR code
-	 * (a pick-on-the-fly, LM, GS1 or EAN13 code) does NOT identify an existing HU and is rejected rather than
-	 * resolved by a second lookup: silently mapping such a code onto whichever HU happens to share its value
-	 * would pick from the wrong unit.
+	 * Every label kind that can appear on a unit is accepted: a metasfresh global QR code, a configured
+	 * scannable code format, or the plain {@code M_HU.Value} / {@code ExternalBarcode} printed on it.
+	 * {@link #parse(ScannedCode)} already resolves all of them, so this method only narrows its result.
+	 * <p>
+	 * Some codes are recognized by {@code parse} but do not refer to an existing unit — a pick-on-the-fly,
+	 * LM, GS1 or EAN13 code. Those are rejected. They are deliberately not retried as an
+	 * {@code M_HU.Value} / {@code ExternalBarcode} lookup, because such a code could coincidentally equal
+	 * some unit's value; picking from the wrong unit would be worse than a clear rejection.
 	 */
 	@NonNull
 	public HUQRCode getQRCodeByScannedCode(@NonNull final ScannedCode scannedCode)

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
@@ -44,6 +44,7 @@ import de.metas.handlingunits.qrcodes.special.PickOnTheFlyQRCode;
 import de.metas.organization.OrgId;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
+import de.metas.scannable_code.ScannedCode;
 import de.metas.util.Services;
 import de.metas.util.collections.CollectionUtils;
 import lombok.Builder;
@@ -52,6 +53,7 @@ import lombok.Value;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.api.AttributeConstants;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ClientId;
 import org.adempiere.service.ISysConfigBL;
 import org.junit.jupiter.api.BeforeEach;
@@ -297,6 +299,44 @@ class HUQRCodesServiceTest
 			assertThat(huQRCodesService.getQRCodeByHuId(huId))
 					.isEqualTo(qrCode)
 					.isNotSameAs(qrCode);
+		}
+	}
+
+	@Nested
+	class getQRCodeByScannedCode
+	{
+		@Test
+		void globalQRCode()
+		{
+			setGenerateQRCodeIfMissing(true);
+
+			final HuId tuId = createTU();
+			final HUQRCode expectedQrCode = huQRCodesService.getQRCodeByHuId(tuId);
+
+			final HUQRCode resolvedQrCode = huQRCodesService.getQRCodeByScannedCode(ScannedCode.ofString(expectedQrCode.toGlobalQRCodeString()));
+
+			assertThat(resolvedQrCode).isEqualTo(expectedQrCode);
+		}
+
+		@Test
+		void externalBarcode()
+		{
+			setGenerateQRCodeIfMissing(true);
+
+			final HuId tuId = createTU();
+			final HUQRCode expectedQrCode = huQRCodesService.getQRCodeByHuId(tuId);
+
+			final String externalBarcode = "EXT-BARCODE-123";
+			final I_M_HU hu = InterfaceWrapperHelper.load(tuId, I_M_HU.class);
+			final IAttributeStorage huAttributes = helper.createMutableHUContext()
+					.getHUAttributeStorageFactory()
+					.getAttributeStorage(hu);
+			huAttributes.setSaveOnChange(true);
+			huAttributes.setValue(AttributeConstants.ATTR_ExternalBarcode, externalBarcode);
+
+			final HUQRCode resolvedQrCode = huQRCodesService.getQRCodeByScannedCode(ScannedCode.ofString(externalBarcode));
+
+			assertThat(resolvedQrCode).isEqualTo(expectedQrCode);
 		}
 	}
 

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
@@ -338,6 +338,17 @@ class HUQRCodesServiceTest
 
 			assertThat(resolvedQrCode).isEqualTo(expectedQrCode);
 		}
+
+		@Test
+		void codeThatParsesToSomethingOtherThanAnAssignedHU_isRejected()
+		{
+			// "PICK_ON_THE_FLY" parses successfully - but to a PickOnTheFlyQRCode, which identifies no
+			// existing handling unit. It must be rejected rather than resolved onto whichever HU happens
+			// to carry that string as its M_HU.Value / ExternalBarcode.
+			assertThatThrownBy(() -> huQRCodesService.getQRCodeByScannedCode(ScannedCode.ofString("PICK_ON_THE_FLY")))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("Invalid HU QR code");
+		}
 	}
 
 	@Nested

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/PickingMobileApplication.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/PickingMobileApplication.java
@@ -47,6 +47,7 @@ import de.metas.handlingunits.picking.job.model.TUPickingTarget;
 import de.metas.handlingunits.picking.job.service.commands.get_next_eligible_line.GetNextEligibleLineToPackRequest;
 import de.metas.handlingunits.picking.job.service.commands.get_next_eligible_line.GetNextEligibleLineToPackResponse;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
+import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
 import de.metas.handlingunits.serialno.SerialNoSet;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.TranslatableStrings;
@@ -127,6 +128,7 @@ public class PickingMobileApplication implements WorkflowBasedMobileApplication
 	@NonNull private final PickingWorkflowLaunchersProvider wfLaunchersProvider;
 	@NonNull private final DisplayValueProviderService displayValueProviderService;
 	@NonNull private final PackedHUCarrierAdviseService packedHUCarrierAdviseService;
+	@NonNull private final HUQRCodesService huQRCodesService;
 
 	@Override
 	public MobileApplicationId getApplicationId() {return APPLICATION_ID;}
@@ -449,7 +451,7 @@ public class PickingMobileApplication implements WorkflowBasedMobileApplication
 		return pickingJobRestService.processStepEvents(pickingJob, events);
 	}
 
-	private static PickingJobStepEvent fromJson(
+	private PickingJobStepEvent fromJson(
 			@NonNull final JsonPickingStepEvent json,
 			@NonNull final PickingJob pickingJob,
 			@NonNull final PickingJobOptions pickingJobOptions)
@@ -479,8 +481,14 @@ public class PickingMobileApplication implements WorkflowBasedMobileApplication
 				.serialNos(json.getSerialNos() != null ? SerialNoSet.parseStrings(json.getSerialNos()) : null)
 				.isCloseTarget(json.isCloseTarget())
 				//
+				// Any supported HU label may identify the unpack target - a metasfresh global QR code, a
+				// configured scannable code format, or the plain M_HU.Value / ExternalBarcode printed on the
+				// unit. Resolving through the shared bridge keeps this in step with the pick-from side, which
+				// has always accepted all of them. A skipped target scan stays legal (unpick to the floor),
+				// so the blank-tolerant Optional chain is preserved.
 				.unpickToTargetQRCode(StringUtils.trimBlankToOptional(json.getUnpickToTargetQRCode())
-						.map(HUQRCode::fromGlobalQRCodeJsonString)
+						.map(ScannedCode::ofString)
+						.map(huQRCodesService::getQRCodeByScannedCode)
 						.orElse(null))
 				.unpickProductId(ProductId.ofNullableString(json.getUnpickProductId()))
 				.qtyToUnpick(json.getUnpickQty())

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/activity_handlers/SetPickFromHUWFActivityHandler.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/activity_handlers/SetPickFromHUWFActivityHandler.java
@@ -4,10 +4,10 @@ import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.picking.job.model.HUInfo;
 import de.metas.handlingunits.picking.job.model.PickingJob;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
-import de.metas.handlingunits.qrcodes.model.IHUQRCode;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
 import de.metas.picking.workflow.PickingJobRestService;
 import de.metas.picking.workflow.handlers.PickingMobileApplication;
+import de.metas.scannable_code.ScannedCode;
 import de.metas.workflow.rest_api.activity_features.set_scanned_barcode.JsonQRCode;
 import de.metas.workflow.rest_api.activity_features.set_scanned_barcode.SetScannedBarcodeRequest;
 import de.metas.workflow.rest_api.activity_features.set_scanned_barcode.SetScannedBarcodeSupport;
@@ -21,7 +21,6 @@ import de.metas.workflow.rest_api.model.WFProcess;
 import de.metas.workflow.rest_api.service.WFActivityHandler;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.adempiere.exceptions.AdempiereException;
 import org.springframework.stereotype.Component;
 
 import static de.metas.picking.workflow.handlers.activity_handlers.PickingWFActivityHelper.getPickingJob;
@@ -82,7 +81,7 @@ public class SetPickFromHUWFActivityHandler implements WFActivityHandler, SetSca
 	@Override
 	public WFProcess setScannedBarcode(@NonNull final SetScannedBarcodeRequest request)
 	{
-		final HUQRCode qrCode = parseHUQRCode(request.getScannedBarcode());
+		final HUQRCode qrCode = huQRCodesService.getQRCodeByScannedCode(ScannedCode.ofString(request.getScannedBarcode()));
 		final HuId huId = huQRCodesService.getHuIdByQRCode(qrCode);
 		final HUInfo pickFromHU = HUInfo.builder()
 				.id(huId)
@@ -93,18 +92,5 @@ public class SetPickFromHUWFActivityHandler implements WFActivityHandler, SetSca
 				request.getWfProcess(),
 				pickingJob -> pickingJobRestService.setPickFromHU(pickingJob, pickFromHU)
 		);
-	}
-
-	private HUQRCode parseHUQRCode(final String scannedCode)
-	{
-		final IHUQRCode huQRCode = huQRCodesService.parse(scannedCode);
-		if (huQRCode instanceof HUQRCode)
-		{
-			return (HUQRCode)huQRCode;
-		}
-		else
-		{
-			throw new AdempiereException("Invalid HU QR code: " + scannedCode);
-		}
 	}
 }

--- a/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_spanning_picks.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_spanning_picks.spec.js
@@ -33,6 +33,12 @@ const createMasterdata = async ({ packedGtin }) => {
                     // Bare TU target (no LU): the CU is packed directly into a top-level TU.
                     pickTo: ['TU'],
                     allowCompletingPartialPickingJob: true,
+                    // Both scenarios below pick PARTIALLY (2 of 4), which leaves a rejected qty. The
+                    // rejected-reason prompt is a sticky header-row field shared by the whole suite, so
+                    // inheriting it makes these specs depend on whatever ran before them (and on the DB
+                    // flavour). Set it explicitly: no reason is required, so the qty dialog can be
+                    // confirmed and the scenario is about the unpick, not about the reason prompt.
+                    allowSkippingRejectedReason: true,
                 }
             },
             bpartners: { "BP1": {} },

--- a/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_two_lines.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_two_lines.spec.js
@@ -37,6 +37,12 @@ const createMasterdata = async ({ gtinP1, gtinP2 }) => {
                     // top-level TU (sales_order aggregation sets the pick target once, at job level).
                     pickTo: ['TU'],
                     allowCompletingPartialPickingJob: true,
+                    // Both scenarios below pick PARTIALLY (2 of 4), which leaves a rejected qty. The
+                    // rejected-reason prompt is a sticky header-row field shared by the whole suite, so
+                    // inheriting it makes these specs depend on whatever ran before them (and on the DB
+                    // flavour). Set it explicitly: no reason is required, so the qty dialog can be
+                    // confirmed and the scenario is about the unpick, not about the reason prompt.
+                    allowSkippingRejectedReason: true,
                 }
             },
             bpartners: { "BP1": {} },

--- a/e2e/mobile-webui/tests/spec/picking/unpack/picking_unpack_legacy_label_target.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/unpack/picking_unpack_legacy_label_target.spec.js
@@ -1,0 +1,243 @@
+import { test } from "../../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../../../utils/screens/picking/PickingJobScreen";
+import { Backend } from "../../../utils/screens/Backend";
+import { LoginScreen } from "../../../utils/screens/LoginScreen";
+import { expectErrorToast } from "../../../utils/common";
+import { expect } from '@playwright/test';
+
+// A valid 14-digit GS1 GTIN, made unique per run so the strict GTIN->product resolve
+// (ProductDAO.getProductIdByGTINStrictly, AD_Client_ID=METASFRESH) matches EXACTLY one product.
+// Same technique as picking_partial_unpack.spec.js / pick_by_ExternalBarcode.spec.js.
+let _gtinSeq = 0;
+const uniqueGtin14 = () => {
+    const seq = `${(_gtinSeq++) % 100}`.padStart(2, '0');
+    const ts = `${Date.now()}`.slice(-11).padStart(11, '0');
+    return `9${seq}${ts}`;
+};
+// The GS1 scannable string for a product GTIN: Application Identifier 01 + the 14-digit GTIN.
+const gs1GtinScan = (gtin14) => `01${gtin14}`;
+
+// The order is fully picked onto one LU, then a partial qty is unpacked ("Entpacken") back onto a
+// SECOND, already-open target LU that carries a legacy/customer label instead of a metasfresh QR
+// code. This mirrors picking_partial_unpack.spec.js's masterdata shape (see its comments for why the
+// target LU's starting fill is forced to the PI's full 20 TU x 4 = 80 PCE and cannot be created empty).
+const createMasterdata = async ({ packedGtin, targetExternalBarcode } = {}) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                    // Not exercised by these tests (nothing here completes a partial job), but the header
+                    // row is sticky (../../../CLAUDE.md "Debugging Flaky Tests" rule 3) and this spec
+                    // already writes the other picking fields on that same row, so set it explicitly too
+                    // rather than leave it to whatever a previous spec/run left behind.
+                    allowCompletingPartialPickingJob: true,
+                },
+            },
+            bpartners: { BP1: {} },
+            warehouses: { wh: {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                P1: { gtin: packedGtin, prices: [{ price: 1 }] },
+            },
+            packingInstructions: {
+                PI: { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'P1', qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                // HU1: the pickable source HU.
+                HU1: { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
+                // HU2: the mandatory target LU the unpicked qty is returned into. Carries the legacy
+                // customer barcode under test (undefined when a test does not need it).
+                HU2: { product: 'P1', warehouse: 'wh', packingInstructions: 'PI', externalBarcode: targetExternalBarcode },
+            },
+            salesOrders: {
+                SO1: {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 12, piItemProduct: 'TU' }],
+                },
+            },
+        },
+    });
+};
+
+const loginAndStartJob = async ({ masterdata }) => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+    return { pickingJobId };
+};
+
+const pickAll3TUFromHU1 = async ({ masterdata, pickingJobId }) => await test.step('Pick all 3 TU (12 PCE) from HU1', async () => {
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '0 TU' });
+    await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '3' });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU' });
+    // Registers the dynamically-created `lu1` HU in the backend test context so the assertions below
+    // can refer to it by identifier (same mechanism used throughout picking_partial_unpack.spec.js).
+    await Backend.expect({
+        title: 'baseline: 12 PCE packed on lu1',
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: { qtyPicked: [{ qtyPicked: '12 PCE', qtyTUs: 3, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }] },
+                },
+            },
+        },
+        hus: { lu1: { huStatus: 'S', storages: { P1: '12 PCE' } } },
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Unpack into a legacy-labelled target LU — operator scans its printed customer barcode', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Unpack to a target LU identified by a legacy/customer label');
+    allure.severity('critical');
+
+    const targetExternalBarcode = `EXT${Date.now()}`;
+    const masterdata = await createMasterdata({ packedGtin: uniqueGtin14(), targetExternalBarcode });
+    const packedScan = gs1GtinScan(masterdata.products.P1.gtin);
+
+    const { pickingJobId } = await loginAndStartJob({ masterdata });
+    await pickAll3TUFromHU1({ masterdata, pickingJobId });
+
+    // The target LU is already open on the floor and carries the customer's own printed barcode
+    // (an ExternalBarcode) instead of a metasfresh QR code — the everyday case for a customer who
+    // labels their own reusable pallets. The operator scans that label to return the unpicked goods.
+    await test.step('Unpack 4 PCE and return them to the target LU by scanning its printed customer barcode', async () => {
+        await PickingJobScreen.unpickItem({
+            scannedCode: packedScan,
+            expectDefaultQty: '12',
+            qty: '4',
+            targetHUQRCode: masterdata.handlingUnits.HU2.externalBarcode,
+        });
+
+        // 2 TU (8 PCE) stays packed on the source LU; the unpicked 4 PCE has moved into the target LU,
+        // which starts at its PI-forced 80 PCE (see masterdata comment above) -> 80 + 4 = 84 PCE.
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '2 TU' });
+        await Backend.expect({
+            title: 'legacy-barcode target: 8 PCE stays packed on the source LU, 4 PCE moved into the target LU (80 start + 4 = 84)',
+            hus: {
+                lu1: { huStatus: 'S', storages: { P1: '8 PCE' } },
+                [masterdata.handlingUnits.HU2.qrCode]: { storages: { P1: '84 PCE' } },
+            },
+        });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Unpack into a target LU by scanning its plain HU value (no ExternalBarcode)', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Unpack to a target LU identified by its plain M_HU.Value');
+    allure.severity('critical');
+
+    // This target LU deliberately carries NO ExternalBarcode: the operator has nothing to scan but the
+    // HU's own plain value. M_HU.Value is always the M_HU_ID (confirmed by the feature owner, and
+    // verified against the stack: 40/40 HUs had value = m_hu_id, none null, none differing), so the
+    // value printed on such a label is exactly the huId the masterdata API already returns. No DB
+    // read and no masterdata-API change is needed to know what the operator would scan.
+    const masterdata = await createMasterdata({ packedGtin: uniqueGtin14() });
+    const packedScan = gs1GtinScan(masterdata.products.P1.gtin);
+
+    const { pickingJobId } = await loginAndStartJob({ masterdata });
+    await pickAll3TUFromHU1({ masterdata, pickingJobId });
+
+    await test.step('Unpack 4 PCE and return them to the target LU by scanning its plain HU value', async () => {
+        await PickingJobScreen.unpickItem({
+            scannedCode: packedScan,
+            expectDefaultQty: '12',
+            qty: '4',
+            targetHUQRCode: masterdata.handlingUnits.HU2.huId,
+        });
+
+        // 2 TU (8 PCE) stays packed on the source LU; the unpicked 4 PCE has moved into the target LU,
+        // which starts at its PI-forced 80 PCE (see masterdata comment above) -> 80 + 4 = 84 PCE.
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '2 TU' });
+        await Backend.expect({
+            title: 'plain-HU-value target: 8 PCE stays packed on the source LU, 4 PCE moved into the target LU (80 start + 4 = 84)',
+            hus: {
+                lu1: { huStatus: 'S', storages: { P1: '8 PCE' } },
+                [masterdata.handlingUnits.HU2.qrCode]: { storages: { P1: '84 PCE' } },
+            },
+        });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan an unrecognised code at the unpack target — clear message, nothing moves, recovery works', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Unpack target scan rejects an unrecognised code with a clear message');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ packedGtin: uniqueGtin14() });
+    const packedScan = gs1GtinScan(masterdata.products.P1.gtin);
+    const targetHUQRCode = masterdata.handlingUnits.HU2.qrCode;
+    // A code that matches no known format at all (no metasfresh QR, no GTIN/EAN, no GRAI, no
+    // ExternalBarcode/HU value on file) — the case where the system genuinely cannot identify what
+    // was scanned.
+    const unrecognisedCode = `NOT-A-CODE-${Date.now()}`;
+
+    const { pickingJobId } = await loginAndStartJob({ masterdata });
+    await pickAll3TUFromHU1({ masterdata, pickingJobId });
+
+    // Drive the unpick panel up to the target-HU scan stage (product + qty already entered).
+    await PickingJobScreen.unpickAdvanceToTargetStage({ scannedCode: packedScan, expectDefaultQty: '12', qty: '4' });
+
+    await test.step('Scan a code the system cannot identify as the unpack target — the operator must see a clear, actionable message', async () => {
+        await expectErrorToast('Unrecognised code at unpack target', async () => {
+            await PickingJobScreen.scanCodeAtTargetStageNoCommit({ scannedCode: unrecognisedCode });
+        }, ({ textContent }) => {
+            // The operator must be told their scan wasn't recognised, not handed a generic
+            // "please try again / contact support" report with no actionable detail.
+            expect(textContent).toContain('QR code not recognized');
+        });
+        // The panel did not close: the target-HU scanner is still armed so the operator can simply
+        // scan the correct target LU next.
+        await PickingJobScreen.expectOnTargetScanStage();
+    });
+
+    // Nothing moved: the source LU still holds all 12 PCE, the target LU is untouched.
+    await Backend.expect({
+        title: 'after the unrecognised scan: nothing moved, source LU still holds 12 PCE, target LU untouched',
+        hus: {
+            lu1: { huStatus: 'S', storages: { P1: '12 PCE' } },
+            [targetHUQRCode]: { storages: { P1: '80 PCE' } },
+        },
+    });
+
+    await test.step('Scan the correct target LU — the unpick commits normally and the panel is usable again', async () => {
+        await PickingJobScreen.scanTargetHUAndCommit({ qrCode: targetHUQRCode });
+    });
+
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '2 TU' });
+    await Backend.expect({
+        title: 'recovery: 8 PCE stays packed on the source LU, 4 PCE moved into the target LU (80 + 4 = 84)',
+        hus: {
+            lu1: { huStatus: 'S', storages: { P1: '8 PCE' } },
+            [targetHUQRCode]: { storages: { P1: '84 PCE' } },
+        },
+    });
+});


### PR DESCRIPTION
## Problem

At the mobile picking **unpack** step, the target-HU scan accepted **only** a metasfresh global QR code. Scanning the warehouse's own printed label on the target unit — an `ExternalBarcode` attribute, or the plain `M_HU.Value` — was rejected, even though the pick-*from* side of the same screen has always accepted all of them.

Worse, the rejection was not operator-facing. `GlobalQRCode.ofString().orThrow()` throws via `Check.mkEx`, whose default is a plain `RuntimeException`, so `userFriendlyError` was false and the picker got the generic *"Please try again. If the problem persists, contact support"* fallback — while the real reason (`Invalid global QR code(1): <code>`) stayed in the HTTP response body and an `AD_Issue` row.

## Change

Hoists the "resolve any supported scanned HU label to that unit's `HUQRCode`" step out of `SetPickFromHUWFActivityHandler`'s private helper into `HUQRCodesService.getQRCodeByScannedCode(ScannedCode)`, and routes the unpack target through it instead of `HUQRCode.fromGlobalQRCodeJsonString`.

- **Accepted** at the unpack target now: a metasfresh global QR code, and the plain `M_HU.Value` / `ExternalBarcode` printed on the unit (which `parse` resolves by looking the unit up and returning *its* QR code).
- **Rejected**, deliberately: every other `IHUQRCode` — `PickOnTheFlyQRCode`, `LMQRCode`, `CustomHUQRCode`, `GS1HUQRCode`, `EAN13HUQRCode`. These describe goods or an intent, not one specific unit. They are *not* retried as an `M_HU.Value`/`ExternalBarcode` lookup, because such a code could coincidentally equal some unit's value and picking from the wrong unit is worse than a clear rejection.
- The rejection now carries `scannedCode` + `huQRCodeType` as exception parameters, so a log line says which kind of code was refused.
- Skipping the target scan (unpick to the floor) stays legal — the blank-tolerant `Optional` chain is preserved.

`fromJson` becomes an instance method so it can reach the injected service; its only caller already ran in instance context.

**No behaviour change on the pick-from side** — `SetPickFromHUWFActivityHandler` now delegates to the shared method, which narrows exactly as its deleted private helper did (`parse(String)` is itself just `parse(ScannedCode.ofString(...))`).

**As an intended side effect, an unrecognised scan is now operator-facing.** Routing through the shared bridge means an unresolvable code reaches `parse`'s own terminal `MobileQRCodeMessages.newNotRecognizedException`, an `AdMessageKey`-based translatable exception that `AdempiereException` auto-marks as a user validation error. The picker now sees `QR code not recognized: <the code they scanned>`.

## Tests

New mobile-webui spec `picking/unpack/picking_unpack_legacy_label_target.spec.js`:

- legacy `ExternalBarcode` as the unpack target,
- plain `M_HU.Value` as the unpack target,
- an unrecognised code at the unpack target → operator-facing message, nothing moved, the panel stays usable.

New JUnit coverage on `HUQRCodesService.getQRCodeByScannedCode` for a global QR code, an `ExternalBarcode`, and the reject branch.

Two pre-existing specs (`picking_partial_unpack_TU_floor_spanning_picks`, `..._TU_floor_two_lines`) additionally now set `allowSkippingRejectedReason` themselves. Both do a *partial* pick, which leaves a rejected qty; whether a reason is mandatory is a sticky header-row field they never set, so they inherited it and hung for 120 s against any database where it is `N` — which is the DDL default. Unrelated to the fix, but they sit in the folder this change touches.

## Verification

- `de.metas.handlingunits.base` unfiltered unit suite: 1051 pass. `de.metas.picking.rest-api`: 54 pass.
- Cucumber `byScannedCode_qrcode_hash` and `mobileui/picking/Pick_TUs_from_LU`, run locally: 6 scenarios / 14 tests pass.
- Mobile Playwright: the whole `picking/unpack/` folder 14/14 and the whole `picking/` folder 137/137 locally; `mobile test` 296/0 in CI.
- The three added/changed specs cleared a four-leg flake gate: pattern audit, 30 consecutive local runs each at `--retries=0`, both cross-run pollution orders, and a green CI round — started from the hostile `IsAllowSkippingRejectedReason='N'` default so it tested the fix rather than a friendly config.
