### PR TITLE
MobileUI job start — a pushed launchers snapshot can no longer delete a workflow process

### DIFF
--- a/e2e/mobile-webui/tests/harness/jobStartRecovery.test.js
+++ b/e2e/mobile-webui/tests/harness/jobStartRecovery.test.js
@@ -1,0 +1,88 @@
+import { test } from '../../playwright.config';
+import { expect } from '@playwright/test';
+import { setCurrentPage } from '../utils/common';
+import { recoverToLauncherList } from '../utils/screens/jobStartRecovery';
+
+/**
+ * The recovery DECISION, driven against a scripted fake page, with no browser.
+ *
+ * A job start does not normally land on the applications menu, so a real E2E run never exercises the
+ * recovery branch. This is the only test that runs the recovery decision across all of its outcomes.
+ *
+ * How it can be browserless: tests/utils/common.js exports setCurrentPage(currentPage), which assigns
+ * the module-level `page` every screen helper reads. A test that does NOT destructure the `page`
+ * fixture never launches a browser, so it can install a fake and drive the helper against it.
+ *
+ * NEVER declare `{ page }` in a test signature in this file — that pulls in the real browser fixture
+ * (playwright.config.js's `page` override calls setCurrentPage(realPage)) and overwrites the fake.
+ *
+ * Scope note: this targets `recoverToLauncherList` rather than `tapLauncherUntilJobScreen`, because
+ * that one cannot be driven with a fake page at all — `resolveLauncherTapTarget` calls
+ * `expect(locator).toHaveCount(1)`, and Playwright's `expect` only accepts a real Locator. That is
+ * exactly why the recovery decision lives in its own module with no `expect` in it.
+ */
+
+// Which selectors are currently attached to the fake DOM.
+let attached = {};
+// Selector -> the attachment changes a tap on it causes (the navigation it triggers).
+let afterTap = {};
+// Every selector tapped, in order.
+let tapped = [];
+
+const fakePage = {
+    locator: (selector) => ({
+        waitFor: async () => {
+            if (!attached[selector]) {
+                throw new Error(`fakePage: ${selector} is not attached`);
+            }
+        },
+        tap: async () => {
+            tapped.push(selector);
+            Object.assign(attached, afterTap[selector] ?? {});
+        },
+    }),
+};
+
+test.beforeEach(() => {
+    attached = {};
+    afterTap = {};
+    tapped = [];
+    setCurrentPage(fakePage);
+});
+
+test('recoverToLauncherList: already back on the launcher list -> launcherList, no tap', async () => {
+    attached['#WFLaunchersScreen'] = true;
+
+    const outcome = await recoverToLauncherList({ applicationId: 'picking' });
+
+    expect(outcome).toBe('launcherList');
+    expect(tapped).toEqual([]);
+});
+
+test('recoverToLauncherList: landed on the applications menu and re-entry succeeds -> recovered', async () => {
+    attached['#ApplicationsListScreen'] = true;
+    afterTap['#picking-button'] = { '#WFLaunchersScreen': true };
+
+    const outcome = await recoverToLauncherList({ applicationId: 'picking' });
+
+    expect(outcome).toBe('recovered');
+    expect(tapped).toEqual(['#picking-button']);
+});
+
+test('recoverToLauncherList: neither screen attached (a navigation still in flight) -> unknown, no tap', async () => {
+    const outcome = await recoverToLauncherList({ applicationId: 'picking' });
+
+    expect(outcome).toBe('unknown');
+    expect(tapped).toEqual([]);
+});
+
+// This case matters most: a broken re-entry must never authorise a re-tap of the launcher, which
+// could double-start the workflow.
+test('recoverToLauncherList: menu attached but re-entry does not bring up the list -> unknown', async () => {
+    attached['#ApplicationsListScreen'] = true;
+
+    const outcome = await recoverToLauncherList({ applicationId: 'picking' });
+
+    expect(outcome).toBe('unknown');
+    expect(tapped).toEqual(['#picking-button']);
+});

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
@@ -7,10 +7,15 @@ import { expect } from '@playwright/test';
 import { expectClasses } from '../../expectations';
 import { DistributionJobsDropAllScreen } from './DistributionJobsDropAllScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
+import { JOB_START_ARRIVAL_TIMEOUT, JOB_START_TAP_ATTEMPTS, recoverToLauncherList } from '../jobStartRecovery';
 
 const NAME = 'DistributionJobsListScreen';
 /** @returns {import('@playwright/test').Locator} */
 const containerElement = () => page.locator('#WFLaunchersScreen');
