### PR TITLE
CI: keep the e2e stack log reachable when a Playwright job is cancelled

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1872,20 +1872,10 @@ jobs:
           mfregistry: metasfresh
           dbqualifier: preloaded
         run: |
-          docker compose --profile mobile logs --timestamps db rabbitmq search app wiremock mobile > infra.log 2>&1 || true
+          timeout 120 docker compose --profile mobile logs --timestamps db rabbitmq search app wiremock mobile > infra.log 2>&1 || true
       - name: commit post-test db image
         run: |
           docker commit e2e-tests-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postmobiletest
-      # `if: always()` so a cancelled job still frees the runner's containers.
-      - name: stop stack
-        if: always()
-        working-directory: docker-builds/e2e-tests/
-        env:
-          mfversion: ${{ needs.init.outputs.tag-fixed }}
-          mfregistry: metasfresh
-          dbqualifier: preloaded
-        run: |
-          docker compose --profile mobile down
       # ===== ALLURE REPORT GENERATION =====
       - name: Generate Allure Report for Mobile
         uses: ./.github/actions/generate-allure-report
@@ -1951,6 +1941,19 @@ jobs:
           path: docker-builds/e2e-tests/playwright-report-mobile/junit/results.xml
           if-no-files-found: ignore
           retention-days: 30
+      # Deliberately the LAST step of the job. `if: always()` so a cancelled job still frees
+      # the runner's containers - but on a cancelled job every `always()` step shares one
+      # 5-minute cancellation window, and an unresponsive container is exactly what makes
+      # teardown slow, so the evidence uploads must get that window first.
+      - name: stop stack
+        if: always()
+        working-directory: docker-builds/e2e-tests/
+        env:
+          mfversion: ${{ needs.init.outputs.tag-fixed }}
+          mfregistry: metasfresh
+          dbqualifier: preloaded
+        run: |
+          docker compose --profile mobile down
       # Allure reports uploaded by publish-test-reports job
 
   frontend_webui_test:
@@ -2009,20 +2012,10 @@ jobs:
           mfregistry: metasfresh
           dbqualifier: preloaded
         run: |
-          docker compose --profile frontend logs --timestamps db rabbitmq search app wiremock webapi webui > infra.log 2>&1 || true
+          timeout 120 docker compose --profile frontend logs --timestamps db rabbitmq search app wiremock webapi webui > infra.log 2>&1 || true
       - name: commit post-test db image
         run: |
           docker commit e2e-tests-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postfrontendtest-${{ matrix.shard_label }}
-      # `if: always()` so a cancelled job still frees the runner's containers.
-      - name: stop stack
-        if: always()
-        working-directory: docker-builds/e2e-tests/
-        env:
-          mfversion: ${{ needs.init.outputs.tag-fixed }}
-          mfregistry: metasfresh
-          dbqualifier: preloaded
-        run: |
-          docker compose --profile frontend down
       - name: Upload Allure results
         uses: actions/upload-artifact@v6
         if: always()
@@ -2071,6 +2064,19 @@ jobs:
           path: docker-builds/e2e-tests/playwright-report-frontend/junit/results.xml
           if-no-files-found: ignore
           retention-days: 30
+      # Deliberately the LAST step of the job. `if: always()` so a cancelled job still frees
+      # the runner's containers - but on a cancelled job every `always()` step shares one
+      # 5-minute cancellation window, and an unresponsive container is exactly what makes
+      # teardown slow, so the evidence uploads must get that window first.
+      - name: stop stack
+        if: always()
+        working-directory: docker-builds/e2e-tests/
+        env:
+          mfversion: ${{ needs.init.outputs.tag-fixed }}
+          mfregistry: metasfresh
+          dbqualifier: preloaded
+        run: |
+          docker compose --profile frontend down
 
   # =============================================================================
   # Merge Frontend Playwright Allure Results from Sharded Runners

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1854,9 +1854,37 @@ jobs:
         run: |
           # Start stack and attach only to playwright container for clean logs
           docker compose --profile mobile up --attach playwright-mobile --abort-on-container-exit --exit-code-from playwright-mobile 2>&1 | tee playwright.log && echo "${PIPESTATUS[0]}" > playwright.exit-code
