### PR TITLE
Merge: soft_panda_hotfix -> new_dawn_uat

### DIFF
--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/api/impl/PostingService.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/api/impl/PostingService.java
@@ -13,10 +13,12 @@ import de.metas.acct.posting.log.DocumentPostingLogService;
 import de.metas.logging.LogManager;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.ad.table.ReferencedRecordRepository;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.util.lang.IAutoCloseable;
+import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.SpringContextHolder;
 import org.compiere.SpringContextHolder.Lazy;
 import org.compiere.acct.Doc;
@@ -32,6 +34,7 @@ public class PostingService implements IPostingService
 	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
 	@NonNull private final IAcctSchemaDAO acctSchemaDAO = Services.get(IAcctSchemaDAO.class);
+	@NonNull private final Lazy<ReferencedRecordRepository> referencedRecordRepositoryHolder = SpringContextHolder.lazyBean(ReferencedRecordRepository.class);
 	@NonNull private final Lazy<DocumentPostingUserNotificationService> userNotificationsHolder = SpringContextHolder.lazyBean(DocumentPostingUserNotificationService.class);
 	@NonNull private final Lazy<AcctDocRegistry> acctDocRegistryHolder = SpringContextHolder.lazyBean(AcctDocRegistry.class);
 	@NonNull private final Lazy<DocumentPostingBusService> postingBusServiceHolder = SpringContextHolder.lazyBean(DocumentPostingBusService.class);
@@ -100,6 +103,13 @@ public class PostingService implements IPostingService
 		}
 		catch (final Exception ex)
 		{
+			if (isDocumentDeleted(request.getRecord()))
+			{
+				// A deleted document has no accounting facts left to post: not an error to report to the user, but keep the exception in the log.
+				logger.debug("Skip posting {} because the document does not exist anymore", request.getRecord(), ex);
+				return;
+			}
+
 			final AdempiereException metasfreshException = AdempiereException.wrapIfNeeded(ex);
 			
 			documentPostingLogServiceHolder.get().logPostingError(request, metasfreshException);
@@ -108,6 +118,20 @@ public class PostingService implements IPostingService
 			{
 				userNotificationsHolder.get().notifyPostingError(request.getOnErrorNotifyUserId(), request.getRecord(), metasfreshException);
 			}
+		}
+	}
+
+	private boolean isDocumentDeleted(@NonNull final TableRecordReference documentRef)
+	{
+		try
+		{
+			return !referencedRecordRepositoryHolder.get().exists(documentRef);
+		}
+		catch (final Exception ex)
+		{
+			// Called from a catch block: an exception thrown here would replace the actual posting error.
+			logger.warn("Failed checking if {} still exists. Considering it as still existing.", documentRef, ex);
+			return false;
 		}
 	}
 

