### PR TITLE
Invoice candidates: save the reopened candidate through the DAO

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -2276,7 +2276,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 		}
 
 		invoiceCandDAO.invalidateCand(candidate);
-		InterfaceWrapperHelper.save(candidate);
+		invoiceCandDAO.save(candidate);
 	}
 
 	@Override


### PR DESCRIPTION
## What

Propagating `soft_panda_hotfix` up to `new_dawn_uat`
(https://github.com/metasfresh/metasfresh/pull/25684) fails `test (java)` on an ArchUnit rule:

```
[de.metas.swat.base] InterfaceWrapperHelper.save/saveRecord/load
must only be called from *Repository / *DAO classes
```

The violation is `InvoiceCandBL.openInvoiceCandidate`, added by
https://github.com/metasfresh/metasfresh/pull/25673. The sibling `closeInvoiceCandidate` makes the
identical call but predates the rule and is frozen into the baseline
(`archunit_store`, `InvoiceCandBL.java:2332`), so only the new method fails.

It is invisible on `soft_panda_hotfix` because the architecture tests exist **only** on
`new_dawn_uat` (416 files vs 0). Fixing it here, at the source branch, rather than on the merge
branch — otherwise `soft_panda_hotfix` keeps the violation and every future merge up re-introduces
it.

## Change

One line: `InterfaceWrapperHelper.save(candidate)` -> `invoiceCandDAO.save(candidate)`, the path six
other call sites in this class already use.

**Not byte-identical, deliberately.** `InvoiceCandDAO.save` rethrows only for a candidate that is not
yet persisted; for an already-persisted one — always the case here, since these are retrieved by
order line id — it flags the error on the candidate and stores the message instead of throwing.
That is the intended behaviour for this flow, whose whole purpose is to make invoicing failures
visible on the record rather than swallow them.

## Test

The covering test is the architecture rule itself, which lives on the target branch. Verified
locally against the merge worktree that `closeInvoiceCandidate` is in the freeze baseline and
`openInvoiceCandidate` is not — i.e. a genuine new violation, not a stale baseline.

Local validation on this branch: `de.metas.swat/de.metas.swat.base` unfiltered unit suite —
426 tests, 0 failures, 0 errors, 9 skipped.
