### PR TITLE
Purchase order: receipt-exists change lock applies to user edits only

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
@@ -32,6 +32,7 @@ import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
 import de.metas.cucumber.stepdefs.IdentifierIds_StepDefData;
+import de.metas.cucumber.stepdefs.InterfaceWrapperHelperUtils;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.StepDefConstants;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
@@ -415,82 +416,149 @@ public class C_OrderLine_StepDef
 	@And("update C_OrderLine:")
 	public void update_C_OrderLine(@NonNull final DataTable dataTable)
 	{
-		final List<Map<String, String>> table = dataTable.asMaps();
-		for (final Map<String, String> row : table)
+		dataTable.asMaps().forEach(row -> updateOrderLine(row, false));
+	}
+
+	@And("update C_OrderLine expecting error:")
+	public void update_C_OrderLine_expectingError(@NonNull final DataTable dataTable)
+	{
+		updateOrderLineExpectingError(dataTable, false);
+	}
+
+	@And("update C_OrderLine as UI action expecting error:")
+	public void update_C_OrderLine_asUIAction_expectingError(@NonNull final DataTable dataTable)
+	{
+		updateOrderLineExpectingError(dataTable, true);
+	}
+
+	private void updateOrderLineExpectingError(@NonNull final DataTable dataTable, final boolean asUIAction)
+	{
+		final List<Map<String, String>> rows = dataTable.asMaps();
+		if (rows.size() > 1)
 		{
-			final String olIdentifier = DataTableUtil.extractStringForColumnName(row, I_C_OrderLine.COLUMNNAME_C_OrderLine_ID + "." + TABLECOLUMN_IDENTIFIER);
-			final de.metas.handlingunits.model.I_C_OrderLine orderLine = InterfaceWrapperHelper.create(orderLineTable.get(olIdentifier), de.metas.handlingunits.model.I_C_OrderLine.class);
-
-			final String contractIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_C_Flatrate_Term_ID + "." + TABLECOLUMN_IDENTIFIER);
-
-			if (Check.isNotBlank(contractIdentifier))
-			{
-				final I_C_Flatrate_Term contract = contractTable.get(contractIdentifier);
-
-				orderLine.setC_Flatrate_Term_ID(contract.getC_Flatrate_Term_ID());
-			}
-
-			final BigDecimal updatedQtyEntered = DataTableUtil.extractBigDecimalOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_QtyEntered);
-			if (updatedQtyEntered != null)
-			{
-				orderLine.setQtyEntered(updatedQtyEntered);
-			}
-
-			final String piItemProductIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + de.metas.handlingunits.model.I_C_OrderLine.COLUMNNAME_M_HU_PI_Item_Product_ID);
-			if (Check.isNotBlank(piItemProductIdentifier))
-			{
-				final Integer piItemProductId = huPiItemProductTable.getOptional(piItemProductIdentifier)
-						.map(I_M_HU_PI_Item_Product::getM_HU_PI_Item_Product_ID)
-						.orElseGet(() -> Integer.parseInt(piItemProductIdentifier));
-
-				orderLine.setM_HU_PI_Item_Product_ID(piItemProductId);
-			}
-
-			final String attributeSetInstanceIdentifier = DataTableUtil.extractNullableStringForColumnName(row, "OPT." + COLUMNNAME_M_AttributeSetInstance_ID + "." + StepDefConstants.TABLECOLUMN_IDENTIFIER);
-			if (de.metas.util.Check.isNotBlank(attributeSetInstanceIdentifier))
-			{
-				final String asiIdentifierValue = DataTableUtil.nullToken2Null(attributeSetInstanceIdentifier);
-				if (asiIdentifierValue == null)
-				{
-					orderLine.setM_AttributeSetInstance_ID(-1);
-				}
-				else
-				{
-					final I_M_AttributeSetInstance attributeSetInstance = attributeSetInstanceTable.get(attributeSetInstanceIdentifier);
-					assertThat(attributeSetInstance).isNotNull();
-
-					orderLine.setM_AttributeSetInstance_ID(attributeSetInstance.getM_AttributeSetInstance_ID());
-				}
-			}
-
-			final BigDecimal updatedQtyOrdered = DataTableUtil.extractBigDecimalOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_QtyOrdered);
-			if (updatedQtyOrdered != null)
-			{
-				orderLine.setQtyOrdered(updatedQtyOrdered);
-			}
-
-			final String asiIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_M_AttributeSetInstance_ID + "." + TABLECOLUMN_IDENTIFIER);
-
-			if (Check.isNotBlank(asiIdentifier))
-			{
-				final Integer asiId = attributeSetInstanceTable.getOptional(asiIdentifier)
-						.map(I_M_AttributeSetInstance::getM_AttributeSetInstance_ID)
-						.orElseGet(() -> Integer.parseInt(asiIdentifier));
-
-				orderLine.setM_AttributeSetInstance_ID(asiId);
-			}
-
-			final String projectIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_C_Project_ID + "." + TABLECOLUMN_IDENTIFIER);
-			if (Check.isNotBlank(projectIdentifier))
-			{
-				final I_C_Project project = projectTable.get(projectIdentifier);
-				orderLine.setC_Project_ID(project.getC_Project_ID());
-			}
-
-			saveRecord(orderLine);
-
-			orderLineTable.putOrReplace(olIdentifier, orderLine);
+			throw new IllegalArgumentException("Multiple rows are not supported!");
 		}