-          # Capture infrastructure logs separately for debugging
-          docker compose --profile mobile logs --no-log-prefix db rabbitmq search app mobile > infra.log 2>&1 || true
+      # Own step with `if: always()`: when `run test` is cancelled at the job-level
+      # `timeout-minutes`, only `always()` steps still run, so a capture chained behind the
+      # blocking `docker compose up` inside `run test` was unreachable in exactly the case
+      # that needs it - a stack container going unresponsive mid-suite, every remaining test
+      # burning its full timeout, and the job killed at the cap. `!cancelled()` cannot be
+      # used here: it is false on a cancelled job, which is the case being captured.
+      # `wiremock` is included (no `profiles:` key, so it starts in both profiles); the
+      # playwright container is not - its stdout is already `playwright.log`. Service
+      # prefixes are kept and `--timestamps` added so that a merged multi-service log stays
+      # attributable and correlatable with the test-side failure times.
+      - name: capture stack logs
+        if: always()
+        working-directory: docker-builds/e2e-tests/
+        env:
+          mfversion: ${{ needs.init.outputs.tag-fixed }}
+          mfregistry: metasfresh
+          dbqualifier: preloaded
+        run: |
+          docker compose --profile mobile logs --timestamps db rabbitmq search app wiremock mobile > infra.log 2>&1 || true
+      - name: commit post-test db image
+        run: |
           docker commit e2e-tests-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postmobiletest
+      # `if: always()` so a cancelled job still frees the runner's containers.
+      - name: stop stack
+        if: always()
+        working-directory: docker-builds/e2e-tests/
+        env:
+          mfversion: ${{ needs.init.outputs.tag-fixed }}
+          mfregistry: metasfresh
+          dbqualifier: preloaded
+        run: |
           docker compose --profile mobile down
       # ===== ALLURE REPORT GENERATION =====
       - name: Generate Allure Report for Mobile
@@ -1898,14 +1926,22 @@ jobs:
         working-directory: docker-builds/e2e-tests/
         run: |
           if [ $(cat playwright.exit-code) != 0 ]; then tail -1000 playwright.log && exit 1; fi
+      # `always()`, not `success() || failure()`: `failure()` is false on a job that
+      # concluded `cancelled` (job-level timeout), so the old guard skipped this upload
+      # precisely when `infra.log` was the only remaining evidence. Upload the artifact
+      # even on success too, because it can contain valuable information about how to
+      # improve, optimize etc.
       - uses: actions/upload-artifact@v6
-        if: success() || failure() # upload the artifact even if is success because that artifact can contain valuable information about how to improve, optimize etc
+        if: always()
         with:
           name: playwright-mobile-report
           path: |
             docker-builds/e2e-tests/playwright-report-mobile/
             docker-builds/e2e-tests/test-results-mobile/
             docker-builds/e2e-tests/infra.log
+          # a cancelled run may not have flushed the playwright report; a missing path
+          # must warn, never fail the step
+          if-no-files-found: warn
           retention-days: 30
       - name: Upload Playwright Mobile JUnit results
         uses: actions/upload-artifact@v6
@@ -1955,9 +1991,37 @@ jobs:
         run: |
           # Start stack and attach only to playwright container for clean logs
           docker compose --profile frontend up --attach playwright-frontend --abort-on-container-exit --exit-code-from playwright-frontend 2>&1 | tee playwright.log && echo "${PIPESTATUS[0]}" > playwright.exit-code