--- a/backend/de.metas.acct.base/src/test/java/de/metas/acct/api/impl/PostingServiceTest.java
+++ b/backend/de.metas.acct.base/src/test/java/de/metas/acct/api/impl/PostingServiceTest.java
@@ -1,0 +1,141 @@
+package de.metas.acct.api.impl;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.acct.api.DocumentPostMultiRequest;
+import de.metas.acct.api.DocumentPostRequest;
+import de.metas.acct.api.IAcctSchemaDAO;
+import de.metas.acct.doc.AcctDocRegistry;
+import de.metas.acct.posting.DocumentPostingUserNotificationService;
+import de.metas.acct.posting.log.DocumentPostingLogService;
+import de.metas.user.UserId;
+import de.metas.util.Services;
+import org.adempiere.ad.table.ReferencedRecordRepository;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_C_Invoice;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PostingServiceTest
+{
+	private static final ClientId CLIENT_ID = ClientId.ofRepoId(1000000);
+	private static final UserId NOTIFY_USER_ID = UserId.ofRepoId(1234);
+
+	private AcctDocRegistry acctDocRegistry;
+	private DocumentPostingLogService documentPostingLogService;
+	private DocumentPostingUserNotificationService userNotificationService;
+
+	private PostingService postingService;
+
+	@BeforeEach
+	void init()
+	{
+		init(ReferencedRecordRepository::newInstanceForUnitTesting);
+	}
+
+	/** The supplier is invoked only after the test helper enabled the unit-test mode and cleared the previously registered beans. */
+	private void init(final Supplier<ReferencedRecordRepository> referencedRecordRepositorySupplier)
+	{
+		AdempiereTestHelper.get().init();
+
+		final IAcctSchemaDAO acctSchemaDAO = mock(IAcctSchemaDAO.class);
+		when(acctSchemaDAO.getAllByClient(any())).thenReturn(ImmutableList.of());
+		Services.registerService(IAcctSchemaDAO.class, acctSchemaDAO);
+
+		acctDocRegistry = mock(AcctDocRegistry.class);
+		documentPostingLogService = mock(DocumentPostingLogService.class);
+		userNotificationService = mock(DocumentPostingUserNotificationService.class);
+
+		SpringContextHolder.registerJUnitBean(AcctDocRegistry.class, acctDocRegistry);
+		SpringContextHolder.registerJUnitBean(DocumentPostingLogService.class, documentPostingLogService);
+		SpringContextHolder.registerJUnitBean(DocumentPostingUserNotificationService.class, userNotificationService);
+		SpringContextHolder.registerJUnitBean(ReferencedRecordRepository.class, referencedRecordRepositorySupplier.get());
+
+		postingService = new PostingService();
+	}
+
+	private void postNow(final TableRecordReference documentRef)
+	{
+		postingService.postAfterCommit(DocumentPostMultiRequest.of(DocumentPostRequest.builder()
+				.record(documentRef)
+				.clientId(CLIENT_ID)
+				.onErrorNotifyUserId(NOTIFY_USER_ID)
+				.build()));
+	}
+
+	private TableRecordReference createInvoiceReference()
+	{
+		final I_C_Invoice invoice = InterfaceWrapperHelper.newInstance(I_C_Invoice.class);
+		InterfaceWrapperHelper.save(invoice);
+		return TableRecordReference.of(invoice);
+	}
+
+	@Nested
+	@DisplayName("document was deleted after the posting was scheduled")
+	class DocumentDeleted
+	{
+		@Test
+		void neitherLogsAPostingErrorNorNotifiesTheUser()
+		{
+			final TableRecordReference deletedDocumentRef = TableRecordReference.of(I_C_Invoice.Table_Name, 9649545);
+			when(acctDocRegistry.get(any(), eq(deletedDocumentRef)))
+					.thenThrow(new AdempiereException("No document found for " + deletedDocumentRef));
+
+			postNow(deletedDocumentRef);
+
+			verify(documentPostingLogService, never()).logPostingError(any(), any());
+			verify(userNotificationService, never()).notifyPostingError(any(UserId.class), any(), any(Exception.class));
+		}
+	}
+
+	@Nested
+	@DisplayName("document still exists but cannot be posted")
+	class DocumentExists
+	{
+		@Test
+		void logsThePostingErrorAndNotifiesTheUser()
+		{
+			final TableRecordReference existingDocumentRef = createInvoiceReference();
+			when(acctDocRegistry.get(any(), eq(existingDocumentRef)))
+					.thenThrow(new AdempiereException("account determination failed"));
+
+			postNow(existingDocumentRef);
+
+			verify(documentPostingLogService).logPostingError(any(), any());
+			verify(userNotificationService).notifyPostingError(eq(NOTIFY_USER_ID), eq(existingDocumentRef), any(Exception.class));
+		}
+
+		@Test
+		@DisplayName("the posting error is still reported when we cannot check whether the document exists")
+		void logsThePostingErrorEvenIfTheExistenceCheckFails()
+		{
+			final ReferencedRecordRepository failingRecordRepository = mock(ReferencedRecordRepository.class);
+			when(failingRecordRepository.exists(any())).thenThrow(new AdempiereException("database is not available"));
+			init(() -> failingRecordRepository);
+
+			final TableRecordReference documentRef = TableRecordReference.of(I_C_Invoice.Table_Name, 9649545);
+			when(acctDocRegistry.get(any(), eq(documentRef)))
+					.thenThrow(new AdempiereException("account determination failed"));
+
+			postNow(documentRef);
+
+			verify(documentPostingLogService).logPostingError(any(), any());
+			verify(userNotificationService).notifyPostingError(eq(NOTIFY_USER_ID), eq(documentRef), any(Exception.class));
+		}
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/dao/impl/POJOQuery.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/dao/impl/POJOQuery.java
@@ -407,7 +407,8 @@ public class POJOQuery<T> extends AbstractTypedQuery<T>
 
 		final POJOLookupMap db = POJOLookupMap.get();
 
-		return db.getRecords(modelClass, filters).size();
+		// NOTE: a query created from a plain tableName has a generic modelClass, so the tableName aware overload is required.
+		return db.getRecords(getTableNameToUse(modelClass), modelClass, filters, null).size();
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/table/ReferencedRecordRepository.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/table/ReferencedRecordRepository.java
@@ -1,0 +1,64 @@
+package org.adempiere.ad.table;
+
+import com.google.common.annotations.VisibleForTesting;
+import de.metas.util.Services;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.Adempiere;
+import org.compiere.SpringContextHolder;
+import org.springframework.stereotype.Repository;
+
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * Repository Tables: dynamic - resolved at runtime from the given {@link TableRecordReference}
+ * Repository Cluster: -
+ */
+@Repository
+@RequiredArgsConstructor
+public class ReferencedRecordRepository
+{
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@VisibleForTesting
+	public static ReferencedRecordRepository newInstanceForUnitTesting()
+	{
+		Adempiere.assertUnitTestMode();
+		//noinspection DataFlowIssue
+		return SpringContextHolder.getBeanOrSupply(ReferencedRecordRepository.class, ReferencedRecordRepository::new);
+	}
+
+	public boolean exists(@NonNull final TableRecordReference recordRef)
+	{
+		final String tableName = recordRef.getTableName();
+
+		// NOTE: intentionally not restricted to active records - an inactive record still exists.
+		return queryBL.createQueryBuilder(tableName)
+				.addEqualsFilter(InterfaceWrapperHelper.getKeyColumnName(tableName), recordRef.getRecord_ID())
+				.create()
+				.anyMatch();
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/table/ReferencedRecordRepositoryTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/table/ReferencedRecordRepositoryTest.java
@@ -1,0 +1,76 @@
+package org.adempiere.ad.table;
+
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+public class ReferencedRecordRepositoryTest
+{
+	private ReferencedRecordRepository referencedRecordRepository;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		referencedRecordRepository = ReferencedRecordRepository.newInstanceForUnitTesting();
+	}
+
+	@Test
+	void existingRecord()
+	{
+		final I_C_UOM record = createUOM(true);
+
+		assertThat(referencedRecordRepository.exists(TableRecordReference.of(record))).isTrue();
+	}
+
+	@Test
+	void missingRecord()
+	{
+		assertThat(referencedRecordRepository.exists(TableRecordReference.of(I_C_UOM.Table_Name, 999999))).isFalse();
+	}
+
+	/** Guards the deliberate absence of an active-records filter in {@link ReferencedRecordRepository#exists(TableRecordReference)}. */
+	@Test
+	void inactiveRecordStillExists()
+	{
+		final I_C_UOM record = createUOM(false);
+
+		assertThat(referencedRecordRepository.exists(TableRecordReference.of(record))).isTrue();
+	}
+
+	private static I_C_UOM createUOM(final boolean active)
+	{
+		final I_C_UOM record = InterfaceWrapperHelper.newInstance(I_C_UOM.class);
+		record.setName("test");
+		record.setIsActive(active);
+		InterfaceWrapperHelper.saveRecord(record);
+		return record;
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -645,6 +645,14 @@ public class C_Invoice_Candidate_StepDef
 						row.getAsOptionalString(I_C_Invoice_Candidate.COLUMNNAME_ErrorMsg)
 								.ifPresent(expected -> softly.assertThat(finalInvoiceCandidate.getErrorMsg()).as("ErrorMsg").contains(expected));
 
+						// IsError/ErrorMsg are cleared again by the next "update invalid invoice candidates" run;
+						// IsInvoicingError/InvoicingErrorMsg survive it and record that a "Create Invoices" run failed.
+						row.getAsOptionalBoolean(I_C_Invoice_Candidate.COLUMNNAME_IsInvoicingError)
+								.ifPresent(expected -> softly.assertThat(finalInvoiceCandidate.isInvoicingError()).as("IsInvoicingError").isEqualTo(expected));
+
+						row.getAsOptionalString(I_C_Invoice_Candidate.COLUMNNAME_InvoicingErrorMsg)
+								.ifPresent(expected -> softly.assertThat(finalInvoiceCandidate.getInvoicingErrorMsg()).as("InvoicingErrorMsg").contains(expected));
+
 						row.getAsOptionalBigDecimal(I_C_Invoice_Candidate.COLUMNNAME_PriceActual)
 								.ifPresent(expected -> softly.assertThat(finalInvoiceCandidate.getPriceActual()).as("PriceActual").isEqualByComparingTo(expected));
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
@@ -32,6 +32,7 @@ import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
 import de.metas.cucumber.stepdefs.IdentifierIds_StepDefData;
+import de.metas.cucumber.stepdefs.InterfaceWrapperHelperUtils;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.StepDefConstants;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
@@ -412,85 +413,184 @@ public class C_OrderLine_StepDef
 		}
 	}
 
+	/**
+	 * Updates previously registered order lines, applying every value column that is present.
+	 *
+	 * <p>The save runs as a background write, i.e. the way an automatic writer such as the invoicing
+	 * run saves a line. Use {@code update C_OrderLine expecting error:} with {@code AsUIAction} to save
+	 * as a user edit instead.</p>
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <ul>
+	 *     <li>{@code C_OrderLine_ID} — required, identifier of the line to update</li>
+	 *     <li>{@code C_Flatrate_Term_ID}, {@code QtyEntered}, {@code M_HU_PI_Item_Product_ID},
+	 *         {@code M_AttributeSetInstance_ID}, {@code QtyOrdered}, {@code C_Project_ID} — optional,
+	 *         each is applied only when the column is present</li>
+	 *   </ul>
+	 * @cucumber.example
+	 * <pre>
+	 * And update C_OrderLine:
+	 *   | C_OrderLine_ID.Identifier | OPT.QtyEntered |
+	 *   | ol_1                      | 50             |
+	 * </pre>
+	 */
 	@And("update C_OrderLine:")
 	public void update_C_OrderLine(@NonNull final DataTable dataTable)
 	{
-		final List<Map<String, String>> table = dataTable.asMaps();
-		for (final Map<String, String> row : table)
+		dataTable.asMaps().forEach(row -> updateOrderLine(row, false));
+	}
+
+	/**
+	 * Same as {@code update C_OrderLine:}, but the save is expected to be rejected.
+	 *
+	 * <p>With {@code AsUIAction} the record is flagged as a manual user action before it is saved, the
+	 * way the WebUI's save handler does it — that is what makes a model interceptor apply a policy it
+	 * enforces for user edits only.</p>
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <ul>
+	 *     <li>{@code C_OrderLine_ID} — required, identifier of the line to update</li>
+	 *     <li>the value columns of {@code update C_OrderLine:} — optional</li>
+	 *     <li>{@code ErrorCode} — optional, the expected error code of the thrown exception</li>
+	 *     <li>{@code ErrorMessage} — optional, an expected substring of the exception message;
+	 *         at least one of {@code ErrorCode} / {@code ErrorMessage} has to be given</li>
+	 *     <li>{@code AsUIAction} — optional, defaults to {@code N}</li>
+	 *   </ul>
+	 * @cucumber.example
+	 * <pre>
+	 * And update C_OrderLine expecting error:
+	 *   | C_OrderLine_ID.Identifier | OPT.C_Project_ID.Identifier | OPT.AsUIAction | OPT.ErrorCode        |
+	 *   | ol_1                      | project_2                   | Y              | ORDER_RECEIPT_EXISTS |
+	 * </pre>
+	 */
+	@And("update C_OrderLine expecting error:")
+	public void update_C_OrderLine_expectingError(@NonNull final DataTable dataTable)
+	{
+		final List<Map<String, String>> rowMaps = dataTable.asMaps();
+		if (rowMaps.size() > 1)
 		{
-			final String olIdentifier = DataTableUtil.extractStringForColumnName(row, I_C_OrderLine.COLUMNNAME_C_OrderLine_ID + "." + TABLECOLUMN_IDENTIFIER);
-			final de.metas.handlingunits.model.I_C_OrderLine orderLine = InterfaceWrapperHelper.create(orderLineTable.get(olIdentifier), de.metas.handlingunits.model.I_C_OrderLine.class);
-
-			final String contractIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_C_Flatrate_Term_ID + "." + TABLECOLUMN_IDENTIFIER);
-
-			if (Check.isNotBlank(contractIdentifier))
-			{
-				final I_C_Flatrate_Term contract = contractTable.get(contractIdentifier);
-
-				orderLine.setC_Flatrate_Term_ID(contract.getC_Flatrate_Term_ID());
-			}
-
-			final BigDecimal updatedQtyEntered = DataTableUtil.extractBigDecimalOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_QtyEntered);
-			if (updatedQtyEntered != null)
-			{
-				orderLine.setQtyEntered(updatedQtyEntered);
-			}
-
-			final String piItemProductIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + de.metas.handlingunits.model.I_C_OrderLine.COLUMNNAME_M_HU_PI_Item_Product_ID);
-			if (Check.isNotBlank(piItemProductIdentifier))
-			{
-				final Integer piItemProductId = huPiItemProductTable.getOptional(piItemProductIdentifier)
-						.map(I_M_HU_PI_Item_Product::getM_HU_PI_Item_Product_ID)
-						.orElseGet(() -> Integer.parseInt(piItemProductIdentifier));
-
-				orderLine.setM_HU_PI_Item_Product_ID(piItemProductId);
-			}
-
-			final String attributeSetInstanceIdentifier = DataTableUtil.extractNullableStringForColumnName(row, "OPT." + COLUMNNAME_M_AttributeSetInstance_ID + "." + StepDefConstants.TABLECOLUMN_IDENTIFIER);
-			if (de.metas.util.Check.isNotBlank(attributeSetInstanceIdentifier))
-			{
-				final String asiIdentifierValue = DataTableUtil.nullToken2Null(attributeSetInstanceIdentifier);
-				if (asiIdentifierValue == null)
-				{
-					orderLine.setM_AttributeSetInstance_ID(-1);
-				}
-				else
-				{
-					final I_M_AttributeSetInstance attributeSetInstance = attributeSetInstanceTable.get(attributeSetInstanceIdentifier);
-					assertThat(attributeSetInstance).isNotNull();
-
-					orderLine.setM_AttributeSetInstance_ID(attributeSetInstance.getM_AttributeSetInstance_ID());
-				}
-			}
-
-			final BigDecimal updatedQtyOrdered = DataTableUtil.extractBigDecimalOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_QtyOrdered);
-			if (updatedQtyOrdered != null)
-			{
-				orderLine.setQtyOrdered(updatedQtyOrdered);
-			}
-
-			final String asiIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_M_AttributeSetInstance_ID + "." + TABLECOLUMN_IDENTIFIER);
-
-			if (Check.isNotBlank(asiIdentifier))
-			{
-				final Integer asiId = attributeSetInstanceTable.getOptional(asiIdentifier)
-						.map(I_M_AttributeSetInstance::getM_AttributeSetInstance_ID)
-						.orElseGet(() -> Integer.parseInt(asiIdentifier));
-
-				orderLine.setM_AttributeSetInstance_ID(asiId);
-			}
-
-			final String projectIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_C_Project_ID + "." + TABLECOLUMN_IDENTIFIER);
-			if (Check.isNotBlank(projectIdentifier))
-			{
-				final I_C_Project project = projectTable.get(projectIdentifier);
-				orderLine.setC_Project_ID(project.getC_Project_ID());
-			}
-
-			saveRecord(orderLine);
-
-			orderLineTable.putOrReplace(olIdentifier, orderLine);
+			throw new IllegalArgumentException("Multiple rows are not supported!");
 		}