+		final Map<String, String> row = rows.get(0);
+
+		final String expectedErrorCode = DataTableUtil.extractStringOrNullForColumnName(row, "OPT.ErrorCode");
+		final String expectedMessagePart = DataTableUtil.extractStringOrNullForColumnName(row, "OPT.ErrorMessage");
+		if (Check.isBlank(expectedErrorCode) && Check.isBlank(expectedMessagePart))
+		{
+			throw new IllegalArgumentException("Either ErrorCode or ErrorMessage has to be given!");
+		}
+
+		try
+		{
+			updateOrderLine(row, asUIAction);
+
+			Assertions.fail("An Exception should have been thrown !");
+		}
+		catch (final AdempiereException exception)
+		{
+			if (Check.isNotBlank(expectedErrorCode))
+			{
+				assertThat(exception.getErrorCode()).isEqualTo(expectedErrorCode);
+			}
+			if (Check.isNotBlank(expectedMessagePart))
+			{
+				assertThat(exception.getMessage()).contains(expectedMessagePart);
+			}
+		}
+	}
+
+	/**
+	 * @param asUIAction if true, the record is flagged as a manual user action before it is saved, the way
+	 * the WebUI's save handler does it. Model interceptors that only guard *user* edits fire just in that case.
+	 */
+	private void updateOrderLine(@NonNull final Map<String, String> row, final boolean asUIAction)
+	{
+		final String olIdentifier = DataTableUtil.extractStringForColumnName(row, I_C_OrderLine.COLUMNNAME_C_OrderLine_ID + "." + TABLECOLUMN_IDENTIFIER);
+		final de.metas.handlingunits.model.I_C_OrderLine orderLine = InterfaceWrapperHelper.create(orderLineTable.get(olIdentifier), de.metas.handlingunits.model.I_C_OrderLine.class);
+
+		final String contractIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_C_Flatrate_Term_ID + "." + TABLECOLUMN_IDENTIFIER);
+
+		if (Check.isNotBlank(contractIdentifier))
+		{
+			final I_C_Flatrate_Term contract = contractTable.get(contractIdentifier);
+
+			orderLine.setC_Flatrate_Term_ID(contract.getC_Flatrate_Term_ID());
+		}
+
+		final BigDecimal updatedQtyEntered = DataTableUtil.extractBigDecimalOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_QtyEntered);
+		if (updatedQtyEntered != null)
+		{
+			orderLine.setQtyEntered(updatedQtyEntered);
+		}
+
+		final String piItemProductIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + de.metas.handlingunits.model.I_C_OrderLine.COLUMNNAME_M_HU_PI_Item_Product_ID);
+		if (Check.isNotBlank(piItemProductIdentifier))
+		{
+			final Integer piItemProductId = huPiItemProductTable.getOptional(piItemProductIdentifier)
+					.map(I_M_HU_PI_Item_Product::getM_HU_PI_Item_Product_ID)
+					.orElseGet(() -> Integer.parseInt(piItemProductIdentifier));
+
+			orderLine.setM_HU_PI_Item_Product_ID(piItemProductId);
+		}
+
+		final String attributeSetInstanceIdentifier = DataTableUtil.extractNullableStringForColumnName(row, "OPT." + COLUMNNAME_M_AttributeSetInstance_ID + "." + StepDefConstants.TABLECOLUMN_IDENTIFIER);
+		if (de.metas.util.Check.isNotBlank(attributeSetInstanceIdentifier))
+		{
+			final String asiIdentifierValue = DataTableUtil.nullToken2Null(attributeSetInstanceIdentifier);
+			if (asiIdentifierValue == null)
+			{
+				orderLine.setM_AttributeSetInstance_ID(-1);
+			}
+			else
+			{
+				final I_M_AttributeSetInstance attributeSetInstance = attributeSetInstanceTable.get(attributeSetInstanceIdentifier);
+				assertThat(attributeSetInstance).isNotNull();
+
+				orderLine.setM_AttributeSetInstance_ID(attributeSetInstance.getM_AttributeSetInstance_ID());
+			}
+		}
+
+		final BigDecimal updatedQtyOrdered = DataTableUtil.extractBigDecimalOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_QtyOrdered);
+		if (updatedQtyOrdered != null)
+		{
+			orderLine.setQtyOrdered(updatedQtyOrdered);
+		}
+
+		final String asiIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_M_AttributeSetInstance_ID + "." + TABLECOLUMN_IDENTIFIER);
+
+		if (Check.isNotBlank(asiIdentifier))
+		{
+			final Integer asiId = attributeSetInstanceTable.getOptional(asiIdentifier)
+					.map(I_M_AttributeSetInstance::getM_AttributeSetInstance_ID)
+					.orElseGet(() -> Integer.parseInt(asiIdentifier));
+
+			orderLine.setM_AttributeSetInstance_ID(asiId);
+		}
+
+		final String projectIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_C_Project_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (Check.isNotBlank(projectIdentifier))
+		{
+			final I_C_Project project = projectTable.get(projectIdentifier);
+			orderLine.setC_Project_ID(project.getC_Project_ID());
+		}
+
+		if (asUIAction)
+		{
+			InterfaceWrapperHelperUtils.set_ManualUserAction(orderLine);
+		}
+		try
+		{
+			saveRecord(orderLine);
+		}
+		finally
+		{
+			// also on a failed save: the flag lives on the cached PO and would leak into later, non-UI saves
+			if (asUIAction)
+			{
+				InterfaceWrapperHelperUtils.unset_ManualUserAction(orderLine);
+			}
+		}
+
+		orderLineTable.putOrReplace(olIdentifier, orderLine);
 	}
 
 	@And("^delete C_OrderLine identified by (.*), but keep its id into identifierIds table$")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