-          # Capture infrastructure logs separately for debugging
-          docker compose --profile frontend logs --no-log-prefix db rabbitmq search app webapi webui > infra.log 2>&1 || true
+      # Own step with `if: always()`: when `run test` is cancelled at the job-level
+      # `timeout-minutes`, only `always()` steps still run, so a capture chained behind the
+      # blocking `docker compose up` inside `run test` was unreachable in exactly the case
+      # that needs it - a stack container going unresponsive mid-suite, every remaining test
+      # burning its full timeout, and the job killed at the cap. `!cancelled()` cannot be
+      # used here: it is false on a cancelled job, which is the case being captured.
+      # `wiremock` is included (no `profiles:` key, so it starts in both profiles); the
+      # playwright container is not - its stdout is already `playwright.log`. Service
+      # prefixes are kept and `--timestamps` added so that a merged multi-service log stays
+      # attributable and correlatable with the test-side failure times.
+      - name: capture stack logs
+        if: always()
+        working-directory: docker-builds/e2e-tests/
+        env:
+          mfversion: ${{ needs.init.outputs.tag-fixed }}
+          mfregistry: metasfresh
+          dbqualifier: preloaded
+        run: |
+          docker compose --profile frontend logs --timestamps db rabbitmq search app wiremock webapi webui > infra.log 2>&1 || true
+      - name: commit post-test db image
+        run: |
           docker commit e2e-tests-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postfrontendtest-${{ matrix.shard_label }}
+      # `if: always()` so a cancelled job still frees the runner's containers.
+      - name: stop stack
+        if: always()
+        working-directory: docker-builds/e2e-tests/
+        env:
+          mfversion: ${{ needs.init.outputs.tag-fixed }}
+          mfregistry: metasfresh
+          dbqualifier: preloaded
+        run: |
           docker compose --profile frontend down
       - name: Upload Allure results
         uses: actions/upload-artifact@v6
@@ -1984,14 +2048,20 @@ jobs:
         working-directory: docker-builds/e2e-tests/
         run: |
           if [ $(cat playwright.exit-code) != 0 ]; then tail -1000 playwright.log && exit 1; fi
+      # `always()`, not `success() || failure()`: `failure()` is false on a job that
+      # concluded `cancelled` (job-level timeout), so the old guard skipped this upload
+      # precisely when `infra.log` was the only remaining evidence.
       - uses: actions/upload-artifact@v6
-        if: success() || failure()
+        if: always()
         with:
           name: playwright-frontend-report-${{ matrix.shard_label }}
           path: |
             docker-builds/e2e-tests/playwright-report-frontend/
             docker-builds/e2e-tests/test-results-frontend/
             docker-builds/e2e-tests/infra.log
+          # a cancelled run may not have flushed the playwright report; a missing path
+          # must warn, never fail the step
+          if-no-files-found: warn
           retention-days: 30
       - name: Upload Playwright Frontend JUnit results
         uses: actions/upload-artifact@v6

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1876,6 +1876,19 @@ jobs:
       - name: commit post-test db image
         run: |
           docker commit e2e-tests-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postmobiletest
+      # `!cancelled()` - i.e. success or failure, but NOT a cancellation. On those paths the
+      # stack is torn down as early as it was before this was a separate step, so the runner
+      # does not hold ~7 idle containers through report generation, the image push and the
+      # artifact uploads (and x3 for the parallel frontend shards).
+      - name: stop stack
+        if: ${{ !cancelled() }}
+        working-directory: docker-builds/e2e-tests/
+        env:
+          mfversion: ${{ needs.init.outputs.tag-fixed }}
+          mfregistry: metasfresh
+          dbqualifier: preloaded
+        run: |
+          docker compose --profile mobile down
       # ===== ALLURE REPORT GENERATION =====
       - name: Generate Allure Report for Mobile
         uses: ./.github/actions/generate-allure-report
@@ -1941,12 +1954,12 @@ jobs:
           path: docker-builds/e2e-tests/playwright-report-mobile/junit/results.xml
           if-no-files-found: ignore
           retention-days: 30