+		final Map<String, String> rowMap = rowMaps.get(0);
+		final DataTableRow row = DataTableRow.singleRow(rowMap);
+
+		final String expectedErrorCode = row.getAsOptionalString("ErrorCode").orElse(null);
+		final String expectedMessagePart = row.getAsOptionalString("ErrorMessage").orElse(null);
+		if (Check.isBlank(expectedErrorCode) && Check.isBlank(expectedMessagePart))
+		{
+			throw new IllegalArgumentException("Either ErrorCode or ErrorMessage has to be given!");
+		}
+
+		try
+		{
+			updateOrderLine(rowMap, row.getAsOptionalBoolean("AsUIAction").orElseFalse());
+
+			Assertions.fail("An Exception should have been thrown !");
+		}
+		catch (final AdempiereException exception)
+		{
+			if (Check.isNotBlank(expectedErrorCode))
+			{
+				assertThat(exception.getErrorCode()).isEqualTo(expectedErrorCode);
+			}
+			if (Check.isNotBlank(expectedMessagePart))
+			{
+				assertThat(exception.getMessage()).contains(expectedMessagePart);
+			}
+		}
+	}
+
+	private void updateOrderLine(@NonNull final Map<String, String> row, final boolean asUIAction)
+	{
+		final String olIdentifier = DataTableUtil.extractStringForColumnName(row, I_C_OrderLine.COLUMNNAME_C_OrderLine_ID + "." + TABLECOLUMN_IDENTIFIER);
+		final de.metas.handlingunits.model.I_C_OrderLine orderLine = InterfaceWrapperHelper.create(orderLineTable.get(olIdentifier), de.metas.handlingunits.model.I_C_OrderLine.class);
+
+		final String contractIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_C_Flatrate_Term_ID + "." + TABLECOLUMN_IDENTIFIER);
+
+		if (Check.isNotBlank(contractIdentifier))
+		{
+			final I_C_Flatrate_Term contract = contractTable.get(contractIdentifier);
+
+			orderLine.setC_Flatrate_Term_ID(contract.getC_Flatrate_Term_ID());
+		}
+
+		final BigDecimal updatedQtyEntered = DataTableUtil.extractBigDecimalOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_QtyEntered);
+		if (updatedQtyEntered != null)
+		{
+			orderLine.setQtyEntered(updatedQtyEntered);
+		}
+
+		final String piItemProductIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + de.metas.handlingunits.model.I_C_OrderLine.COLUMNNAME_M_HU_PI_Item_Product_ID);
+		if (Check.isNotBlank(piItemProductIdentifier))
+		{
+			final Integer piItemProductId = huPiItemProductTable.getOptional(piItemProductIdentifier)
+					.map(I_M_HU_PI_Item_Product::getM_HU_PI_Item_Product_ID)
+					.orElseGet(() -> Integer.parseInt(piItemProductIdentifier));
+
+			orderLine.setM_HU_PI_Item_Product_ID(piItemProductId);
+		}
+
+		final String attributeSetInstanceIdentifier = DataTableUtil.extractNullableStringForColumnName(row, "OPT." + COLUMNNAME_M_AttributeSetInstance_ID + "." + StepDefConstants.TABLECOLUMN_IDENTIFIER);
+		if (de.metas.util.Check.isNotBlank(attributeSetInstanceIdentifier))
+		{
+			final String asiIdentifierValue = DataTableUtil.nullToken2Null(attributeSetInstanceIdentifier);
+			if (asiIdentifierValue == null)
+			{
+				orderLine.setM_AttributeSetInstance_ID(-1);
+			}
+			else
+			{
+				final I_M_AttributeSetInstance attributeSetInstance = attributeSetInstanceTable.get(attributeSetInstanceIdentifier);
+				assertThat(attributeSetInstance).isNotNull();
+
+				orderLine.setM_AttributeSetInstance_ID(attributeSetInstance.getM_AttributeSetInstance_ID());
+			}
+		}
+
+		final BigDecimal updatedQtyOrdered = DataTableUtil.extractBigDecimalOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_QtyOrdered);
+		if (updatedQtyOrdered != null)
+		{
+			orderLine.setQtyOrdered(updatedQtyOrdered);
+		}
+
+		final String asiIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_M_AttributeSetInstance_ID + "." + TABLECOLUMN_IDENTIFIER);
+
+		if (Check.isNotBlank(asiIdentifier))
+		{
+			final Integer asiId = attributeSetInstanceTable.getOptional(asiIdentifier)
+					.map(I_M_AttributeSetInstance::getM_AttributeSetInstance_ID)
+					.orElseGet(() -> Integer.parseInt(asiIdentifier));
+
+			orderLine.setM_AttributeSetInstance_ID(asiId);
+		}
+
+		final String projectIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_C_Project_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (Check.isNotBlank(projectIdentifier))
+		{
+			final I_C_Project project = projectTable.get(projectIdentifier);
+			orderLine.setC_Project_ID(project.getC_Project_ID());
+		}
+
+		if (asUIAction)
+		{
+			InterfaceWrapperHelperUtils.set_ManualUserAction(orderLine);
+		}
+		try
+		{
+			saveRecord(orderLine);
+		}
+		finally
+		{
+			// also on a failed save: the flag lives on the cached PO and would leak into later, non-UI saves
+			if (asUIAction)
+			{
+				InterfaceWrapperHelperUtils.unset_ManualUserAction(orderLine);
+			}
+		}
+
+		orderLineTable.putOrReplace(olIdentifier, orderLine);
 	}
 
 	@And("^delete C_OrderLine identified by (.*), but keep its id into identifierIds table$")

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredReceiptSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredReceiptSchedule.feature
@@ -1,0 +1,84 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+@ghActions:run_on_executor5
+Feature: Closing an undelivered receipt disposition closes the purchase invoice candidate
+## F00701: Invoice Candidates
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-07-26T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+
+    And load M_Warehouse:
+      | M_Warehouse_ID.Identifier | Value        |
+      | warehouseStd              | StdWarehouse |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_1       |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl_PO      | ps_1               | DE           | EUR           | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_PO     | pl_PO          |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | plv_PO                 | product      | 10.0     | PCE      |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | M_PricingSystem_ID | IsVendor | IsCustomer |
+      | bpartner_1 | ps_1               | Y        | N          |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_1        | bpartner_1               | Y                   | Y                   |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID.Identifier |
+      | LU                    |
+      | TU                    |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | IsCurrent |
+      | LU_Version         | LU         | LU          | Y         |
+      | TU_Version         | TU         | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType | OPT.Included_HU_PI_ID.Identifier |
+      | huPiItemLU                 | LU_Version                    | 10  | HU       | TU                               |
+      | huPiItemTU                 | TU_Version                    |     | MI       |                                  |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | product_TU_10CU                    | huPiItemTU                 | product                 | 10  | 2021-01-01 |
+
+  @Id:S0164_100
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: Closing an undelivered receipt disposition closes the purchase invoice candidate
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | po1        | false   | bpartner_1    | POO         | 2022-07-26  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | QtyEnteredTU | M_HU_PI_Item_Product_ID |
+      | po1_l1     | po1        | product      | 100        | 10           | product_TU_10CU         |
+    And the order identified by po1 is completed
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.QtyOrderedTU |
+      | receiptSchedule1                | po1                   | po1_l1                    | bpartner_1               | l_1                               | product                 | 100        | warehouseStd              | 10               |
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
+      | invoiceCand_1                     | po1                       | po1_l1                    | 0                | 0            |
+
+    When the M_ReceiptSchedule identified by receiptSchedule1 is closed
+
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_1                     | 0            | true                 | true          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredShipmentSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredShipmentSchedule.feature
@@ -1,0 +1,66 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+@ghActions:run_on_executor5
+Feature: Closing an undelivered shipment disposition closes the sales invoice candidate
+## F00701: Invoice Candidates
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-07-26T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_1       |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl_SO      | ps_1               | DE           | EUR           | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_SO     | pl_SO          |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | plv_SO                 | product      | 10.0     | PCE      |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | M_PricingSystem_ID | IsVendor | IsCustomer | OPT.InvoiceRule |
+      | bpartner_1 | ps_1               | N        | Y          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_1        | bpartner_1               | Y                   | Y                   |
+
+  @Id:S0164_200
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: Closing an undelivered shipment disposition closes the sales invoice candidate
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | so1        | true    | bpartner_1    | SOO         | 2022-07-26  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | so1_l1     | so1        | product      | 100        |
+    And the order identified by so1 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier        | C_OrderLine_ID.Identifier | IsToRecompute |
+      | shipmentSchedule1 | so1_l1                    | N             |
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
+      | invoiceCand_1                     | so1                       | so1_l1                    | 0                | 0            |
+
+    When the M_ShipmentSchedule identified by shipmentSchedule1 is closed
+
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_1                     | 0            | true                 | true          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesOnReactivatedPurchaseOrder.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesOnReactivatedPurchaseOrder.feature
@@ -1,0 +1,109 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+@ghActions:run_on_executor5
+Feature: Create Invoices on a reactivated purchase order that already has a material receipt
+## F00701: Invoice Candidates
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-07-26T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+    And set sys config boolean value true for sys config PO_AllowReactivationIfReceiptsCreated
+
+    And load M_Warehouse:
+      | M_Warehouse_ID.Identifier | Value        |
+      | warehouseStd              | StdWarehouse |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_1       |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl_PO      | ps_1               | DE           | EUR           | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_PO     | pl_PO          |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | plv_PO                 | product      | 10.0     | PCE      |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | M_PricingSystem_ID | IsVendor | IsCustomer |
+      | bpartner_1 | ps_1               | Y        | N          |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_1        | bpartner_1               | Y                   | Y                   |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID.Identifier |
+      | LU                    |
+      | TU                    |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | IsCurrent |
+      | LU_Version         | LU         | LU          | Y         |
+      | TU_Version         | TU         | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType | OPT.Included_HU_PI_ID.Identifier |
+      | huPiItemLU                 | LU_Version                    | 10  | HU       | TU                               |
+      | huPiItemTU                 | TU_Version                    |     | MI       |                                  |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | product_TU_10CU                    | huPiItemTU                 | product                 | 10  | 2021-01-01 |
+
+  @Id:S0161_100
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: Create Invoices succeeds for a purchase order that was reactivated after its material receipt
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | po1        | false   | bpartner_1    | POO         | 2022-07-26  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | QtyEnteredTU | M_HU_PI_Item_Product_ID |
+      | po1_l1     | po1        | product      | 100        | 10           | product_TU_10CU         |
+    And the order identified by po1 is completed
+
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.QtyOrderedTU |
+      | receiptSchedule1                | po1                   | po1_l1                    | bpartner_1               | l_1                               | product                 | 100        | warehouseStd              | 10               |
+    And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
+      | M_HU_LUTU_Configuration_ID.Identifier | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier | OPT.M_LU_HU_PI_ID.Identifier |
+      | huLuTuConfig                          | hu1                | receiptSchedule1                | N               | 1     | N               | 10    | N               | 10          | product_TU_10CU                    | LU                           |
+    And create material receipt
+      | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | hu1                | receiptSchedule1                | materialReceipt       |
+    And validate M_In_Out status
+      | M_InOut_ID.Identifier | DocStatus |
+      | materialReceipt       | CO        |
+    And validate the created material receipt lines
+      | M_InOutLine_ID      | M_InOut_ID      | M_Product_ID | movementqty | processed |
+      | materialReceiptLine | materialReceipt | product      | 100         | true      |
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice | OPT.M_InOutLine_ID.Identifier |
+      | invoiceCand_1                     | po1                       | po1_l1                    | 100              | 100          | materialReceiptLine           |
+
+    # Once reactivated the order is no longer complete, so every save of its lines recomputes C_Tax_ID
+    # - a column the receipt-exists guard on C_OrderLine does not ignore.
+    And the order identified by po1 is reactivated
+
+    And process invoice candidates
+      | C_Invoice_Candidate_ID |
+      | invoiceCand_1          |
+    And after not more than 60s, C_Invoice are found:
+      | C_Invoice_ID.Identifier | C_Invoice_Candidate_ID.Identifier |
+      | vendorInvoice           | invoiceCand_1                     |
+    And validate created invoices
+      | C_Invoice_ID  | C_BPartner_ID | C_BPartner_Location_ID | DocStatus |
+      | vendorInvoice | bpartner_1    | l_1                    | CO        |
+    And validate created invoice lines
+      | C_InvoiceLine_ID  | C_Invoice_ID  | M_Product_ID | QtyInvoiced |
+      | vendorInvoiceLine | vendorInvoice | product      | 100         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
@@ -1,0 +1,183 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+@ghActions:run_on_executor5
+Feature: A failing "Create Invoices" run reports back to the user who started it
+## F00701: Invoice Candidates
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2021-12-21T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value true for sys config de.metas.report.jasper.IsMockReportService
+
+  @Id:S0163_100
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: A "Create Invoices" run that fails for the selected candidate notifies the user who started it
+    Given metasfresh contains M_Products:
+      | Identifier | Name              |
+      | p_ie_1     | salesProduct_ie_1 |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                   | Value                   | OPT.IsActive |
+      | ps_ie_1    | ie_pricing_system_name | ie_pricing_system_value | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name               | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_ie_1    | ps_ie_1                       | DE                        | EUR                 | ie_price_list_name | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name              | ValidFrom  |
+      | plv_ie_1   | pl_ie_1                   | ie_salesOrder-PLV | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_ie_1    | plv_ie_1                          | p_ie_1                  | 10.0     | PCE               | Normal                        |
+    And metasfresh contains C_BPartners:
+      | Identifier       | Name           | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | endcustomer_ie_1 | ie_Endcustomer | N            | Y              | ps_ie_1                       |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_ie_1     | ie_bPLocation | endcustomer_ie_1         | Y                   | Y                   |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | o_ie_1     | true    | endcustomer_ie_1         | 2021-04-17  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_ie_1    | o_ie_1                | p_ie_1                  | 10         |
+    And the order identified by o_ie_1 is completed
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_ie_1                           | ol_ie_1                   | 0            |
+
+    # InvoiceRule=Immediate makes the candidate invoiceable without a delivery, so the run really tries to invoice it.
+    And update invoice candidates
+      | C_Invoice_Candidate_ID.Identifier | OPT.InvoiceRule_Override |
+      | ic_ie_1                           | I                        |
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_ie_1                           | ol_ie_1                   | 10           |
+
+    # Credit stop makes completing the generated invoice throw @BPartnerCreditStop@, so the run genuinely fails.
+    And upsert C_BPartner_Stats
+      | C_BPartner_ID.Identifier | SOCreditStatus.Code |
+      | endcustomer_ie_1         | S                   |
+
+    And load AD_User:
+      | AD_User_ID.Identifier | Login      |
+      | user_metasfresh       | metasfresh |
+    And load AD_Message:
+      | Identifier        | Value                |
+      | msgInvoicingError | Event_InvoicingError |
+
+    # A failing candidate is never processed, so the "wait until processed" variant would only time out.
+    When process invoice candidates and verify C_Invoice_Candidate is not processed after 30s
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_ie_1                           |
+
+    # IsInvoicingError and not IsError: the "update invalid invoice candidates" run that follows clears IsError again.
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | IsInvoicingError | OPT.Processed |
+      | ic_ie_1                           | true             | false         |
+
+    And after not more than 60s, validate AD_Note:
+      | Identifier | AD_Message_ID.Identifier | OPT.AD_User_ID.Identifier |
+      | note_1     | msgInvoicingError        | user_metasfresh           |
+
+  @Id:S0163_200
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: A "Create Invoices" run over a mixed selection still invoices the good candidate and reports the failed one
+    Given metasfresh contains M_Products:
+      | Identifier | Name              |
+      | p_mx_1     | salesProduct_mx_1 |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                   | Value                   | OPT.IsActive |
+      | ps_mx_1    | mx_pricing_system_name | mx_pricing_system_value | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name               | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_mx_1    | ps_mx_1                       | DE                        | EUR                 | mx_price_list_name | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name              | ValidFrom  |
+      | plv_mx_1   | pl_mx_1                   | mx_salesOrder-PLV | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_mx_1    | plv_mx_1                          | p_mx_1                  | 10.0     | PCE               | Normal                        |
+
+    And metasfresh contains C_BPartners:
+      | Identifier       | Name               | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | customer_mx_good | mx_GoodCustomer    | N            | Y              | ps_mx_1                       |
+      | customer_mx_bad  | mx_BlockedCustomer | N            | Y              | ps_mx_1                       |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN             | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_mx_good  | mx_bPLocation_g | customer_mx_good         | Y                   | Y                   |
+      | l_mx_bad   | mx_bPLocation_b | customer_mx_bad          | Y                   | Y                   |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | o_mx_good  | true    | customer_mx_good         | 2021-04-17  |
+      | o_mx_bad   | true    | customer_mx_bad          | 2021-04-17  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_mx_good | o_mx_good             | p_mx_1                  | 10         |
+      | ol_mx_bad  | o_mx_bad              | p_mx_1                  | 10         |
+    And the order identified by o_mx_good is completed
+    And the order identified by o_mx_bad is completed
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_mx_good                        | ol_mx_good                | 0            |
+      | ic_mx_bad                         | ol_mx_bad                 | 0            |
+
+    # InvoiceRule=Immediate makes both candidates invoiceable without a delivery, so the run really tries to invoice them.
+    And update invoice candidates
+      | C_Invoice_Candidate_ID.Identifier | OPT.InvoiceRule_Override |
+      | ic_mx_good                        | I                        |
+      | ic_mx_bad                         | I                        |
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_mx_good                        | ol_mx_good                | 10           |
+      | ic_mx_bad                         | ol_mx_bad                 | 10           |
+
+    # The two candidates have different bill partners, so they aggregate into two invoice headers with
+    # separate transactions: the good one commits, the credit-stopped one rolls back and is marked failed.
+    And upsert C_BPartner_Stats
+      | C_BPartner_ID.Identifier | SOCreditStatus.Code |
+      | customer_mx_bad          | S                   |
+
+    And load AD_User:
+      | AD_User_ID.Identifier | Login      |
+      | user_metasfresh       | metasfresh |
+    And load AD_Message:
+      | Identifier        | Value                |
+      | msgInvoicingError | Event_InvoicingError |
+
+    # The note is looked up with firstOnly(), so drop the preceding scenario's Event_InvoicingError note first.
+    And AD_Note table is reset
+
+    When process invoice candidates
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_mx_good,ic_mx_bad              |
+
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_ID.Identifier | C_Invoice_Candidate_ID.Identifier |
+      | invoice_mx_good         | ic_mx_good                        |
+    And validate created invoices
+      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | processed | DocStatus |
+      | invoice_mx_good         | customer_mx_good         | l_mx_good                         | true      | CO        |
+
+    And validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | IsInvoicingError | OPT.Processed |
+      | ic_mx_good                        | false            | true          |
+      | ic_mx_bad                         | true             | false         |
+
+    And after not more than 60s, validate AD_Note:
+      | Identifier | AD_Message_ID.Identifier | OPT.AD_User_ID.Identifier |
+      | note_1     | msgInvoicingError        | user_metasfresh           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/reopenInvoiceCandidateOnReopenedDisposition.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/reopenInvoiceCandidateOnReopenedDisposition.feature
@@ -1,0 +1,159 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+@ghActions:run_on_executor5
+Feature: Reopening a receipt disposition reopens the purchase invoice candidate
+## F00701: Invoice Candidates
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-07-26T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+
+    And load M_Warehouse:
+      | M_Warehouse_ID.Identifier | Value        |
+      | warehouseStd              | StdWarehouse |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_1       |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl_PO      | ps_1               | DE           | EUR           | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_PO     | pl_PO          |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | plv_PO                 | product      | 10.0     | PCE      |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | M_PricingSystem_ID | IsVendor | IsCustomer |
+      | bpartner_1 | ps_1               | Y        | N          |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_1        | bpartner_1               | Y                   | Y                   |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID.Identifier |
+      | LU                    |
+      | TU                    |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | IsCurrent |
+      | LU_Version         | LU         | LU          | Y         |
+      | TU_Version         | TU         | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType | OPT.Included_HU_PI_ID.Identifier |
+      | huPiItemLU                 | LU_Version                    | 10  | HU       | TU                               |
+      | huPiItemTU                 | TU_Version                    |     | MI       |                                  |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | product_TU_10CU                    | huPiItemTU                 | product                 | 10  | 2021-01-01 |
+
+  @Id:S0164_300
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: Reopening a closed undelivered receipt disposition reopens the purchase invoice candidate
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | po1        | false   | bpartner_1    | POO         | 2022-07-26  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | QtyEnteredTU | M_HU_PI_Item_Product_ID |
+      | po1_l1     | po1        | product      | 100        | 10           | product_TU_10CU         |
+    And the order identified by po1 is completed
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.QtyOrderedTU |
+      | receiptSchedule1                | po1                   | po1_l1                    | bpartner_1               | l_1                               | product                 | 100        | warehouseStd              | 10               |
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
+      | invoiceCand_1                     | po1                       | po1_l1                    | 0                | 0            |
+
+    When the M_ReceiptSchedule identified by receiptSchedule1 is closed
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_1                     | 0            | true                 | true          |
+
+    When the M_ReceiptSchedule identified by receiptSchedule1 is reactivated
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_1                     | 0            | false                | false         |
+
+  @Id:S0164_400
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: Reactivating a purchase order only parks its receipt disposition and leaves the invoice candidate open
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | po2        | false   | bpartner_1    | POO         | 2022-07-26  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | QtyEnteredTU | M_HU_PI_Item_Product_ID |
+      | po2_l1     | po2        | product      | 100        | 10           | product_TU_10CU         |
+    And the order identified by po2 is completed
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.QtyOrderedTU |
+      | receiptSchedule2                | po2                   | po2_l1                    | bpartner_1               | l_1                               | product                 | 100        | warehouseStd              | 10               |
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
+      | invoiceCand_2                     | po2                       | po2_l1                    | 0                | 0            |
+
+    When the order identified by po2 is reactivated
+
+    # IsDeliveryClosed stays true while parked: the parking path deliberately does not reopen it
+    # (display-only); the next complete does - see @Id:S0164_500.
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_2                     | 0            | true                 | false         |
+
+  @Id:S0164_500
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: Re-completing a reactivated purchase order reopens the parked receipt disposition and its invoice candidate
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | po3        | false   | bpartner_1    | POO         | 2022-07-26  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | QtyEnteredTU | M_HU_PI_Item_Product_ID |
+      | po3_l1     | po3        | product      | 100        | 10           | product_TU_10CU         |
+    And the order identified by po3 is completed
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.QtyOrderedTU |
+      | receiptSchedule3                | po3                   | po3_l1                    | bpartner_1               | l_1                               | product                 | 100        | warehouseStd              | 10               |
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
+      | invoiceCand_3                     | po3                       | po3_l1                    | 0                | 0            |
+
+    When the M_ReceiptSchedule identified by receiptSchedule3 is closed
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_3                     | 0            | true                 | true          |
+
+    # The parking path only closes dispositions that are still open, so an already-closed one is untouched.
+    When the order identified by po3 is reactivated
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_3                     | 0            | true                 | true          |
+
+    When the order identified by po3 is completed
+    Then after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.IsClosed | OPT.Processed |
+      | receiptSchedule3                | po3                   | po3_l1                    | bpartner_1               | l_1                               | product                 | 100        | warehouseStd              | false        | false         |
+    And validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_3                     | 0            | false                | false         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderQty.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderQty.feature
@@ -514,3 +514,142 @@ Feature: Purchase order
     And after not more than 30s, M_ReceiptSchedule are found:
       | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier    | C_OrderLine_ID.Identifier    | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.Processed | OPT.IsClosed |
       | rs_PO_close_reopen              | order_PO_rs_close_reopen | orderLine_PO_rs_close_reopen | supplier_PO              | supplierLocation_PO               | product_PO_17062022     | 10         | warehouseStd              | false         | false        |