@@ -413,35 +413,71 @@ public class C_OrderLine_StepDef
 		}
 	}
 
+	/**
+	 * Updates previously registered order lines, applying every value column that is present.
+	 *
+	 * <p>The save runs as a background write, i.e. the way an automatic writer such as the invoicing
+	 * run saves a line. Use {@code update C_OrderLine expecting error:} with {@code AsUIAction} to save
+	 * as a user edit instead.</p>
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <ul>
+	 *     <li>{@code C_OrderLine_ID} — required, identifier of the line to update</li>
+	 *     <li>{@code C_Flatrate_Term_ID}, {@code QtyEntered}, {@code M_HU_PI_Item_Product_ID},
+	 *         {@code M_AttributeSetInstance_ID}, {@code QtyOrdered}, {@code C_Project_ID} — optional,
+	 *         each is applied only when the column is present</li>
+	 *   </ul>
+	 * @cucumber.example
+	 * <pre>
+	 * And update C_OrderLine:
+	 *   | C_OrderLine_ID.Identifier | OPT.QtyEntered |
+	 *   | ol_1                      | 50             |
+	 * </pre>
+	 */
 	@And("update C_OrderLine:")
 	public void update_C_OrderLine(@NonNull final DataTable dataTable)
 	{
 		dataTable.asMaps().forEach(row -> updateOrderLine(row, false));
 	}
 