-      # Deliberately the LAST step of the job. `if: always()` so a cancelled job still frees
-      # the runner's containers - but on a cancelled job every `always()` step shares one
-      # 5-minute cancellation window, and an unresponsive container is exactly what makes
-      # teardown slow, so the evidence uploads must get that window first.
-      - name: stop stack
-        if: always()
+      # The cancellation counterpart of `stop stack`, deliberately the LAST step: on a
+      # cancelled job every conditional step shares one 5-minute cancellation window, and an
+      # unresponsive container is exactly what makes `docker compose down` slow, so teardown
+      # must not run ahead of the evidence uploads it exists to protect.
+      - name: stop stack after cancellation
+        if: ${{ cancelled() }}
         working-directory: docker-builds/e2e-tests/
         env:
           mfversion: ${{ needs.init.outputs.tag-fixed }}
@@ -2016,6 +2029,19 @@ jobs:
       - name: commit post-test db image
         run: |
           docker commit e2e-tests-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postfrontendtest-${{ matrix.shard_label }}
+      # `!cancelled()` - i.e. success or failure, but NOT a cancellation. On those paths the
+      # stack is torn down as early as it was before this was a separate step, so the runner
+      # does not hold ~7 idle containers through report generation, the image push and the
+      # artifact uploads (and x3 for the parallel frontend shards).
+      - name: stop stack
+        if: ${{ !cancelled() }}
+        working-directory: docker-builds/e2e-tests/
+        env:
+          mfversion: ${{ needs.init.outputs.tag-fixed }}
+          mfregistry: metasfresh
+          dbqualifier: preloaded
+        run: |
+          docker compose --profile frontend down
       - name: Upload Allure results
         uses: actions/upload-artifact@v6
         if: always()
@@ -2064,12 +2090,12 @@ jobs:
           path: docker-builds/e2e-tests/playwright-report-frontend/junit/results.xml
           if-no-files-found: ignore
           retention-days: 30
-      # Deliberately the LAST step of the job. `if: always()` so a cancelled job still frees
-      # the runner's containers - but on a cancelled job every `always()` step shares one
-      # 5-minute cancellation window, and an unresponsive container is exactly what makes
-      # teardown slow, so the evidence uploads must get that window first.
-      - name: stop stack
-        if: always()
+      # The cancellation counterpart of `stop stack`, deliberately the LAST step: on a
+      # cancelled job every conditional step shares one 5-minute cancellation window, and an
+      # unresponsive container is exactly what makes `docker compose down` slow, so teardown
+      # must not run ahead of the evidence uploads it exists to protect.
+      - name: stop stack after cancellation
+        if: ${{ cancelled() }}
         working-directory: docker-builds/e2e-tests/
         env:
           mfversion: ${{ needs.init.outputs.tag-fixed }}


### PR DESCRIPTION
## Failure mode

Both Playwright E2E jobs carry a job-level `timeout-minutes: 60` — `frontend_webui_test` (`.github/workflows/cicd.yaml:1922`) and `mobile_test` (`:1834`). When a container in the e2e stack goes unresponsive mid-suite, the suite does not fail fast: every remaining test burns its full per-test cap (300 s) times its retries until the job clock runs out. GitHub then kills the job, so its conclusion is **`cancelled`**, not `failed` — and `assert success` never runs.

That is precisely the failure for which the stack's own `infra.log` is the only remaining evidence, and it was the one conclusion under which the log could not be recovered.

## The two independent reasons the log was unreachable

1. **The capture was chained inside the cancelled step.** `docker compose … logs … > infra.log` sat *after* the blocking `docker compose … up` in the same `run test` step. That step is what gets cancelled at the cap, so the capture never executed and `infra.log` was never written.
2. **The upload guard does not fire on `cancelled`.** The artifact carrying `infra.log` was uploaded `if: success() || failure()`. Per the https://docs.github.com/en/actions/reference/workflows-and-actions/expressions, `failure()` "returns `true` when any previous step of a job fails" — a job that concluded `cancelled` satisfies neither `success()` nor `failure()`, so the upload was skipped.

Net effect: exactly when the backend log was needed, nothing was produced and nothing was uploaded.

## Evidence