+
+  @from:cucumber
+  @allure.label.epic:E0140_Purchasing
+  @allure.label.feature:F00600_Purchase_Order
+  @F00600
+  @Id:S0156_710
+  Scenario: Purchase order line with a material receipt: background changes pass, user edits stay blocked, QtyEntered >= QtyDelivered still enforced
+    Given metasfresh contains C_Projects:
+      | Identifier           |
+      | project_PO_receipt_1 |
+      | project_PO_receipt_2 |
+    And metasfresh contains C_Orders:
+      | Identifier       | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.DocBaseType | OPT.M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.DeliveryRule | OPT.DeliveryViaRule |
+      | order_PO_receipt | N       | supplier_PO              | 2022-06-10  | POO             | ps_PO                             | supplierLocation_PO                   | F                | S                   |
+    And metasfresh contains C_OrderLines:
+      | Identifier           | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine_PO_receipt | order_PO_receipt      | product_PO_17062022     | 10         |
+
+    And the order identified by order_PO_receipt is completed
+
+    And after not more than 30s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier |
+      | receiptSchedule_PO_receipt      | order_PO_receipt      | orderLine_PO_receipt      | supplier_PO              | supplierLocation_PO               | product_PO_17062022     | 10         | warehouseStd              |
+    And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
+      | M_HU_LUTU_Configuration_ID.Identifier | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier | OPT.M_LU_HU_PI_ID.Identifier |
+      | huLuTuConfig_PO_receipt               | hu_PO_receipt      | receiptSchedule_PO_receipt      | N               | 1     | N               | 1     | N               | 10          | huPiItemProduct_17062022           | huPackingTauschpalette       |
+    And create material receipt
+      | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | hu_PO_receipt      | receiptSchedule_PO_receipt      | inOut_PO_receipt      |
+    And validate C_OrderLine:
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
+      | orderLine_PO_receipt      | order_PO_receipt      | product_PO_17062022     | 10         | 10           | 0           | 10    | 0        | EUR          | true      |
+
+    # a background writer - e.g. the invoicing run updating the order line - must not be blocked
+    When update C_OrderLine:
+      | C_OrderLine_ID.Identifier | OPT.C_Project_ID.Identifier |
+      | orderLine_PO_receipt      | project_PO_receipt_1        |
+    Then validate C_OrderLine:
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.QtyEntered | C_Project_ID         |
+      | orderLine_PO_receipt      | order_PO_receipt      | product_PO_17062022     | 10         | 10           | 0           | 10    | 0        | EUR          | true      | 10             | project_PO_receipt_1 |
+
+    # the very same change, made by a user, stays blocked
+    When update C_OrderLine expecting error:
+      | C_OrderLine_ID.Identifier | OPT.C_Project_ID.Identifier | OPT.AsUIAction | OPT.ErrorCode        |
+      | orderLine_PO_receipt      | project_PO_receipt_2        | Y              | ORDER_RECEIPT_EXISTS |
+    Then validate C_OrderLine:
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.QtyEntered | C_Project_ID         |
+      | orderLine_PO_receipt      | order_PO_receipt      | product_PO_17062022     | 10         | 10           | 0           | 10    | 0        | EUR          | true      | 10             | project_PO_receipt_1 |
+
+    # QtyEntered >= QtyDelivered is a data invariant, so it also applies to background writers
+    When update C_OrderLine expecting error:
+      | C_OrderLine_ID.Identifier | OPT.QtyEntered | OPT.ErrorMessage         |
+      | orderLine_PO_receipt      | 5              | Menge < Gelieferte Menge |
+    Then validate C_OrderLine:
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.QtyEntered | C_Project_ID         |
+      | orderLine_PO_receipt      | order_PO_receipt      | product_PO_17062022     | 10         | 10           | 0           | 10    | 0        | EUR          | true      | 10             | project_PO_receipt_1 |
+
+  @from:cucumber
+  @allure.label.epic:E0140_Purchasing
+  @allure.label.feature:F00600_Purchase_Order
+  @F00600
+  @Id:S0156_720
+  Scenario: Receiving a fully matched purchase order line that has no ASI stamps the receipt line's ASI onto it
+  # Reproduces the production defect through the real carrier. No test-only flag, no synthetic write
+  # of the column under test - the receipt itself is what triggers it.
+  #
+  # MMatchPO.afterSave writes five order-line columns. QtyDelivered, DateDelivered, QtyInvoiced and
+  # DateInvoiced are all in assertChangeAllowed's ignoreColumnsChanged, so they cannot fire the
+  # interceptor. M_AttributeSetInstance_ID is NOT in that list, and afterSave stamps it from the
+  # receipt line when the order line has no ASI yet and the receipt fully matches
+  # (M_InOutLine.MovementQty == C_OrderLine.QtyOrdered). That stamp is the only write here that
+  # reaches the guard - and the guard's QtyDelivered==0 early return does not save it, because
+  # afterSave increments QtyDelivered on the in-memory model BEFORE saving.
+  #
+  # Three fixture conditions, all of them real production states:
+  #   1. the product has an attribute set, so the received HU - and hence the receipt line - carries
+  #      a non-zero ASI. Deliberately NOT QualityDiscountPercent: it splits the receipt into two
+  #      lines and destroys the full match the stamp depends on.
+  #   2. the ORDER LINE has no ASI. This is the condition the local stack never produces on its own
+  #      (every local order line gets an empty ASI record) while 37% of the customer's purchase order
+  #      lines have none - 573246 of 1560109 measured 2026-09-01. Cleared explicitly below; the order
+  #      line is still undelivered at that point, so the guard early-returns and the clear is safe.
+  #   3. the receipt fully matches QtyOrdered.
+  #
+  # "create material receipt" both creates and completes the receipt, so it raises the guard itself.
+  # Before the fix this scenario fails there with ORDER_RECEIPT_EXISTS.
+    Given load M_Attribute:
+      | M_Attribute_ID.Identifier | Value     |
+      | attr_ageOffset_PO         | AgeOffset |
+    And add M_AttributeSet:
+      | M_AttributeSet_ID.Identifier | Name                | MandatoryType |
+      | attributeSet_PO_asi          | attributeSet_PO_asi | N             |
+    And add M_AttributeUse:
+      | M_AttributeUse_ID.Identifier | M_AttributeSet_ID.Identifier | M_Attribute_ID.Identifier | SeqNo |
+      | attributeUse_PO_asi          | attributeSet_PO_asi          | attr_ageOffset_PO         | 10    |
+
+    And metasfresh contains M_Products:
+      | Identifier     | Value          | Name           | OPT.M_AttributeSet_ID.Identifier |
+      | product_PO_asi | product_PO_asi | product_PO_asi | attributeSet_PO_asi              |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | huPiItemProduct_PO_asi             | huPiItem_IFCO              | product_PO_asi          | 10  | 2022-03-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_PO_asi  | plv_PO                            | product_PO_asi          | 10.0     | PCE               | Normal                        |
+
+    And metasfresh contains C_Orders:
+      | Identifier   | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.DocBaseType | OPT.M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.DeliveryRule | OPT.DeliveryViaRule |
+      | order_PO_asi | N       | supplier_PO              | 2022-06-10  | POO             | ps_PO                             | supplierLocation_PO                   | F                | S                   |
+    And metasfresh contains C_OrderLines:
+      | Identifier       | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine_PO_asi | order_PO_asi          | product_PO_asi          | 10         |
+
+    And the order identified by order_PO_asi is completed
+
+    # fixture condition 2: an ASI-less purchase order line. Safe here - nothing is delivered yet, so
+    # assertChangeAllowed early-returns on QtyDelivered == 0.
+    And update C_OrderLine:
+      | C_OrderLine_ID.Identifier | OPT.M_AttributeSetInstance_ID.Identifier |
+      | orderLine_PO_asi          | null                                     |
+
+    And after not more than 30s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier |
+      | receiptSchedule_PO_asi          | order_PO_asi          | orderLine_PO_asi          | supplier_PO              | supplierLocation_PO               | product_PO_asi          | 10         | warehouseStd              |
+    And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
+      | M_HU_LUTU_Configuration_ID.Identifier | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier | OPT.M_LU_HU_PI_ID.Identifier |
+      | huLuTuConfig_PO_asi                   | hu_PO_asi          | receiptSchedule_PO_asi          | N               | 1     | N               | 1     | N               | 10          | huPiItemProduct_PO_asi             | huPackingTauschpalette       |
+    And update M_HU_Attribute recursive:
+      | M_HU_ID.Identifier | M_Attribute_ID.Identifier | OPT.ValueNumber |
+      | hu_PO_asi          | attr_ageOffset_PO         | 3               |
+
+    # the whole point: this must NOT raise ORDER_RECEIPT_EXISTS
+    When create material receipt
+      | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | hu_PO_asi          | receiptSchedule_PO_asi          | inOut_PO_asi          |
+
+    Then validate C_OrderLine:
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.QtyEntered |
+      | orderLine_PO_asi          | order_PO_asi          | product_PO_asi          | 10         | 10           | 0           | 10    | 0        | EUR          | true      | 10             |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/C_OrderLine.java
@@ -160,7 +160,9 @@ public class C_OrderLine
 		{
 			validateQtyEntered(orderLine);
 		}