+	/**
+	 * Same as {@code update C_OrderLine:}, but the save is expected to be rejected.
+	 *
+	 * <p>With {@code AsUIAction} the record is flagged as a manual user action before it is saved, the
+	 * way the WebUI's save handler does it — that is what makes a model interceptor apply a policy it
+	 * enforces for user edits only.</p>
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <ul>
+	 *     <li>{@code C_OrderLine_ID} — required, identifier of the line to update</li>
+	 *     <li>the value columns of {@code update C_OrderLine:} — optional</li>
+	 *     <li>{@code ErrorCode} — optional, the expected error code of the thrown exception</li>
+	 *     <li>{@code ErrorMessage} — optional, an expected substring of the exception message;
+	 *         at least one of {@code ErrorCode} / {@code ErrorMessage} has to be given</li>
+	 *     <li>{@code AsUIAction} — optional, defaults to {@code N}</li>
+	 *   </ul>
+	 * @cucumber.example
+	 * <pre>
+	 * And update C_OrderLine expecting error:
+	 *   | C_OrderLine_ID.Identifier | OPT.C_Project_ID.Identifier | OPT.AsUIAction | OPT.ErrorCode        |
+	 *   | ol_1                      | project_2                   | Y              | ORDER_RECEIPT_EXISTS |
+	 * </pre>
+	 */
 	@And("update C_OrderLine expecting error:")
 	public void update_C_OrderLine_expectingError(@NonNull final DataTable dataTable)
 	{
-		updateOrderLineExpectingError(dataTable, false);
-	}
-
-	@And("update C_OrderLine as UI action expecting error:")
-	public void update_C_OrderLine_asUIAction_expectingError(@NonNull final DataTable dataTable)
-	{
-		updateOrderLineExpectingError(dataTable, true);
-	}
-
-	private void updateOrderLineExpectingError(@NonNull final DataTable dataTable, final boolean asUIAction)
-	{
-		final List<Map<String, String>> rows = dataTable.asMaps();
-		if (rows.size() > 1)
+		final List<Map<String, String>> rowMaps = dataTable.asMaps();
+		if (rowMaps.size() > 1)
 		{
 			throw new IllegalArgumentException("Multiple rows are not supported!");
 		}
-		final Map<String, String> row = rows.get(0);
+		final Map<String, String> rowMap = rowMaps.get(0);
+		final DataTableRow row = DataTableRow.singleRow(rowMap);
 
-		final String expectedErrorCode = DataTableUtil.extractStringOrNullForColumnName(row, "OPT.ErrorCode");
-		final String expectedMessagePart = DataTableUtil.extractStringOrNullForColumnName(row, "OPT.ErrorMessage");
+		final String expectedErrorCode = row.getAsOptionalString("ErrorCode").orElse(null);
+		final String expectedMessagePart = row.getAsOptionalString("ErrorMessage").orElse(null);
 		if (Check.isBlank(expectedErrorCode) && Check.isBlank(expectedMessagePart))
 		{
 			throw new IllegalArgumentException("Either ErrorCode or ErrorMessage has to be given!");
@@ -449,7 +485,7 @@ public class C_OrderLine_StepDef
 
 		try
 		{
-			updateOrderLine(row, asUIAction);
+			updateOrderLine(rowMap, row.getAsOptionalBoolean("AsUIAction").orElseFalse());
 
 			Assertions.fail("An Exception should have been thrown !");
 		}
@@ -466,10 +502,6 @@ public class C_OrderLine_StepDef
 		}
 	}
 