Run https://github.com/metasfresh/metasfresh/actions/runs/33524223343, **attempt 1**, job `frontend webui test (3/3)` at https://github.com/metasfresh/metasfresh/actions/runs/33524223343/job/99918067052 — job conclusion `cancelled`. (Attempt 2 re-ran that job and it passed, so the run's *current* artifact list also carries attempt-2 copies; everything below is attempt 1, identified by artifact `created_at`.)

Confirmed via: `gh api "repos/metasfresh/metasfresh/actions/runs/33524223343/attempts/1/jobs?per_page=100" --jq '.jobs[]|select(.name|contains("3/3"))|{conclusion,steps:[.steps[]|{name,conclusion,started:.started_at,completed:.completed_at}]}'`

| step | conclusion | window (UTC) |
|---|---|---|
| `run test` | **cancelled** | 15:33:11 → 16:33:21 = 60 m 10 s vs `timeout-minutes: 60` |
| `Upload Allure results` (`if: always()`) | success | 16:33:21 → 16:33:26 |
| `push-image` | **skipped** | — |
| `produce-summary` | **skipped** | — |
| `assert success` | **skipped** | — |
| `upload-artifact` (playwright report + `infra.log`) | **skipped** | — |
| `Upload Playwright Frontend JUnit results` (`if: always()`) | success | 16:33:26 → 16:33:26 |

The root cause was recoverable only from the allure artifact — **9 × `Error: HTTP 504: Gateway Time-out`** between 15:43:52 and 16:32:21, all `Failed to fetch record data for window 143` (thrown at `e2e/frontend-webui/tests/utils/WebAPIValidation.js:57`, logged at `:66`): the `webapi` container stopped answering ~3 min into the suite and never recovered, so later tests burned their full 300 s × 3 attempts (`purchase-sales-overview.spec.js:82` alone consumed ~32 min) until the job clock ran out.

Two things the step table above pins down:

* **Reason 2, directly.** The report `upload-artifact` step — the only one that carries `infra.log` — is `skipped` on a `cancelled` job, while the two sibling upload steps guarded `if: always()` both ran. Attempt 1 accordingly produced **no** `playwright-frontend-report-shard3`; the only copy of that artifact on the run was created at 17:06:12, i.e. by attempt 2. Confirmed via: `gh api "repos/metasfresh/metasfresh/actions/runs/33524223343/artifacts?per_page=100" --jq '.artifacts[]|select(.name|test("shard"))|{name,created_at}'` — attempt 1's shard-3 output is a single `allure-results-frontend-shard3` at 16:33:27; `playwright-frontend-report-shard3` (17:06:12) and `junit-results-playwright-frontend-shard3` (17:06:14) exist only as attempt-2 copies, whereas shard 1 and shard 2 (which were not cancelled) each have all three from attempt 1.
* **A missing file is already tolerated by the sibling step, and that is the behaviour the report upload needs too.** Attempt 1's `Upload Playwright Frontend JUnit results` (`if: always()`) concluded `success` yet produced no artifact — it carries `if-no-files-found: ignore` and the cancelled run never wrote a junit file. The report upload had no such setting, which is why this change adds `if-no-files-found: warn` to it.

Nothing in the surviving evidence discriminates between connection-pool exhaustion, a locked DB statement, GC/OOM pressure or a thread-pool stall — which is what `infra.log` would have settled.

## Fix

CI-config only. No test, spec or production code touched; no timeout value changed.