-		else
+		// the lock is a policy for user edits only; background writers (e.g. the invoicing run updating
+		// the order line) must not be aborted by it
+		else if (InterfaceWrapperHelper.isUIAction(orderLine))
 		{
 			throw new AdempiereException(ERR_ORDER_MODIFICATION_NOT_ALLOWED_RECEIPT_EXISTS)
 					.markAsUserValidationError();

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
@@ -691,7 +691,9 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 
 			// Fire the side effects that ReceiptScheduleBL.reopen()'s onAfterReopen listener would have done.
 			// orderBL.reopenLine(orderLine) was already called above.
-			invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
+			final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
+			invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
+			invoiceCandBL.openInvoiceCandidatesByOrderLineId(orderLineId);
 		}
 	}
 
@@ -716,6 +718,11 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 			// itself must stay open for editing. Undo the closeLine side-effect.
 			InterfaceWrapperHelper.refresh(orderLine);
 			orderBL.reopenLine(orderLine);
+
+			// Undo the close's Processed_Override=Y too, or the reactivated order's candidates can never be invoiced.
+			// openDeliveryInvoiceCandidatesByOrderLineId is deliberately NOT called: IsDeliveryClosed is display-only
+			// and self-heals on the next complete - see reopenReceiptSchedulesForOrder.
+			invoiceCandBL.openInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
 		}
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
@@ -277,15 +277,26 @@ public class M_ShipmentSchedule
 			return;
 		}
 
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
+
 		if (shipmentSchedule.isClosed())
 		{
 			orderBL.closeLine(orderLine);
-			invoiceCandBL.closeDeliveryInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
+			invoiceCandBL.closeDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
+
+			// see OrderLineReceiptScheduleListener.onAfterClose - same reasoning, sales side
+			if (orderLine.getQtyDelivered().signum() == 0)
+			{
+				invoiceCandBL.closeInvoiceCandidatesByOrderLineId(orderLineId);
+			}
 		}
 		else
 		{
 			orderBL.reopenLine(orderLine);
-			invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
+			invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
+
+			// see OrderLineReceiptScheduleListener.onAfterReopen - same reasoning, sales side
+			invoiceCandBL.openInvoiceCandidatesByOrderLineId(orderLineId);
 		}
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleListener.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleListener.java
@@ -38,7 +38,15 @@ public class OrderLineReceiptScheduleListener extends ReceiptScheduleListenerAda
 
 		orderBL.closeLine(orderLine);
 