+// The job (workflow-process) screen reached after starting a launcher. This id mirrors the private
+// containerElement in DistributionJobScreen.js — keep the two in sync if that screen id changes.
+/** @returns {import('@playwright/test').Locator} */
+const jobScreenElement = () => page.locator('#WFProcessScreen');
 
 export const DistributionJobsListScreen = {
     waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
@@ -42,7 +47,18 @@ export const DistributionJobsListScreen = {
 
     startJob: async ({ launcherTestId }) => {
         return await test.step(`${NAME} Start job for testId "${launcherTestId}"`, async () => {
-            await page.getByTestId(launcherTestId).tap();
+            for (let attempt = 1; attempt <= JOB_START_TAP_ATTEMPTS; attempt++) {
+                await page.getByTestId(launcherTestId).tap();
+                const arrived = await jobScreenElement()
+                    .waitFor({ state: 'attached', timeout: JOB_START_ARRIVAL_TIMEOUT })
+                    .then(() => true, () => false);
+                if (arrived || attempt === JOB_START_TAP_ATTEMPTS) {
+                    break;
+                }
+                if ((await recoverToLauncherList({ applicationId: 'distribution' })) === 'unknown') {
+                    break;
+                }
+            }
             await DistributionJobScreen.waitForScreen();
         });
     },

--- a/e2e/mobile-webui/tests/utils/screens/jobStartRecovery.js
+++ b/e2e/mobile-webui/tests/utils/screens/jobStartRecovery.js
@@ -1,0 +1,42 @@
+import { FAST_ACTION_TIMEOUT, page } from '../common';
+import { ApplicationsListScreen } from './ApplicationsListScreen';
+
+// Bounded tap-and-recover budget, shared by the picking and distribution job-start helpers.
+export const JOB_START_TAP_ATTEMPTS = 3;
+// Short per-attempt wait for the job screen to appear after a tap. On the happy path the first attempt
+// succeeds immediately; only a slow/lost workflow-start round-trip pays this.
+export const JOB_START_ARRIVAL_TIMEOUT = 8000; // 8sec
+
+const isAttached = async (selector) =>
+    await page
+        .locator(selector)
+        .waitFor({ state: 'attached', timeout: FAST_ACTION_TIMEOUT })
+        .then(() => true, () => false);
+
+/**
+ * Decide how to recover after a launcher tap failed to reach the job screen.
+ *
+ * Three outcomes, and only two of them make a re-tap safe:
+ *  - 'launcherList' - we are demonstrably back on the launcher list, so no start is mid-flight and the
+ *    caller may re-tap;
+ *  - 'recovered' - neither screen was attached because the app landed on the APPLICATIONS MENU (the
+ *    observed job-start bounce: the just-started job was pruned from the store and ApplicationLayout
+ *    redirected home). We re-entered the application and the launcher list is up, so a re-tap is safe;
+ *  - 'unknown' - a navigation may still be in flight, or re-entry did not bring the list up. The caller
+ *    must NOT re-tap (that could double-start the workflow); let its trailing full settle decide.
+ *
+ * Known limitation, deliberate: re-entering the application from the menu loses any list filter the spec
+ * had applied (e.g. filterByDocumentNo). A caller that tapped by documentNo still finds its job (that
+ * locator filters by text); a caller that tapped by bare index may then fail its exactly-one-candidate
+ * guard and fail LOUD. That is correct - a silent re-tap on the wrong launcher would be worse.
+ */
+export const recoverToLauncherList = async ({ applicationId, launcherListSelector = '#WFLaunchersScreen' }) => {
+    if (await isAttached(launcherListSelector)) {
+        return 'launcherList';
+    }
+    if (!(await isAttached('#ApplicationsListScreen'))) {
+        return 'unknown';
+    }
+    await ApplicationsListScreen.startApplication(applicationId);
+    return (await isAttached(launcherListSelector)) ? 'recovered' : 'unknown';
+};

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -8,6 +8,12 @@ import { ApplicationsListScreen } from '../ApplicationsListScreen';
 import { expectClasses } from '../../expectations';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
 import { OperatorContextErrorPanel } from '../../components/OperatorContextErrorPanel';
+// Bounded tap-and-recover for the launcher-start navigation (see tapLauncherUntilJobScreen), shared
+// with the distribution job-start helper. Small attempt count with explicit per-step timeouts so the
+// retry cost stays modest: only the first attempt pays the full slow-action settle budget; retries
+// re-settle an already-populated list on a short budget, so a few attempts do not multiply the full
+// 20s screen wait.
+import { JOB_START_ARRIVAL_TIMEOUT, JOB_START_TAP_ATTEMPTS, recoverToLauncherList } from '../jobStartRecovery';
 
 const NAME = 'PickingJobsListScreen';
 /** @returns {import('@playwright/test').Locator} */
@@ -16,15 +22,6 @@ const containerElement = () => page.locator('#WFLaunchersScreen');
 // containerElement in PickingJobScreen.js — keep the two in sync if the workflow-process screen id changes.
 /** @returns {import('@playwright/test').Locator} */
 const jobScreenElement = () => page.locator('#WFProcessScreen');
-
-// Bounded tap-and-recover for the launcher-start navigation (see tapLauncherUntilJobScreen).
-// Small attempt count with explicit per-step timeouts so the retry cost stays modest: only the first
-// attempt pays the full slow-action settle budget; retries re-settle an already-populated list on a
-// short budget, so a few attempts do not multiply the full 20s screen wait.
-const JOB_START_TAP_ATTEMPTS = 3;
-// Short per-attempt wait for the job screen to appear after a tap. On the happy path the first
-// attempt succeeds immediately; only a slow/lost workflow-start round-trip pays this.
-const JOB_START_ARRIVAL_TIMEOUT = 8000; // 8sec
 
 export const PickingJobsListScreen = {
     waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
@@ -66,7 +63,18 @@ export const PickingJobsListScreen = {
     startJob: async ({ index, documentNo, qtyToDeliver, customerLocationId }) => {
         if (documentNo != null) {
             return await test.step(`${NAME} - Start job by documentNo ${documentNo}`, async () => {
-                await locateJobButtons({ documentNo }).tap();
+                for (let attempt = 1; attempt <= JOB_START_TAP_ATTEMPTS; attempt++) {
+                    await locateJobButtons({ documentNo }).tap();
+                    const arrived = await jobScreenElement()
+                        .waitFor({ state: 'attached', timeout: JOB_START_ARRIVAL_TIMEOUT })
+                        .then(() => true, () => false);
+                    if (arrived || attempt === JOB_START_TAP_ATTEMPTS) {
+                        break;
+                    }
+                    if ((await recoverToLauncherList({ applicationId: 'picking' })) === 'unknown') {
+                        break;
+                    }
+                }
                 await PickingJobScreen.waitForScreen();
                 return {
                     pickingJobId: await PickingJobScreen.getPickingJobId(),
@@ -197,15 +205,10 @@ const tapLauncherUntilJobScreen = async ({ index, qtyToDeliver, customerLocation
             break;
         }
 
-        // Not on the job screen yet, and attempts remain. Only loop to re-tap if we are back on the
-        // launcher list — the launcher and job screens are mutually-exclusive routes, so its presence
-        // (attached) means we truly returned, not a mid-transition overlap. Otherwise a navigation may
-        // still be in flight — give it a bounded moment to land rather than blindly re-tapping (which
-        // could double-start the workflow), then let the final settle below settle-or-fail.
-        const backOnLauncherList = await containerElement()
-            .waitFor({ state: 'attached', timeout: FAST_ACTION_TIMEOUT })
-            .then(() => true, () => false);
-        if (!backOnLauncherList) {
+        // Not on the job screen yet, and attempts remain. recoverToLauncherList also handles the case the
+        // old code could not: the app landed on the applications menu, where neither screen is attached,
+        // so breaking out here burned the remaining attempts on the 20s wait.
+        if ((await recoverToLauncherList({ applicationId: 'picking' })) === 'unknown') {
             break;
         }
     }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/applicationRoot/ApplicationLayout.deadDeepLink.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/applicationRoot/ApplicationLayout.deadDeepLink.test.js
@@ -1,0 +1,143 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { combineReducers, createStore } from 'redux';
+
+import { ApplicationLayout } from '../../../containers/applicationRoot/ApplicationLayout';
+import wfProcesses from '../../../reducers/wfProcesses/index';
+import { updateWFProcess } from '../../../actions/WorkflowActions';
+
+// Self-contained guard: a dead deep-link still redirects home.
+//
+// The upstream sibling suite ApplicationLayout.bounceHome.test.js CANNOT LOAD on these branches: it
+// jest.mocks apps/picking/ShelfLifeConfirmDialogHost, a module that only exists further upstream, so the
+// whole suite dies with "Cannot find module" and reports `Tests: 0 total`, so it cannot be met by citing
+// it. This file therefore pins the same two behaviours here, and must stay loadable on these branches:
+// do NOT add an import or a jest.mock for anything outside containers/applicationRoot/,
+// reducers/wfProcesses/ and actions/WorkflowActions.
+//
+// Both halves of the guarantee live below:
+//
+// On a workflow-launcher tap, WFLauncherButton dispatches updateWFProcess and then navigates to the
+// job route in the same start-request `.then`. On React 17 / connected-react-router 6.9 /
+// react-redux 7.2 those updates are not batched, so ApplicationLayout can mount on the job route
+// one render pass BEFORE the store selector observes the just-dispatched process. Calling
+// history.goHome() synchronously on that first pass drops the operator on the root menu mid-start, so
+// the guard must tolerate the ordering: redirect home only if the process is STILL not loaded after a
+// tick.
+//
+// The second test is the "nothing else broke" half: a genuinely dead deep-link (a reload onto a job
+// route whose process no longer exists) must STILL redirect the operator home, exactly once, and must
+// render nothing at all in the meantime.
+
+const WF_PROCESS_ID = 'picking-1000004';
+const SCREEN_ID = 'WFProcessScreen';
+
+const mockGoHome = jest.fn();
+jest.mock('../../../hooks/useMobileNavigation', () => ({
+  useMobileNavigation: () => ({
+    goHome: mockGoHome,
+    push: jest.fn(),
+    replace: jest.fn(),
+    goTo: jest.fn(),
+    goBack: jest.fn(),
+    go: jest.fn(),
+    goToFromLocation: jest.fn(),
+  }),
+}));
+
+// The job route carries a wfProcessId, so the redirect-home guard is armed.
+jest.mock('../../../hooks/useMobileLocation', () => ({
+  useMobileLocation: () => ({ wfProcessId: 'picking-1000004' }),
+}));
+
+jest.mock('../../../reducers/applications', () => ({
+  useApplicationInfo: () => ({ caption: 'Picking', iconClassNames: 'fas fa-box' }),
+}));
+
+jest.mock('../../../reducers/headers', () => ({
+  useNavigationInfoFromHeaders: () => ({
+    screenId: 'WFProcessScreen',
+    caption: 'Picking job',
+    homeLocation: { iconClassName: 'fas fa-home', location: '/' },
+  }),
+  useBackLocationFromHeaders: () => null,
+}));
+
+// Non-fullscreen layout (the real WF screens render the #WFProcessScreen container the e2e gate waits on).
+jest.mock('../../../apps', () => ({ isApplicationFullScreen: () => false }));
+
+jest.mock('../../../utils/ui_trace/useUITraceLocationChange', () => ({
+  useUITraceLocationChange: jest.fn(),
+}));
+jest.mock('../../../utils/ui_trace', () => ({
+  traceFunction: (fn) => fn,
+}));
+
+// Heavy children are irrelevant to the guard; stub them to trivial nodes.
+jest.mock('../../../containers/ViewHeader', () => ({ ViewHeader: () => null }));
+jest.mock('../../../components/ScreenToaster', () => () => null);
+
+describe('ApplicationLayout: a dead deep-link still redirects home, a just-started job does not', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('does not call mockGoHome and renders the WF screen when the process is observed one tick later', () => {
+    // Store starts empty: the just-dispatched process is not yet observable on the job route.
+    const store = createStore(combineReducers({ wfProcesses }));
+
+    const WFScreen = () => <div data-testid="wf-screen-content">workflow content</div>;
+
+    // 1) ApplicationLayout mounts on the job route BEFORE the store observes the process.
+    render(
+      <Provider store={store}>
+        <ApplicationLayout applicationId="picking" Component={WFScreen} />
+      </Provider>
+    );
+
+    // 2) The just-started process becomes visible in the store (the start `.then` dispatch lands),
+    //    still within the same tick — before any deferred redirect could fire.
+    act(() => {
+      store.dispatch(updateWFProcess({ wfProcess: { id: WF_PROCESS_ID, activities: [] }, parent: null }));
+    });
+
+    // 3) Flush any pending timers (a deferred-but-cancelled mockGoHome must not fire).
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    // The operator stays on the job screen — no bounce home, screen rendered (not null).
+    expect(mockGoHome).not.toHaveBeenCalled();
+    expect(document.getElementById(SCREEN_ID)).not.toBeNull();
+    expect(document.querySelector('[data-testid="wf-screen-content"]')).not.toBeNull();
+  });
+
+  it('still redirects home for a genuinely absent process (dead deep-link / reload)', () => {
+    // The process never arrives — the guard must still bounce home once the deferred tick fires.
+    const store = createStore(combineReducers({ wfProcesses }));
+
+    const WFScreen = () => <div data-testid="wf-screen-content">workflow content</div>;
+
+    render(
+      <Provider store={store}>
+        <ApplicationLayout applicationId="picking" Component={WFScreen} />
+      </Provider>
+    );
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    // Redirected home exactly once (not zero times, and not repeatedly on every render pass), and
+    // nothing of the job screen was ever rendered while the guard was armed.
+    expect(mockGoHome).toHaveBeenCalledTimes(1);
+    expect(document.getElementById(SCREEN_ID)).toBeNull();
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/wfLaunchersScreen/launchersFrameAfterTeardownIgnored.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/wfLaunchersScreen/launchersFrameAfterTeardownIgnored.test.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { useLaunchersWebsocket } from '../../../api/launchers';
+
+// ws.disconnectClient is asynchronous, so a launchers frame can still be delivered AFTER the
+// subscription's effect cleanup ran and the screen unmounted -- in the captured failure the STOMP
+// DISCONNECT was logged BEFORE the deleting MESSAGE. An unmounted subscription must not write to the
+// store at all, so the inner frame handler has to drop anything that arrives after teardown.
+//
+// The lifecycle lives in api/launchers.js (useLaunchersWebsocket's useEffect creates the client and its
+// cleanup disconnects it), NOT in containers/wfLaunchersScreen/useLaunchers.js -- which only supplies the
+// OUTER callback and cannot see a frame's arrival. So this test drives useLaunchersWebsocket and asserts
+// on that outer callback: it is the boundary at which a frame would reach the store.
+
+let capturedInnerOnWebsocketMessage = null;
+// `mock`-prefixed on purpose: babel-plugin-jest-hoist hoists the jest.mock factory above these
+// declarations and rejects a READ of any other out-of-scope variable from inside it.
+let mockDisconnectedClients = [];
+
+const FAKE_CLIENT = { id: 'fake-stomp-client' };
+
+// NOTE: plain functions, not jest.fn(impl) -- create-react-app's jest preset sets `resetMocks: true`,
+// which strips implementations passed to jest.fn().
+jest.mock('../../../utils/websocket', () => ({
+  connectAndSubscribe: ({ onWebsocketMessage }) => {
+    capturedInnerOnWebsocketMessage = onWebsocketMessage;
+    return { id: 'fake-stomp-client' };
+  },
+  disconnectClient: (client) => {
+    mockDisconnectedClients.push(client);
+  },
+}));
+
+// A realistic frame: the server serialises the launchers snapshot into message.body as JSON.
+const LAUNCHERS_FRAME = { body: JSON.stringify({ launchers: [] }) };
+
+const WebsocketProbe = ({ onWebsocketMessage }) => {
+  useLaunchersWebsocket({
+    enabled: true,
+    userToken: 'test-user-token',
+    applicationId: 'picking',
+    filterByQRCode: null,
+    filters: {},
+    facets: null,
+    onWebsocketMessage,
+  });
+  return null;
+};
+
+describe('useLaunchersWebsocket: a launchers frame delivered after teardown must not reach the store', () => {
+  beforeEach(() => {
+    capturedInnerOnWebsocketMessage = null;
+    mockDisconnectedClients = [];
+  });
+
+  it('ignores a frame delivered after the subscription tore down', () => {
+    const outerOnWebsocketMessage = jest.fn();
+
+    const { unmount } = render(<WebsocketProbe onWebsocketMessage={outerOnWebsocketMessage} />);
+    expect(typeof capturedInnerOnWebsocketMessage).toBe('function');
+
+    unmount();
+    expect(mockDisconnectedClients).toEqual([FAKE_CLIENT]);
+
+    // ws.disconnectClient is async: the broker can still hand us this frame.
+    capturedInnerOnWebsocketMessage(LAUNCHERS_FRAME);
+
+    expect(outerOnWebsocketMessage).not.toHaveBeenCalled();
+  });
+
+  // CONTROL: the identical frame, delivered while still mounted, must reach the callback exactly once.
+  // Without it the test above could pass by never wiring anything up.
+  it('delivers the same frame while the subscription is still mounted', () => {
+    const outerOnWebsocketMessage = jest.fn();
+
+    render(<WebsocketProbe onWebsocketMessage={outerOnWebsocketMessage} />);
+    expect(typeof capturedInnerOnWebsocketMessage).toBe('function');
+
+    capturedInnerOnWebsocketMessage(LAUNCHERS_FRAME);
+
+    expect(outerOnWebsocketMessage).toHaveBeenCalledTimes(1);
+    expect(outerOnWebsocketMessage).toHaveBeenCalledWith({
+      applicationId: 'picking',
+      applicationLaunchers: { launchers: [] },
+    });
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/wfLaunchersScreen/websocketLaunchersReceiptStamp.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/wfLaunchersScreen/websocketLaunchersReceiptStamp.test.js
@@ -1,0 +1,138 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { combineReducers, createStore } from 'redux';
+
+import { useLaunchers } from '../../../containers/wfLaunchersScreen/useLaunchers';
+import wfProcesses from '../../../reducers/wfProcesses/index';
+import launchers from '../../../reducers/launchers';
+import { isWfProcessLoaded } from '../../../reducers/wfProcesses';
+import { updateWFProcess } from '../../../actions/WorkflowActions';
+
+// Companion to __tests__/reducers/wfProcesses/websocketLaunchersReceiptStampDeletesStartedProcess.test.js.
+// That one pins the reducer contract; THIS one drives the REAL production code path: it captures the
+// `onWebsocketMessage` callback that useLaunchers passes to useLaunchersWebsocket
+// (containers/wfLaunchersScreen/useLaunchers.js) and invokes it, so whatever the websocket route
+// dispatches is produced by production code, not mirrored by the test.
+//
+// Stamping a pushed snapshot with the browser's RECEIPT time makes one the server built BEFORE the job
+// existed look newer than the job, so the wfProcesses garbage collector deletes it. Pushed snapshots
+// therefore carry their own action type, which that reducer has no case for.
+//
+// Comparing the payload's server-side `computedTime` is not a usable alternative: the same DTO serialises
+// it as an ISO-8601 string on the websocket and as an epoch-seconds float on REST, and on a handheld it
+// would compare a SERVER instant against a BROWSER `Date.now()`. Do not introduce that comparison.
+//
+// Interleaving: the server computes the snapshot at T1 (job absent from it), the operator's start is stored
+// at T2, the push is received at T3. The just-started wfProcess must survive.
+
+const WF_PROCESS_ID = 'picking-1000004';
+const T1_SERVER_COMPUTED_SNAPSHOT = 1000;
+const T2_START_DISPATCHED = 2000;
+const T3_WEBSOCKET_RECEIVED = 3000;
+
+let capturedOnWebsocketMessage = null;
+
+// The REST route must not interfere: getLaunchers never resolves, so the only launchers action
+// dispatched in this test is the websocket one.
+// NOTE: plain functions, not jest.fn(impl) -- create-react-app's jest preset sets
+// `resetMocks: true`, which strips implementations passed to jest.fn().
+jest.mock('../../../api/launchers', () => ({
+  getLaunchers: () => new Promise(() => {}),
+  useLaunchersWebsocket: ({ onWebsocketMessage }) => {
+    capturedOnWebsocketMessage = onWebsocketMessage;
+  },
+}));
+
+// Irrelevant to the race; keep them out of the store shape.
+jest.mock('../../../reducers/applications', () => ({
+  useApplicationInfo: () => ({ maxStartedLaunchers: 0, allowStartNextJobOnly: false }),
+}));
+jest.mock('../../../reducers/appHandler', () => ({
+  getTokenFromState: () => 'test-user-token',
+}));
+
+const LaunchersScreenProbe = () => {
+  useLaunchers({
+    applicationId: 'picking',
+    showFilterByQRCode: false,
+    facets: null,
+    filters: {},
+    isEnabled: true,
+  });
+  return null;
+};
+
+describe('useLaunchers: a websocket push must not prune a process started after the snapshot was computed', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    capturedOnWebsocketMessage = null;
+  });
+
+  it('keeps the just-started wfProcess when the pre-start snapshot is pushed after the start', () => {
+    const store = createStore(combineReducers({ wfProcesses, launchers }));
+
+    render(
+      <Provider store={store}>
+        <LaunchersScreenProbe />
+      </Provider>
+    );
+    expect(typeof capturedOnWebsocketMessage).toBe('function');
+
+    // 1) The operator taps the launcher; the start response is stored at T2.
+    jest.spyOn(Date, 'now').mockReturnValue(T2_START_DISPATCHED);
+    act(() => {
+      store.dispatch(updateWFProcess({ wfProcess: { id: WF_PROCESS_ID, activities: [] }, parent: null }));
+    });
+    expect(isWfProcessLoaded(store.getState(), WF_PROCESS_ID)).toBe(true);
+
+    // 2) The websocket push arrives at T3. Its payload was computed by the server at T1 -- before
+    //    the start -- so it does not list the just-started job.
+    Date.now.mockReturnValue(T3_WEBSOCKET_RECEIVED);
+    act(() => {
+      capturedOnWebsocketMessage({
+        applicationId: 'picking',
+        applicationLaunchers: {
+          computedTime: new Date(T1_SERVER_COMPUTED_SNAPSHOT).toISOString(),
+          launchers: [{ startedWFProcessId: null }, { startedWFProcessId: 'picking-9999999' }],
+        },
+      });
+    });
+
+    // The process must still be there -- otherwise ApplicationLayout renders null and bounces the
+    // operator home mid-start (containers/applicationRoot/ApplicationLayout.jsx:34-55).
+    expect(isWfProcessLoaded(store.getState(), WF_PROCESS_ID)).toBe(true);
+  });
+
+  // CONTROL: identical delivery, but the pushed snapshot DOES list the started job. It must survive
+  // -- proving the captured callback really reaches the wfProcesses reducer and that the payload
+  // shape (`launchers[].startedWFProcessId`) is modelled correctly, so the failure above is about
+  // the timestamp source and nothing else.
+  it('keeps the just-started wfProcess when the pushed snapshot does list it', () => {
+    const store = createStore(combineReducers({ wfProcesses, launchers }));
+
+    render(
+      <Provider store={store}>
+        <LaunchersScreenProbe />
+      </Provider>
+    );
+
+    jest.spyOn(Date, 'now').mockReturnValue(T2_START_DISPATCHED);
+    act(() => {
+      store.dispatch(updateWFProcess({ wfProcess: { id: WF_PROCESS_ID, activities: [] }, parent: null }));
+    });
+
+    Date.now.mockReturnValue(T3_WEBSOCKET_RECEIVED);
+    act(() => {
+      capturedOnWebsocketMessage({
+        applicationId: 'picking',
+        applicationLaunchers: {
+          computedTime: new Date(T3_WEBSOCKET_RECEIVED).toISOString(),
+          launchers: [{ startedWFProcessId: WF_PROCESS_ID }],
+        },
+      });
+    });
+
+    expect(isWfProcessLoaded(store.getState(), WF_PROCESS_ID)).toBe(true);
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/pushedLaunchersSnapshotNeverDeletes.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/pushedLaunchersSnapshotNeverDeletes.test.js
@@ -1,0 +1,118 @@
+import reducer from '../../../reducers/wfProcesses/index';
+import launchersReducer from '../../../reducers/launchers';
+import { isWfProcessLoaded } from '../../../reducers/wfProcesses';
+import { updateWFProcess } from '../../../actions/WorkflowActions';
+import { populateLaunchersPushedByServer } from '../../../actions/LauncherActions';
+
+// The primary invariant: a launchers snapshot that arrives by
+// websocket PUSH never removes a workflow process from the store -- for ANY timestamp values, including
+// ones that satisfy the `requestTimestamp >= updatedAt` guard, and including the harshest payload of all:
+// an empty launchers list, which on the requested route deletes every process in the store.
+//
+// The two companion suites each pin exactly ONE interleaving (the captured one), so neither proves the
+// invariant; this one parametrises over the timestamp matrix and asserts the wfProcesses state is
+// UNCHANGED, not merely that one id survived.
+//
+// Pushed snapshots carry their own action type, which reducers/wfProcesses/workflow.js has no case for,
+// so a push cannot prune whatever the clocks say.
+//
+// Comparing the payload's server-side `computedTime` is not a usable alternative: the same DTO serialises
+// it as an ISO-8601 string on the websocket and as an epoch-seconds float on REST, and on a handheld it
+// would compare a SERVER instant against a BROWSER `Date.now()`. Do not introduce that comparison.
+//
+// That a REQUESTED snapshot must still garbage-collect is NOT retested here: it is already covered by
+// staleLaunchersDeletesStartedProcess.test.js, which must stay green after the fix.
+describe('wfProcesses: a PUSHED launchers snapshot never deletes, for ANY timestamps', () => {
+  const WF_PROCESS_ID = 'picking-1000004';
+
+  // Captured epoch ms (capture/FAILING-RUN-probe-1788251568209-1.ndjson; INVESTIGATION.md).
+  // The server built the snapshot at T_SNAPSHOT_BUILT, 198 ms before the job entered the store.
+  const T_SNAPSHOT_BUILT = 1788251575868;
+  const T_JOB_IN_STORE = 1788251576066;
+
+  const COMPUTED_BEFORE_THE_JOB = new Date(T_SNAPSHOT_BUILT).toISOString();
+
+  // A pre-start snapshot: it was built before the job existed, so it does not list WF_PROCESS_ID.
+  const launchersWithoutTheJob = [{ startedWFProcessId: null }, { startedWFProcessId: 'picking-9999999' }];
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    [
+      'frame delivered long after the job (would defeat the requestTimestamp guard)',
+      {
+        computedTime: COMPUTED_BEFORE_THE_JOB,
+        frameDeliveredAt: T_JOB_IN_STORE + 5000,
+        launchers: launchersWithoutTheJob,
+      },
+    ],
+    [
+      'the captured margin (+9 ms)',
+      {
+        computedTime: COMPUTED_BEFORE_THE_JOB,
+        frameDeliveredAt: T_JOB_IN_STORE + 9.6,
+        launchers: launchersWithoutTheJob,
+      },
+    ],
+    [
+      'frame and job in the same millisecond',
+      { computedTime: COMPUTED_BEFORE_THE_JOB, frameDeliveredAt: T_JOB_IN_STORE, launchers: launchersWithoutTheJob },
+    ],
+    [
+      'frame delivered before the job',
+      {
+        computedTime: COMPUTED_BEFORE_THE_JOB,
+        frameDeliveredAt: T_JOB_IN_STORE - 200,
+        launchers: launchersWithoutTheJob,
+      },
+    ],
+    [
+      'payload carries no computedTime at all',
+      { computedTime: undefined, frameDeliveredAt: T_JOB_IN_STORE + 5000, launchers: launchersWithoutTheJob },
+    ],
+    [
+      'empty launchers list (would prune everything)',
+      { computedTime: COMPUTED_BEFORE_THE_JOB, frameDeliveredAt: T_JOB_IN_STORE + 5000, launchers: [] },
+    ],
+  ])('leaves the store untouched: %s', (_caseName, { computedTime, frameDeliveredAt, launchers }) => {
+    // The operator's start is stored; `updatedAt` is stamped from Date.now() by the action creator.
+    jest.spyOn(Date, 'now').mockReturnValue(T_JOB_IN_STORE);
+    const stateBeforeThePush = reducer(
+      undefined,
+      updateWFProcess({ wfProcess: { id: WF_PROCESS_ID, activities: [] }, parent: null })
+    );
+    expect(isWfProcessLoaded({ wfProcesses: stateBeforeThePush }, WF_PROCESS_ID)).toBe(true);
+
+    // A structural copy, so the comparison below cannot be satisfied by the reducer simply handing back
+    // the very same object it was given.
+    const snapshotOfStateBeforeThePush = JSON.parse(JSON.stringify(stateBeforeThePush));
+
+    // The frame is delivered.
+    Date.now.mockReturnValue(frameDeliveredAt);
+    const applicationLaunchers = computedTime === undefined ? { launchers } : { computedTime, launchers };
+    const stateAfterThePush = reducer(
+      stateBeforeThePush,
+      populateLaunchersPushedByServer({ applicationId: 'picking', applicationLaunchers })
+    );
+
+    expect(stateAfterThePush).toEqual(snapshotOfStateBeforeThePush);
+  });
+
+  // The push must keep doing its job: only its ability to PRUNE is removed, not its ability to refresh
+  // what the operator sees. Fails now for the same missing-action-creator reason.
+  it('still refreshes the visible launcher list', () => {
+    const state = {
+      launchers: launchersReducer(
+        undefined,
+        populateLaunchersPushedByServer({
+          applicationId: 'picking',
+          applicationLaunchers: { computedTime: COMPUTED_BEFORE_THE_JOB, launchers: launchersWithoutTheJob },
+        })
+      ),
+    };
+
+    expect(state.launchers.picking.list).toEqual(launchersWithoutTheJob);
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/websocketLaunchersReceiptStampDeletesStartedProcess.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/websocketLaunchersReceiptStampDeletesStartedProcess.test.js
@@ -1,0 +1,86 @@
+import reducer from '../../../reducers/wfProcesses/index';
+import { isWfProcessLoaded } from '../../../reducers/wfProcesses';
+import { updateWFProcess } from '../../../actions/WorkflowActions';
+import { populateLaunchersComplete, populateLaunchersPushedByServer } from '../../../actions/LauncherActions';
+
+// The captured failure, replayed at the reducer level.
+//
+// A launchers snapshot that arrives by websocket PUSH may refresh the visible job list, but must never
+// remove a workflow process from the store: a push carries no request-issued time, so nothing about it can
+// prove a job is gone. Deleting therefore requires an explicitly REQUESTED snapshot, which stamps at
+// request-issue time and so can never over-state its own freshness.
+//
+// Pushed snapshots carry their own action type, which reducers/wfProcesses/workflow.js has no case for,
+// so a push cannot reach the pruning path at all.
+//
+// Comparing the payload's server-side `computedTime` is not a usable alternative: the same DTO serialises
+// it as an ISO-8601 string on the websocket and as an epoch-seconds float on REST, and on a handheld it
+// would compare a SERVER instant against a BROWSER `Date.now()`. Do not introduce that comparison.
+//
+// The numbers are the CAPTURED ones (capture/FAILING-RUN-probe-1788251568209-1.ndjson; INVESTIGATION.md),
+// epoch ms, not round placeholders.
+describe('wfProcesses: a pushed launchers snapshot must not prune a just-started process', () => {
+  const WF_PROCESS_ID = 'picking-1000004';
+
+  // The server computed the snapshot (payload computedTime 2026-09-01T08:32:55.868Z).
+  const T_SNAPSHOT_BUILT = 1788251575868;
+  // The job entered the store: 198 ms AFTER the snapshot was built, so the snapshot cannot know about it.
+  const T_JOB_IN_STORE = 1788251576066;
+  // The push was delivered: 9 ms after the job entered the store (the captured margin, +9 ms).
+  const T_FRAME_RECEIVED = 1788251576075.6;
+
+  // The snapshot predates the start, so it does not list WF_PROCESS_ID.
+  const snapshotBuiltBeforeTheStart = {
+    computedTime: new Date(T_SNAPSHOT_BUILT).toISOString(),
+    launchers: [{ startedWFProcessId: null }, { startedWFProcessId: 'picking-9999999' }],
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const startTheJob = () => {
+    jest.spyOn(Date, 'now').mockReturnValue(T_JOB_IN_STORE);
+    const state = reducer(
+      undefined,
+      updateWFProcess({ wfProcess: { id: WF_PROCESS_ID, activities: [] }, parent: null })
+    );
+    expect(isWfProcessLoaded({ wfProcesses: state }, WF_PROCESS_ID)).toBe(true);
+    return state;
+  };
+
+  // Control: the same snapshot on the REQUESTED route, stamped with the request-issue time, where the
+  // guard in removeWFProcessesFromState keeps the job. It proves the harness models the reducer, the
+  // action shape and the interleaving correctly, so a failure below is about the pushed route alone.
+  it('keeps the just-started wfProcess when the same pre-start snapshot arrives as a REQUESTED snapshot', () => {
+    let state = startTheJob();
+
+    state = reducer(
+      state,
+      populateLaunchersComplete({
+        applicationId: 'picking',
+        applicationLaunchers: snapshotBuiltBeforeTheStart,
+        requestTimestamp: T_SNAPSHOT_BUILT,
+      })
+    );
+
+    expect(isWfProcessLoaded({ wfProcesses: state }, WF_PROCESS_ID)).toBe(true);
+  });
+
+  // The websocket route dispatches a PUSHED snapshot, which this reducer does not handle at all, so the
+  // just-started process survives no matter when the frame was delivered.
+  it('keeps the just-started wfProcess when the pre-start snapshot arrives as a PUSHED snapshot', () => {
+    let state = startTheJob();
+
+    jest.spyOn(Date, 'now').mockReturnValue(T_FRAME_RECEIVED);
+    state = reducer(
+      state,
+      populateLaunchersPushedByServer({
+        applicationId: 'picking',
+        applicationLaunchers: snapshotBuiltBeforeTheStart,
+      })
+    );
+
+    expect(isWfProcessLoaded({ wfProcesses: state }, WF_PROCESS_ID)).toBe(true);
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/actions/LauncherActions.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/actions/LauncherActions.js
@@ -2,6 +2,7 @@ import {
   CLEAR_ACTIVE_FILTERS,
   CLEAR_LAUNCHERS,
   POPULATE_LAUNCHERS_COMPLETE,
+  POPULATE_LAUNCHERS_PUSHED_BY_SERVER,
   POPULATE_LAUNCHERS_START,
   SET_ACTIVE_FILTERS,
 } from '../constants/LaunchersActionTypes';
@@ -20,6 +21,16 @@ export const populateLaunchersComplete = ({ applicationId, applicationLaunchers,
     // `requestTimestamp` is when this launchers snapshot was fetched (request issued). The
     // wfProcesses reducer uses it to avoid pruning a process started after the request went out.
     payload: { applicationId, applicationLaunchers, requestTimestamp },
+  };
+};
+
+export const populateLaunchersPushedByServer = ({ applicationId, applicationLaunchers }) => {
+  return {
+    type: POPULATE_LAUNCHERS_PUSHED_BY_SERVER,
+    // NO requestTimestamp, on purpose: a pushed snapshot carries no request-issued time, so there is no
+    // instant that bounds what it can know about. The wfProcesses reducer does not handle this type at
+    // all, so a push cannot prune a workflow process.
+    payload: { applicationId, applicationLaunchers },
   };
 };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/launchers.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/launchers.js
@@ -100,6 +100,10 @@ export const useLaunchersWebsocket = ({
 
   useEffect(() => {
     let client;
+    // ws.disconnectClient is async, so a frame can still be delivered after this effect's cleanup ran and
+    // the screen unmounted -- in the captured failure the STOMP DISCONNECT was logged BEFORE the deleting
+    // MESSAGE. An unmounted subscription must not write to the store at all.
+    let subscriptionActive = true;
     if (enabled) {
       const topic = `/v2/userWorkflows/launchers/?${toQueryString({
         userToken,
@@ -115,6 +119,7 @@ export const useLaunchersWebsocket = ({
         topic,
         debug: !!window?.debug_ws,
         onWebsocketMessage: (message) => {
+          if (!subscriptionActive) return;
           const applicationLaunchers = JSON.parse(message.body);
           onWebsocketMessage({ applicationId, applicationLaunchers });
         },
@@ -122,6 +127,7 @@ export const useLaunchersWebsocket = ({
     }
 
     return () => {
+      subscriptionActive = false;
       if (client) {
         ws.disconnectClient(client);
         client = null;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/constants/LaunchersActionTypes.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/constants/LaunchersActionTypes.js
@@ -4,6 +4,15 @@
  */
 export const POPULATE_LAUNCHERS_START = 'launchers/loadStart';
 export const POPULATE_LAUNCHERS_COMPLETE = 'launchers/loadComplete';
+
+/**
+ * A launchers snapshot the server pushed over the websocket, as opposed to one this client requested.
+ * A separate type from POPULATE_LAUNCHERS_COMPLETE so that no reducer can prune on it.
+ * @constant
+ * @type {string}
+ */
+export const POPULATE_LAUNCHERS_PUSHED_BY_SERVER = 'launchers/pushedByServer';
+
 export const CLEAR_LAUNCHERS = 'launchers/clear';
 export const SET_ACTIVE_FILTERS = 'launchers/activeFilters/set';
 export const CLEAR_ACTIVE_FILTERS = 'launchers/activeFilters/clear';

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/useLaunchers.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/useLaunchers.js
@@ -3,7 +3,11 @@ import { useEffect, useState } from 'react';
 import { useApplicationLaunchers } from '../../reducers/launchers';
 import { useFilterByQRCode } from './useFilterByQRCode';
 import { toQRCodeString } from '../../utils/qrCode/hu';
-import { clearLaunchers, populateLaunchersComplete } from '../../actions/LauncherActions';
+import {
+  clearLaunchers,
+  populateLaunchersComplete,
+  populateLaunchersPushedByServer,
+} from '../../actions/LauncherActions';
 import { getLaunchers, useLaunchersWebsocket } from '../../api/launchers';
 import { getTokenFromState } from '../../reducers/appHandler';
 import { useApplicationInfo } from '../../reducers/applications';
@@ -54,9 +58,9 @@ export const useLaunchers = ({ applicationId, showFilterByQRCode, facets, filter
     filters,
     facets,
     onWebsocketMessage: ({ applicationId, applicationLaunchers }) => {
-      // A websocket push carries no request-issued time; it reflects current server state, so use
-      // receipt time. This preserves the pre-existing GC behaviour for pushed snapshots.
-      onNewLaunchers({ applicationId, applicationLaunchers, requestTimestamp: Date.now() });
+      // Refreshes the visible list only. Must not go through populateLaunchersComplete, whose action type
+      // carries the power to prune workflow processes.
+      dispatch(populateLaunchersPushedByServer({ applicationId, applicationLaunchers }));
     },
   });
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/launchers.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/launchers.js
@@ -70,7 +70,11 @@ export default function launchers(state = initialState, action) {
         requestTimestamp: timestamp,
       });
     }
-    case types.POPULATE_LAUNCHERS_COMPLETE: {
+    // A pushed snapshot refreshes the visible list exactly like a requested one. Note that neither case
+    // writes `requestTimestamp` -- so this is unchanged behaviour for the REST fetch effect in
+    // useLaunchers.js, whose dependency array reads that field.
+    case types.POPULATE_LAUNCHERS_COMPLETE:
+    case types.POPULATE_LAUNCHERS_PUSHED_BY_SERVER: {
       const { applicationId, applicationLaunchers } = payload;
       return copyAndMergeToState(state, applicationId, {
         isLoading: false,

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/wfProcesses/workflow.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/wfProcesses/workflow.js
@@ -45,6 +45,9 @@ export const workflowReducer = ({ draftState, action }) => {
       return draftState;
     }
 
+    // Only a REQUESTED snapshot may prune: it is stamped when the request was issued, so it cannot claim
+    // knowledge of a job started later. A pushed snapshot carries no such bound, so it has its own action
+    // type that no case here handles -- attaching the prune to the type keeps it unreachable by accident.
     case launcherTypes.POPULATE_LAUNCHERS_COMPLETE: {
       const { applicationLaunchers, requestTimestamp } = action.payload;
 


### PR DESCRIPTION
Sideways port of https://github.com/metasfresh/metasfresh/pull/25697 to the intensive_care family. The defect is in shared mobile core code, so fixing only the branch it was reported on leaves it live for the other families; propagation does not flow sideways, so this family needs its own port.

A launchers snapshot pushed over the websocket was dispatched as `POPULATE_LAUNCHERS_COMPLETE` stamped with the browser receipt time. The `wfProcesses` garbage collector reads that stamp as "this snapshot knows about everything older than it", so a snapshot the server had computed BEFORE a job was started looked newer than the job and deleted it from the store — the operator was thrown back to the applications menu mid job-start. Pushed snapshots now get their own action type that the `wfProcesses` reducer deliberately does not handle, so a push structurally cannot prune; the explicitly requested snapshot stamps at request-issue time and keeps doing all garbage collection.

One conflict, in the import header of `e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js`: an add/add where both sides only add import lines at the same position. Resolved as the union of both import blocks — dropping either side would break that side. Nothing else conflicted.