* **`run test` now only runs `docker compose … up`.** The three commands that were chained behind it are split out:
  * **`capture stack logs`** — `if: always()`, so it runs inside the runner's cancellation window when `run test` is cancelled.
  * **`commit post-test db image`** — left on the implicit `success()` default, since a db image committed mid-suite has no value (and `push-image` is success-gated anyway).
  * **`stop stack` / `stop stack after cancellation`** — the teardown, split into two steps running the identical command, because the right *position* for it differs by conclusion. The two guards are complementary at each step's own evaluation instant, and jointly exhaustive: `cancelled()` is monotonic and the cancellation branch is unconditionally the last step, so the stack is torn down on every conclusion. They are *not* exclusive across the whole job timeline — if a cancellation lands after the early teardown already ran (e.g. during the retrying image push), the late one is re-evaluated and runs too. That costs a second `docker compose down` on an already-torn-down project, which is an idempotent no-op, so no extra guard is warranted: a guard whose only prevented outcome is a no-op would be cargo cult. `if: ${{ !cancelled() }}` (success or failure) sits right after the `docker commit`, i.e. as early as it ran before, so the runner never holds the stack's ~7 idle containers through report generation, the retrying image push and both uploads — times three for the parallel frontend shards. `if: ${{ cancelled() }}` is the **last step of the job**, because on a cancelled job every conditional step shares one 5-minute cancellation window, an unresponsive container is precisely what makes `docker compose down` slow (10 s SIGTERM grace per container by default), and teardown ahead of the uploads would starve the very evidence it exists to protect. The `${{ }}` wrapper is required on `!cancelled()` — a bare `!` starts a YAML tag. As a side benefit the stack is now also torn down when `run test` *itself* fails, which the original single inline script did not do (`set -e` aborted before reaching `down`).
* **The capture is time-bounded**: `timeout 120 docker compose … logs …`. The pre-existing `|| true` covers `timeout`'s exit 124, so a stalled `docker compose logs` truncates `infra.log` rather than consuming the cancellation window or failing the step.
* **The report artifact upload is now `if: always()`**, plus an explicit `if-no-files-found: warn` so a playwright report the cancelled run never flushed cannot turn the step red. Artifact names are unchanged and remain unique per job/shard, so a cancelled job's upload cannot collide with anything.
* **`always()` is required here, not the documented `!cancelled()` alternative.** The expressions reference (URL above) recommends `!cancelled()` over `always()` for tasks that could hang — but `!cancelled()` is false on a cancelled job, i.e. false in exactly the case this change exists to capture. The always-steps are bounded (`docker compose logs`, `docker compose down`), so the hang concern behind that recommendation does not apply.
* **The captured service list is now derived from the compose profile instead of hand-picked**: every service the profile starts, minus the playwright container (whose stdout is already `playwright.log`, and duplicating it would be tens of MB). Concretely that adds the previously-missing **`wiremock`** to both profiles — it has no `profiles:` key in `docker-builds/e2e-tests/compose.yml`, so it starts in every profile, and it is a `depends_on` of `app` and of `playwright-mobile`; if it stalls, requests through it hang, which is the same signature class. Nothing else was missing.
* **`--no-log-prefix` dropped and `--timestamps` added.** The file merges 6–7 services into one stream, so without the prefix no line says which container it came from; the timestamps are what let a container's death be correlated with the test-side failure times (the whole difficulty in the run above). Nothing parses `infra.log` — it is a human-read artifact only.

Both jobs had the identical defect and both are fixed. `health_check` also captures container logs, but it has no job-level `timeout-minutes` and already captures in separate steps, so this failure mode does not apply there and it is untouched.

## Verification