-		invoiceCandBL.closeDeliveryInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
+		invoiceCandBL.closeDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
+
+		// Nothing was received, so the candidates can never be invoiced and would linger as open work that
+		// "Create Invoices" silently skips. A partial receipt must stay open - its delivered part is invoiceable.
+		if (orderLine.getQtyDelivered().signum() == 0)
+		{
+			invoiceCandBL.closeInvoiceCandidatesByOrderLineId(orderLineId);
+		}
 	}
 
 	/**
@@ -60,6 +68,9 @@ public class OrderLineReceiptScheduleListener extends ReceiptScheduleListenerAda
 		}
 
 		orderBL.reopenLine(orderLine);
-		invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
+
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
+		invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
+		invoiceCandBL.openInvoiceCandidatesByOrderLineId(orderLineId);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
@@ -87,6 +87,9 @@ public interface IInvoiceCandBL extends ISingletonService
 
 		void addNotifications(List<I_AD_Note> notifications);
 
+		/** Implementations which are able to notify a user shall do so from here. */
+		void addFailedCandidates(List<I_C_Invoice_Candidate> failedCandidates, Throwable error);
+
 		/**
 		 * @param ctx context (for translation)
 		 * @return result summary (using context language)
@@ -367,6 +370,9 @@ public interface IInvoiceCandBL extends ISingletonService
 	CurrencyPrecision extractPricePrecision(I_C_Invoice_Candidate ic);
 
 	void closeInvoiceCandidatesByOrderLineId(OrderLineId orderLineId);
+
+	/** Undo of {@link #closeInvoiceCandidatesByOrderLineId(OrderLineId)}: clears {@code Processed_Override} and invalidates the candidates. */
+	void openInvoiceCandidatesByOrderLineId(OrderLineId orderLineId);
 
 	/**
 	 * Close the given invoice candidate.

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/ForwardingInvoiceGenerateResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/ForwardingInvoiceGenerateResult.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ForwardingObject;
 
 import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.invoicecandidate.api.IInvoiceCandBL.IInvoiceGenerateResult;
+import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.util.Check;
 
 /**
@@ -97,6 +98,12 @@ public abstract class ForwardingInvoiceGenerateResult extends ForwardingObject i
 	public void addNotifications(final List<I_AD_Note> notifications)
 	{
 		delegate().addNotifications(notifications);
+	}
+
+	@Override
+	public void addFailedCandidates(final List<I_C_Invoice_Candidate> failedCandidates, final Throwable error)
+	{
+		delegate().addFailedCandidates(failedCandidates, error);
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -2259,6 +2259,27 @@ public class InvoiceCandBL implements IInvoiceCandBL
 	}
 
 	@Override
+	public void openInvoiceCandidatesByOrderLineId(@NonNull final OrderLineId orderLineId)
+	{
+		final List<I_C_Invoice_Candidate> invoiceCandidates = invoiceCandDAO.retrieveInvoiceCandidatesForOrderLineId(orderLineId);
+		invoiceCandidates.forEach(this::openInvoiceCandidate);
+	}
+
+	/** Counterpart of {@link #closeInvoiceCandidate(I_C_Invoice_Candidate)}; QtyToInvoice is not restored, the invalidation recomputes it. */
+	private void openInvoiceCandidate(@NonNull final I_C_Invoice_Candidate candidate)
+	{
+		candidate.setProcessed_Override(null);
+
+		if (!InterfaceWrapperHelper.hasChanges(candidate))
+		{
+			return;
+		}
+
+		invoiceCandDAO.invalidateCand(candidate);
+		InterfaceWrapperHelper.save(candidate);
+	}
+
+	@Override
 	public void closeDeliveryInvoiceCandidatesByOrderLineId(@NonNull final OrderLineId orderLineId)
 	{
 		final List<I_C_Invoice_Candidate> invoiceCandidates = invoiceCandDAO.retrieveInvoiceCandidatesForOrderLineId(orderLineId);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -2276,7 +2276,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 		}
 
 		invoiceCandDAO.invalidateCand(candidate);