-	/**
-	 * @param asUIAction if true, the record is flagged as a manual user action before it is saved, the way
-	 * the WebUI's save handler does it. Model interceptors that only guard *user* edits fire just in that case.
-	 */
 	private void updateOrderLine(@NonNull final Map<String, String> row, final boolean asUIAction)
 	{
 		final String olIdentifier = DataTableUtil.extractStringForColumnName(row, I_C_OrderLine.COLUMNNAME_C_OrderLine_ID + "." + TABLECOLUMN_IDENTIFIER);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderQty.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderQty.feature
@@ -514,3 +514,59 @@ Feature: Purchase order
     And after not more than 30s, M_ReceiptSchedule are found:
       | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier    | C_OrderLine_ID.Identifier    | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.Processed | OPT.IsClosed |
       | rs_PO_close_reopen              | order_PO_rs_close_reopen | orderLine_PO_rs_close_reopen | supplier_PO              | supplierLocation_PO               | product_PO_17062022     | 10         | warehouseStd              | false         | false        |
+
+  @from:cucumber
+  @allure.label.epic:E0140_Purchasing
+  @allure.label.feature:F00600_Purchase_Order
+  @F00600
+  @Id:S0156_710
+  Scenario: Purchase order line with a material receipt: background changes pass, user edits stay blocked, QtyEntered >= QtyDelivered still enforced
+    Given metasfresh contains C_Projects:
+      | Identifier           |
+      | project_PO_receipt_1 |
+      | project_PO_receipt_2 |
+    And metasfresh contains C_Orders:
+      | Identifier       | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.DocBaseType | OPT.M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.DeliveryRule | OPT.DeliveryViaRule |
+      | order_PO_receipt | N       | supplier_PO              | 2022-06-10  | POO             | ps_PO                             | supplierLocation_PO                   | F                | S                   |
+    And metasfresh contains C_OrderLines:
+      | Identifier           | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine_PO_receipt | order_PO_receipt      | product_PO_17062022     | 10         |
+
+    And the order identified by order_PO_receipt is completed
+
+    And after not more than 30s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier |
+      | receiptSchedule_PO_receipt      | order_PO_receipt      | orderLine_PO_receipt      | supplier_PO              | supplierLocation_PO               | product_PO_17062022     | 10         | warehouseStd              |
+    And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
+      | M_HU_LUTU_Configuration_ID.Identifier | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier | OPT.M_LU_HU_PI_ID.Identifier |
+      | huLuTuConfig_PO_receipt               | hu_PO_receipt      | receiptSchedule_PO_receipt      | N               | 1     | N               | 1     | N               | 10          | huPiItemProduct_17062022           | huPackingTauschpalette       |
+    And create material receipt
+      | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | hu_PO_receipt      | receiptSchedule_PO_receipt      | inOut_PO_receipt      |
+    And validate C_OrderLine:
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
+      | orderLine_PO_receipt      | order_PO_receipt      | product_PO_17062022     | 10         | 10           | 0           | 10    | 0        | EUR          | true      |
+
+    # a background writer - e.g. the invoicing run updating the order line - must not be blocked
+    When update C_OrderLine:
+      | C_OrderLine_ID.Identifier | OPT.C_Project_ID.Identifier |
+      | orderLine_PO_receipt      | project_PO_receipt_1        |
+    Then validate C_OrderLine:
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.QtyEntered | C_Project_ID         |
+      | orderLine_PO_receipt      | order_PO_receipt      | product_PO_17062022     | 10         | 10           | 0           | 10    | 0        | EUR          | true      | 10             | project_PO_receipt_1 |
+
+    # the very same change, made by a user, stays blocked
+    When update C_OrderLine as UI action expecting error:
+      | C_OrderLine_ID.Identifier | OPT.C_Project_ID.Identifier | OPT.ErrorCode        |
+      | orderLine_PO_receipt      | project_PO_receipt_2        | ORDER_RECEIPT_EXISTS |
+    Then validate C_OrderLine:
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.QtyEntered | C_Project_ID         |
+      | orderLine_PO_receipt      | order_PO_receipt      | product_PO_17062022     | 10         | 10           | 0           | 10    | 0        | EUR          | true      | 10             | project_PO_receipt_1 |
+
+    # QtyEntered >= QtyDelivered is a data invariant, so it also applies to background writers
+    When update C_OrderLine expecting error:
+      | C_OrderLine_ID.Identifier | OPT.QtyEntered | OPT.ErrorMessage         |
+      | orderLine_PO_receipt      | 5              | Menge < Gelieferte Menge |
+    Then validate C_OrderLine:
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.QtyEntered | C_Project_ID         |
+      | orderLine_PO_receipt      | order_PO_receipt      | product_PO_17062022     | 10         | 10           | 0           | 10    | 0        | EUR          | true      | 10             | project_PO_receipt_1 |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderQty.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderQty.feature
@@ -570,3 +570,86 @@ Feature: Purchase order
     Then validate C_OrderLine:
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.QtyEntered | C_Project_ID         |
       | orderLine_PO_receipt      | order_PO_receipt      | product_PO_17062022     | 10         | 10           | 0           | 10    | 0        | EUR          | true      | 10             | project_PO_receipt_1 |
+
+  @from:cucumber
+  @allure.label.epic:E0140_Purchasing
+  @allure.label.feature:F00600_Purchase_Order
+  @F00600
+  @Id:S0156_720
+  Scenario: Receiving a fully matched purchase order line that has no ASI stamps the receipt line's ASI onto it
+  # Reproduces the production defect through the real carrier. No test-only flag, no synthetic write
+  # of the column under test - the receipt itself is what triggers it.
+  #
+  # MMatchPO.afterSave writes five order-line columns. QtyDelivered, DateDelivered, QtyInvoiced and
+  # DateInvoiced are all in assertChangeAllowed's ignoreColumnsChanged, so they cannot fire the
+  # interceptor. M_AttributeSetInstance_ID is NOT in that list, and afterSave stamps it from the
+  # receipt line when the order line has no ASI yet and the receipt fully matches
+  # (M_InOutLine.MovementQty == C_OrderLine.QtyOrdered). That stamp is the only write here that
+  # reaches the guard - and the guard's QtyDelivered==0 early return does not save it, because
+  # afterSave increments QtyDelivered on the in-memory model BEFORE saving.
+  #
+  # Three fixture conditions, all of them real production states:
+  #   1. the product has an attribute set, so the received HU - and hence the receipt line - carries
+  #      a non-zero ASI. Deliberately NOT QualityDiscountPercent: it splits the receipt into two
+  #      lines and destroys the full match the stamp depends on.
+  #   2. the ORDER LINE has no ASI. This is the condition the local stack never produces on its own
+  #      (every local order line gets an empty ASI record) while 37% of the customer's purchase order
+  #      lines have none - 573246 of 1560109 measured 2026-09-01. Cleared explicitly below; the order
+  #      line is still undelivered at that point, so the guard early-returns and the clear is safe.
+  #   3. the receipt fully matches QtyOrdered.
+  #
+  # "create material receipt" both creates and completes the receipt, so it raises the guard itself.
+  # Before the fix this scenario fails there with ORDER_RECEIPT_EXISTS.
+    Given load M_Attribute:
+      | M_Attribute_ID.Identifier | Value     |
+      | attr_ageOffset_PO         | AgeOffset |
+    And add M_AttributeSet:
+      | M_AttributeSet_ID.Identifier | Name                | MandatoryType |
+      | attributeSet_PO_asi          | attributeSet_PO_asi | N             |
+    And add M_AttributeUse:
+      | M_AttributeUse_ID.Identifier | M_AttributeSet_ID.Identifier | M_Attribute_ID.Identifier | SeqNo |
+      | attributeUse_PO_asi          | attributeSet_PO_asi          | attr_ageOffset_PO         | 10    |
+
+    And metasfresh contains M_Products:
+      | Identifier     | Value          | Name           | OPT.M_AttributeSet_ID.Identifier |
+      | product_PO_asi | product_PO_asi | product_PO_asi | attributeSet_PO_asi              |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | huPiItemProduct_PO_asi             | huPiItem_IFCO              | product_PO_asi          | 10  | 2022-03-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_PO_asi  | plv_PO                            | product_PO_asi          | 10.0     | PCE               | Normal                        |
+
+    And metasfresh contains C_Orders:
+      | Identifier   | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.DocBaseType | OPT.M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.DeliveryRule | OPT.DeliveryViaRule |
+      | order_PO_asi | N       | supplier_PO              | 2022-06-10  | POO             | ps_PO                             | supplierLocation_PO                   | F                | S                   |
+    And metasfresh contains C_OrderLines:
+      | Identifier       | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine_PO_asi | order_PO_asi          | product_PO_asi          | 10         |
+
+    And the order identified by order_PO_asi is completed
+
+    # fixture condition 2: an ASI-less purchase order line. Safe here - nothing is delivered yet, so
+    # assertChangeAllowed early-returns on QtyDelivered == 0.
+    And update C_OrderLine:
+      | C_OrderLine_ID.Identifier | OPT.M_AttributeSetInstance_ID.Identifier |
+      | orderLine_PO_asi          | null                                     |
+
+    And after not more than 30s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier |
+      | receiptSchedule_PO_asi          | order_PO_asi          | orderLine_PO_asi          | supplier_PO              | supplierLocation_PO               | product_PO_asi          | 10         | warehouseStd              |
+    And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
+      | M_HU_LUTU_Configuration_ID.Identifier | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier | OPT.M_LU_HU_PI_ID.Identifier |
+      | huLuTuConfig_PO_asi                   | hu_PO_asi          | receiptSchedule_PO_asi          | N               | 1     | N               | 1     | N               | 10          | huPiItemProduct_PO_asi             | huPackingTauschpalette       |
+    And update M_HU_Attribute recursive:
+      | M_HU_ID.Identifier | M_Attribute_ID.Identifier | OPT.ValueNumber |
+      | hu_PO_asi          | attr_ageOffset_PO         | 3               |
+
+    # the whole point: this must NOT raise ORDER_RECEIPT_EXISTS
+    When create material receipt
+      | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | hu_PO_asi          | receiptSchedule_PO_asi          | inOut_PO_asi          |
+
+    Then validate C_OrderLine:
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.QtyEntered |
+      | orderLine_PO_asi          | order_PO_asi          | product_PO_asi          | 10         | 10           | 0           | 10    | 0        | EUR          | true      | 10             |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderQty.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderQty.feature
@@ -556,9 +556,9 @@ Feature: Purchase order
       | orderLine_PO_receipt      | order_PO_receipt      | product_PO_17062022     | 10         | 10           | 0           | 10    | 0        | EUR          | true      | 10             | project_PO_receipt_1 |
 
     # the very same change, made by a user, stays blocked
-    When update C_OrderLine as UI action expecting error:
-      | C_OrderLine_ID.Identifier | OPT.C_Project_ID.Identifier | OPT.ErrorCode        |
-      | orderLine_PO_receipt      | project_PO_receipt_2        | ORDER_RECEIPT_EXISTS |
+    When update C_OrderLine expecting error:
+      | C_OrderLine_ID.Identifier | OPT.C_Project_ID.Identifier | OPT.AsUIAction | OPT.ErrorCode        |
+      | orderLine_PO_receipt      | project_PO_receipt_2        | Y              | ORDER_RECEIPT_EXISTS |
     Then validate C_OrderLine:
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.QtyEntered | C_Project_ID         |
       | orderLine_PO_receipt      | order_PO_receipt      | product_PO_17062022     | 10         | 10           | 0           | 10    | 0        | EUR          | true      | 10             | project_PO_receipt_1 |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/C_OrderLine.java
@@ -160,7 +160,9 @@ public class C_OrderLine
 		{
 			validateQtyEntered(orderLine);
 		}
-		else
+		// the lock is a policy for user edits only; background writers (e.g. the invoicing run updating
+		// the order line) must not be aborted by it
+		else if (InterfaceWrapperHelper.isUIAction(orderLine))
 		{
 			throw new AdempiereException(ERR_ORDER_MODIFICATION_NOT_ALLOWED_RECEIPT_EXISTS)
 					.markAsUserValidationError();


### PR DESCRIPTION
## What

Since this instance received the receipt-exists change lock, **goods receipts fail outright** on a
common class of purchase order line.

`de.metas.handlingunits.model.validator.C_OrderLine#assertChangeAllowed` throws
`ERR_ORDER_MODIFICATION_NOT_ALLOWED_RECEIPT_EXISTS` ("Dieser Auftrag ist aufgrund eines vorhandenen
abgeschlossenen Wareneingangs für Änderungen gesperrt") on **background** writes, not only user
edits. The exception aborts the whole receipt transaction, so nothing is persisted and the operator
gets an error instead of a goods receipt.

## Root cause

`MMatchPO.afterSave` (`MMatchPO.java:225-283`) writes exactly five `C_OrderLine` columns.
`QtyDelivered`, `DateDelivered`, `QtyInvoiced` and `DateInvoiced` are all in the guard's
`ignoreColumnsChanged`, so they cannot fire the interceptor at all. **`M_AttributeSetInstance_ID` is
not in that list** — and `afterSave` stamps it from the receipt line:

```java
if (orderLine.getM_AttributeSetInstance_ID() == 0 && getM_InOutLine_ID() > 0)
    if (iol.getMovementQty().compareTo(orderLine.getQtyOrdered()) == 0)   // full match
        orderLine.setM_AttributeSetInstance_ID(iol.getM_AttributeSetInstance_ID());
InterfaceWrapperHelper.save(orderLine);
```

So the ASI stamp is the only write on that path that can reach the guard. The guard's
`QtyDelivered.signum() == 0` early return does not protect it either: `afterSave` increments
`QtyDelivered` on the in-memory model **before** saving, so the early return never triggers — not
even on a first receipt. `QtyEntered` and `C_UOM_ID` are untouched, so control falls to the `else`
and throws.

The write being refused is metasfresh stamping **its own** attribute set instance as part of
matching. It was never a user modification of the order, so a user-edit policy should never have
applied to it.

## Evidence

Measured on the customer instance:

- **218 occurrences, 2026-05-31 .. 2026-09-01, none of them from the WebUI.** Every one is a
  background carrier: goods-receipt creation (`InOutProducer.processReceipt` -> `MatchPOBL.create` ->
  `MMatchPO.afterSave`, 166x), the Create Invoices work package (`InvoiceCandWorkpackageProcessor` ->
  `MInvoice.completeIt` -> `MatchPOBL.create`, ~46x), `ReceiptScheduleBL.close` -> `OrderBL.closeLine`
  (19x), the invoice-candidate revalidation work package (2x) and `ReceiptScheduleBL.reopen` (1x).
- **Successful ASI stamps went from ~970/month to exactly zero** the month the guard went live there
  (2026-05-31), while overall receipt volume *rose* over the same period. Not a volume artefact — the
  stamp simply stopped succeeding.
- **37% of purchase order lines have no ASI** (573 246 of 1 560 109), so the exposed population is
  large. The 218 persisted issues are the visible tip, not the total: only some carriers write one.

## Change

`else` becomes `else if (InterfaceWrapperHelper.isUIAction(orderLine))`, so only user edits are
blocked. This mirrors the sibling guard
`de.metas.inoutcandidate.modelvalidator.C_Order#assertChangeAllowed`, gated on `isUIAction` since it
was introduced.

Deliberately **not** an early return at the top of the method: that would also skip
`validateQtyEntered`, dropping the `QtyEntered >= QtyDelivered` **data invariant** for background
writes. Only the policy becomes user-scoped; the invariant keeps applying to every writer.

Considered and rejected: adding `M_AttributeSetInstance_ID` to `ignoreColumnsChanged`. It fixes this
path, but it would also let a **user** re-stamp the ASI on a received line — which is exactly what
the lock exists to prevent. The UI-action gate keeps that blocked.

## Trade-off

Gating on `isUIAction` removes the fail-fast net for *every* non-UI writer, not only this one. A
future background defect that mutates `C_BPartner_ID`, `M_Product_ID`, `M_HU_PI_Item_Product_ID` or
`C_Project_ID` on a delivered PO line would now succeed silently instead of throwing. Accepted
because the sibling `C_Order` guard has run this way without incident, and because the
`QtyEntered >= QtyDelivered` invariant is kept outside the gate and still applies to every writer.

## Test

`@Id:S0156_720` in `purchaseOrderQty.feature` reproduces the defect **through the real carrier** — a
genuine goods receipt, no test-only flag and no direct write of the column under test. Verified RED
on the unfixed code (fails at `create material receipt` with the German ORDER_RECEIPT_EXISTS message
thrown from `assertChangeAllowed`) and GREEN with the fix.

Three fixture conditions, all real production states:

1. the product carries an attribute set, so the received HU — and therefore the receipt line — has a
   non-zero ASI. Deliberately not `QualityDiscountPercent`, which splits the receipt into two lines
   and destroys the full match the stamp depends on;
2. the **order line has no ASI**. Every order line created on a local stack gets an empty ASI record,
   against 37% ASI-less at the customer — that mismatch, not the attribute wiring, is why an earlier
   attempt at this scenario passed on unfixed code;
3. the receipt fully matches `QtyOrdered`.

`@Id:S0156_710` is kept alongside it. It exercises the predicate directly — a background write
passes, the same write as a UI action is still blocked, and `QtyEntered < QtyDelivered` still throws
for background writers — which is the half `S0156_720` does not cover. Supporting step-def change:
`update C_OrderLine expecting error:` takes an optional `AsUIAction` column that flags the record via
`InterfaceWrapperHelperUtils.set_ManualUserAction`, the same thing the WebUI's `DefaultSaveHandler`
does before saving an edited record.