* Verified: `actionlint -shellcheck= -pyflakes= .github/workflows/cicd.yaml` (actionlint 1.7.12) run against this branch and against `origin/soft_panda_hotfix`, output diffed — identical, one line each, the same pre-existing `base-version-matrix` expression warning at `:30`. Zero new findings, and the file parses.
* Verified: asserted structurally against the parsed workflow and `docker-builds/e2e-tests/compose.yml` (a `yaml.safe_load` of both, then explicit assertions — all 14 per job passed): order is `run test` → `capture stack logs` → `commit post-test db image` → `stop stack`, with `stop stack after cancellation` last, in both jobs; `capture stack logs` is `always()`-guarded, the two teardowns carry exactly `${{ !cancelled() }}` and `${{ cancelled() }}` and run the identical command; every `upload-artifact` guard is `always()` and every one of them runs **before** the cancellation teardown; the captured service set equals each profile's service set minus its playwright container; the capture is bounded by `timeout 120` and still cannot fail its step; the report upload carries `infra.log` and `if-no-files-found: warn`; artifact names are unique within each job; `timeout-minutes` is unchanged at 60 in both.
* Verified locally with the real `docker compose` CLI, not only by parsing YAML: `docker compose --profile frontend|mobile config --services` returns exactly `app db playwright-frontend rabbitmq search webapi webui wiremock` and `app db mobile playwright-mobile rabbitmq search wiremock`, and the two capture commands were executed verbatim (`timeout 120 docker compose --profile … logs --timestamps <services>`) — both exit 0 with every service name resolving. Negative control: substituting a bogus service name makes the same command fail with `no such service`, so the CLI really does validate the list and a typo would not have passed silently.
* Verified that `if-no-files-found: warn` is `actions/upload-artifact`'s documented default ("Output a warning but do not fail the action"), so that line is behaviourally a no-op — it pins the intent in the diff rather than relying on the default.
* Verified against the documentation, not asserted from memory: https://docs.github.com/en/actions/reference/workflows-and-actions/expressions — `always()` "causes the step to always execute, and returns `true`, even when canceled", `failure()` "returns `true` when any previous step of a job fails", and "a default status check of `success()` is applied unless you include one of these functions"; https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-cancellation — a step whose condition evaluates true (`if: always()`) "will not get canceled", and "after the 5 minute cancellation timeout period, the server will forcibly terminate all jobs and steps marked for cancellation that are still running".
* Verified that the 5-minute cancellation window is workable in practice, not merely reasoned: on the cancelled attempt above, the pre-existing `Upload Allure results` step (`if: always()`, an `actions/upload-artifact` call) uploaded 107 MB and **completed successfully in 5 s** — 16:33:21 → 16:33:26, immediately after `run test` was cancelled — and the sibling always-guarded junit upload also ran. The two new steps (`docker compose logs`, `docker compose down`) are cheaper than that upload.
* Verified that the previous behaviour was cancellation-specific and not also broken on ordinary test failures: the default shell for a `run` step is `bash -e {0}` — `pipefail` belongs only to an explicit `shell: bash` (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax) — so `docker compose up … | tee` returned `tee`'s status 0, the `&&` never short-circuited and `set -e` never aborted the script. Empirically: run https://github.com/metasfresh/metasfresh/actions/runs/33533466906 has `frontend webui test (1/3)` = `failure` and its `playwright-frontend-report-shard1` artifact is present, i.e. the old chained capture did run on a plain failure. Only the `cancelled` path was affected.
* **NOT verified — stated as a limitation:** the end-to-end behaviour of a cancelled job on this workflow. This change only becomes observable when a Playwright job is actually cancelled by its timeout, which cannot be forced without deliberately breaking a run. Nor is it proven that the `always()` steps fit the 5-minute window against a genuinely unresponsive container — that is what the `timeout 120` bound and the teardown-last ordering are designed to make robust, and the first real occurrence after this merges is what will confirm it. What CI does prove on this PR is the complementary half — the green path is unaffected: if the split steps had broken `docker compose logs` / `docker commit` / `docker compose down`, or if the `always()` upload could fail on a missing file, both Playwright jobs would go red here.

## Out of scope, deliberately

The frontend Playwright container already receives `CI=true` (`docker-builds/e2e-tests/compose.yml:178`, set unconditionally), and `e2e/frontend-webui/playwright.config.js:9` is `retries: process.env.CI ? 2 : 0` — so the frontend suite already retries twice in CI.

Only the `playwright-mobile` service has no `CI=` entry, so with the identical expression at `e2e/mobile-webui/playwright.config.js:15` the mobile suite is the one that runs with `retries: 0`.

Changing the mobile side is deliberately out of scope here and needs its own decision: enabling retries trades flake noise for masked regressions — a test that self-heals on retry is reported `flaky`, not `failed`, and nothing currently watches that count.