-		InterfaceWrapperHelper.save(candidate);
+		invoiceCandDAO.save(candidate);
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
@@ -1120,6 +1120,11 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 					result.add(note);
 				}
 			}
+
+			// This method is the one choke point all three failure call sites reach.
+			// Survives the rollback that is about to happen: the AD_Note is created out-of-trx (TRXNAME_None).
+			getCollector().addFailedCandidates(affectedCands, error);
+
 			return result;
 
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceGenerateResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceGenerateResult.java
@@ -31,6 +31,7 @@ import org.compiere.model.I_AD_Note;
 import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.i18n.IMsgBL;
 import de.metas.invoicecandidate.api.IInvoiceCandBL.IInvoiceGenerateResult;
+import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.util.Accessor;
 import de.metas.util.Services;
 
@@ -44,6 +45,7 @@ import de.metas.util.Services;
 
 	private final boolean storeInvoices;
 	private int invoiceCount = 0;
+	private int failedCandidateCount = 0;
 
 	/**
 	 * 
@@ -107,6 +109,16 @@ import de.metas.util.Services;
 			this.notifications.addAll(list);
 			this.notificationsWhereClause = null;
 		}
+	}
+
+	@Override
+	public void addFailedCandidates(final List<I_C_Invoice_Candidate> failedCandidates, final Throwable error)
+	{
+		if (failedCandidates == null || failedCandidates.isEmpty())
+		{
+			return;
+		}
+		this.failedCandidateCount += failedCandidates.size();
 	}
 
 	@Override
@@ -209,6 +221,10 @@ import de.metas.util.Services;
 		if (notifications != null && !notifications.isEmpty())
 		{
 			sb.append(", notifications=").append(notifications);
+		}
+		if (failedCandidateCount > 0)
+		{
+			sb.append(", failedCandidateCount=").append(failedCandidateCount);
 		}
 		sb.append("]");
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/UserNotificationsInvoiceGenerateResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/UserNotificationsInvoiceGenerateResult.java
@@ -5,7 +5,10 @@ import org.adempiere.invoice.event.InvoiceUserNotificationsProducer;
 import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.invoicecandidate.api.IInvoiceCandBL.IInvoiceGenerateResult;
 import de.metas.invoicecandidate.api.impl.ForwardingInvoiceGenerateResult;
+import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.user.UserId;
+
+import java.util.List;
 
 /**
  * {@link ForwardingInvoiceGenerateResult} implementation which is also creating and sending user notifications via {@link InvoiceUserNotificationsProducer}.
@@ -39,5 +42,13 @@ public class UserNotificationsInvoiceGenerateResult extends ForwardingInvoiceGen
 		super.addInvoice(invoice);
 
 		invoiceGeneratedEventBus.notifyGenerated(invoice, recipientUserId);
+	}
+
+	@Override
+	public void addFailedCandidates(final List<I_C_Invoice_Candidate> failedCandidates, final Throwable error)
+	{
+		super.addFailedCandidates(failedCandidates, error);
+
+		invoiceGeneratedEventBus.notifyInvoicingError(failedCandidates, error, recipientUserId);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/ConfigValidator.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/ConfigValidator.java
@@ -100,6 +100,7 @@ public class ConfigValidator extends AbstractModuleInterceptor
 		//
 		// Setup event bus topics on which swing client notification listener shall subscribe
 		Services.get(IEventBusFactory.class).addAvailableUserNotificationsTopic(InvoiceUserNotificationsProducer.EVENTBUS_TOPIC);
+		Services.get(IEventBusFactory.class).addAvailableUserNotificationsTopic(InvoiceUserNotificationsProducer.EVENTBUS_TOPIC_Error);
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/org/adempiere/invoice/event/InvoiceUserNotificationsProducer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/org/adempiere/invoice/event/InvoiceUserNotificationsProducer.java
@@ -5,6 +5,7 @@ import de.metas.event.IEventBus;
 import de.metas.event.Topic;
 import de.metas.event.Type;
 import de.metas.i18n.AdMessageKey;
+import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.logging.LogManager;
 import de.metas.notification.INotificationBL;
 import de.metas.notification.UserNotificationRequest;
@@ -12,12 +13,15 @@ import de.metas.notification.UserNotificationRequest.TargetRecordAction;
 import de.metas.user.UserId;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_Invoice;
+import org.compiere.util.Env;
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * {@link IEventBus} wrapper implementation tailored for sending events about generated invoices.
@@ -37,9 +41,19 @@ public class InvoiceUserNotificationsProducer
 			.type(Type.DISTRIBUTED)
 			.build();
 
+	/**
+	 * Separate from {@link #EVENTBUS_TOPIC} because every subscriber of that one expects the event to reference
+	 * a C_Invoice, and a failure event references none.
+	 */
+	public static final Topic EVENTBUS_TOPIC_Error = Topic.builder()
+			.name("de.metas.invoicecandidate.UserNotifications.InvoicingErrors")
+			.type(Type.DISTRIBUTED)
+			.build();
+
 	private static final transient Logger logger = LogManager.getLogger(InvoiceUserNotificationsProducer.class);
 
 	private static final AdMessageKey MSG_Event_InvoiceGenerated = AdMessageKey.of("Event_InvoiceGenerated");
+	private static final AdMessageKey MSG_Event_InvoicingError = AdMessageKey.of("Event_InvoicingError");
 
 	private InvoiceUserNotificationsProducer()
 	{
@@ -89,6 +103,39 @@ public class InvoiceUserNotificationsProducer
 				.contentADMessageParam(bpName)
 				.targetAction(TargetRecordAction.of(invoiceRef))
 				.build();
+	}
+
+	public InvoiceUserNotificationsProducer notifyInvoicingError(
+			@Nullable final List<I_C_Invoice_Candidate> failedCandidates,
+			@Nullable final Throwable error,
+			@Nullable final UserId recipientUserId)
+	{
+		// Without this, a forwarded-but-empty call would notify "0 invoice candidate(s) could not be invoiced".
+		if (failedCandidates == null || failedCandidates.isEmpty())
+		{
+			return this;
+		}
+
+		try
+		{
+			// send() and not sendAfterCommit(): the invoicing transaction is rolled back on error,
+			// so an after-commit notification would never be sent.
+			Services.get(INotificationBL.class).send(UserNotificationRequest.builder()
+					.topic(EVENTBUS_TOPIC_Error)
+					.recipientUserId(recipientUserId != null ? recipientUserId : Env.getLoggedUserId())
+					.contentADMessage(MSG_Event_InvoicingError)
+					.contentADMessageParam(failedCandidates.size())
+					// extractMessage() and not getLocalizedMessage(): the latter is null for e.g. an NPE,
+					// which would render the note as "...: null".
+					.contentADMessageParam(AdempiereException.extractMessage(error))
+					.build());
+		}
+		catch (final Exception ex)
+		{
+			logger.warn("Failed creating invoicing-error event for {} candidate(s). Ignored.", failedCandidates.size(), ex);
+		}
+
+		return this;
 	}
 
 	private UserNotificationRequest.UserNotificationRequestBuilder newUserNotificationRequest()

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5821320_sys_Event_InvoicingError_message.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5821320_sys_Event_InvoicingError_message.sql
@@ -1,0 +1,37 @@
+-- IDs allocated from idserver.metas.de on 2026-08-31:
+--   AD_MigrationScript 5821320 (this script)
+--   AD_Message         545816 (Event_InvoicingError)
+--
+-- Notification shown to the user who started a "Create Invoices" run when some or all of the
+-- selected invoice candidates could not be invoiced.
+--   {0} = number of invoice candidates that failed
+--   {1} = the error text
+
+-- 2026-08-31T15:11:41
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545816 /*From ID Server*/,0,TO_TIMESTAMP('2026-08-31 15:11:41','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','{0} Rechnungskandidat(en) konnten nicht fakturiert werden: {1}','E',TO_TIMESTAMP('2026-08-31 15:11:41','YYYY-MM-DD HH24:MI:SS'),100,'Event_InvoicingError')
+;
+
+-- 2026-08-31T15:11:42
+UPDATE AD_Message SET ErrorCode='INVOICING_ERROR',Updated=TO_TIMESTAMP('2026-08-31 15:11:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Message_ID=545816
+;
+
+-- 2026-08-31T15:11:43
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545816
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- 2026-08-31T15:11:44
+UPDATE AD_Message_Trl SET MsgText='{0} invoice candidate(s) could not be invoiced: {1}',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-31 15:11:44','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545816
+;
+
+-- 2026-08-31T15:11:45
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-31 15:11:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545816
+;
+
+-- 2026-08-31T15:11:46
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-31 15:11:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545816
+;


### PR DESCRIPTION
Forward merge-through of the whole `soft_panda_hotfix` branch into `new_dawn_uat`.

`soft_panda_hotfix` was exactly 2 commits ahead of `new_dawn_uat`; both belong to the same
piece of work and were reviewed and merged on their own PRs:

- https://github.com/metasfresh/metasfresh/pull/25663 — Accounting: skip posting silently when the
  document was deleted after the posting was scheduled (https://github.com/metasfresh/metasfresh/commit/5a38e5af1b8d8df4d92167918b635a58396d746a)
- https://github.com/metasfresh/metasfresh/pull/25673 — Invoice candidates: report failed
  Create Invoices runs, and close candidates of undelivered dispositions (https://github.com/metasfresh/metasfresh/commit/09bfdee9dc069b6375de43c2c68340f4e727cd45)

The merge was conflict-free.

### Migration script

`backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5821320_sys_Event_InvoicingError_message.sql`

- purely additive AD metadata (one `AD_Message` + its `AD_Message_Trl` rows), `AD_Message_ID=545816`
  from the central ID server — it redefines no existing view or function, so there is no
  whole-object DDL regression risk.
- the file does not exist on `new_dawn_uat`, and prefix `5821320` is higher than the highest
  migration prefix currently on `new_dawn_uat` (`5821230`), so ordering is correct and no
  re-numbering is needed.

### Merge instructions

Merge with a **merge commit** (`--merge`), never squash — squashing a merge-through destroys the
parent relationship and makes every later `soft_panda_hotfix` -> `new_dawn_uat` merge re-conflict.
