### PR TITLE
French public-procurement references on orders and business partners

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5821370_sys_PublicProcurement_C_Order_Columns.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5821370_sys_PublicProcurement_C_Order_Columns.sql
@@ -1,0 +1,114 @@
+-- New C_Order columns for French public-procurement invoice references: a market number and
+-- a commitment number, captured once on the order (their natural source) so they can be read
+-- through to the invoice by a later migration's virtual columns, without re-entry at invoicing
+-- time.
+--
+-- Columns are portal-neutral by design (PublicProcurement*, not tied to any one submission
+-- platform) so they survive a change of platform. Both are plain VARCHAR(40), not mandatory
+-- (only relevant for public-sector orders subject to these statutory references).
+--
+-- Known glossary gap: the metasfresh terminology glossary has no entry for the French statutory
+-- terms behind these two references, so no German neologism is coined here. Each AD_Element's
+-- BASE-language Name/PrintName is the FRENCH STATUTORY TERM exactly as it is printed on the
+-- customer's reference invoice ('MARCHE' -> 'Marché', 'ENGAGEMENT' -> 'Engagement') — grounded
+-- in that document, not invented — and en_US carries the English caption, marked translated.
+-- This is a deliberate, documented deviation from the usual German-base convention, and it is
+-- what the approved plan specifies. de_DE/de_CH are left IsTranslated='N' and therefore fall
+-- back to the French base text; the German wording is a terminology question for a human.
+--
+-- AD_Table_ID for C_Order = 259 (verified via psql against the local stack).
+-- EntityType='D' (core dictionary metadata; C_Order is a core table).
+-- PersonalDataCategory='NP' — both columns are administrative references to a public contract/
+-- market held by a government body, not personal data about a natural person.
+--
+-- IDs allocated from the central ID server:
+--   AD_MigrationScript 5821370  (this script's prefix)
+--   AD_Element  585393  (PublicProcurementMarketNo)
+--   AD_Column   593441  (C_Order.PublicProcurementMarketNo)
+--   AD_Element  585394  (PublicProcurementCommitmentNo)
+--   AD_Column   593442  (C_Order.PublicProcurementCommitmentNo)
+--
+-- Do NOT touch: any existing migration file; C_Invoice; C_BPartner; any window, tab or field row
+-- (those belong to later, separate tasks).
+
+-- ============================================================
+-- Column 1: C_Order.PublicProcurementMarketNo
+-- ============================================================
+
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585393 /*From ID Server*/,0,'PublicProcurementMarketNo',TO_TIMESTAMP('2026-09-01 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Marché','Marché',TO_TIMESTAMP('2026-09-01 10:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585393
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- English is the deliberately-translated language here (base column already carries the English
+-- caption); mark it translated. German is intentionally left IsTranslated='N' (falls back to the
+-- English base text) — see header comment.
+UPDATE AD_Element_Trl SET Name='Public Procurement Market No.', PrintName='Public Procurement Market No.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 10:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585393 AND AD_Language='en_US'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585393,'en_US')
+;
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,PersonalDataCategory,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593441 /*From ID Server*/,585393,0,10,259,'PublicProcurementMarketNo',TO_TIMESTAMP('2026-09-01 10:01:00','YYYY-MM-DD HH24:MI:SS'),100,'N','D',0,40,'Y','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N',0,'Marché','NP',0,0,TO_TIMESTAMP('2026-09-01 10:01:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=593441
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+/* DDL */ select update_Column_Translation_From_AD_Element(585393)
+;
+
+/* DDL */ SELECT public.db_alter_table('C_Order','ALTER TABLE public.C_Order ADD COLUMN PublicProcurementMarketNo VARCHAR(40)')
+;
+
+-- ============================================================
+-- Column 2: C_Order.PublicProcurementCommitmentNo
+-- ============================================================
+
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585394 /*From ID Server*/,0,'PublicProcurementCommitmentNo',TO_TIMESTAMP('2026-09-01 10:02:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Engagement','Engagement',TO_TIMESTAMP('2026-09-01 10:02:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585394
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- English is the deliberately-translated language here (base column already carries the English
+-- caption); mark it translated. German is intentionally left IsTranslated='N' (falls back to the
+-- English base text) — see header comment.
+UPDATE AD_Element_Trl SET Name='Public Procurement Commitment No.', PrintName='Public Procurement Commitment No.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 10:02:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585394 AND AD_Language='en_US'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585394,'en_US')
+;
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,PersonalDataCategory,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593442 /*From ID Server*/,585394,0,10,259,'PublicProcurementCommitmentNo',TO_TIMESTAMP('2026-09-01 10:03:00','YYYY-MM-DD HH24:MI:SS'),100,'N','D',0,40,'Y','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N',0,'Engagement','NP',0,0,TO_TIMESTAMP('2026-09-01 10:03:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=593442
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+/* DDL */ select update_Column_Translation_From_AD_Element(585394)
+;
+
+/* DDL */ SELECT public.db_alter_table('C_Order','ALTER TABLE public.C_Order ADD COLUMN PublicProcurementCommitmentNo VARCHAR(40)')
+;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5821490_sys_PublicProcurement_C_BPartner_Columns.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5821490_sys_PublicProcurement_C_BPartner_Columns.sql
@@ -12,6 +12,14 @@
 -- added by 5643560_sys_add_FirmenbuchNR_to_Business_Partner_Window.sql) which is reused as-is
 -- for the invoiced body's OWN SIRET and is NOT touched by this script.
 --
+-- On the length gap between the two SIRET-shaped columns: PublicAuthoritySiret is VARCHAR(20)
+-- while CommercialRegisterNumber is VARCHAR(60). That is deliberate, not an oversight.
+-- CommercialRegisterNumber is a GENERIC company-registration field used by every country's
+-- partners (German Firmenbuch numbers, other national registers), so it is sized for the
+-- widest case. PublicAuthoritySiret holds only a French SIRET, which is a fixed 14 digits;
+-- 20 leaves room for the usual grouping separators (e.g. '123 456 789 12345', 18 chars) while
+-- still rejecting input that cannot be a SIRET at all.
+--
 -- Known glossary gap: the metasfresh terminology glossary has no entry for the French statutory
 -- terms behind these two references, so no German neologism is coined here. Each AD_Element's
 -- BASE-language Name/PrintName is the FRENCH STATUTORY TERM exactly as it is printed on the

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5821490_sys_PublicProcurement_C_BPartner_Columns.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5821490_sys_PublicProcurement_C_BPartner_Columns.sql
@@ -1,0 +1,119 @@
+-- New C_BPartner columns for French public-procurement invoice references: a service code and
+-- a State SIRET, captured once on the business partner (their natural source, stable per
+-- public-sector customer per REQUIREMENTS.md assumption A2) so they can be read through to the
+-- invoice by a later migration's virtual columns, without re-entry at invoicing time.
+--
+-- Columns are portal-neutral by design (PublicProcurement*/PublicAuthority*, not tied to any one
+-- submission platform) so they survive a change of platform. Both are plain VARCHAR, not
+-- mandatory (only relevant for public-sector business partners subject to these statutory
+-- references).
+--
+-- Not to be confused with C_BPartner.CommercialRegisterNumber (VARCHAR(60), label FirmenbuchNR,
+-- added by 5643560_sys_add_FirmenbuchNR_to_Business_Partner_Window.sql) which is reused as-is
+-- for the invoiced body's OWN SIRET and is NOT touched by this script.
+--
+-- Known glossary gap: the metasfresh terminology glossary has no entry for the French statutory
+-- terms behind these two references, so no German neologism is coined here. Each AD_Element's
+-- BASE-language Name/PrintName is the FRENCH STATUTORY TERM exactly as it is printed on the
+-- customer's reference invoice ('CODE SERVICE' -> 'Code service', 'SIRET ETAT' -> 'SIRET État')
+-- -- grounded in that document, not invented -- and en_US carries the English caption, marked
+-- translated. This is a deliberate, documented deviation from the usual German-base convention,
+-- and it is what the approved plan specifies. de_DE/de_CH are left IsTranslated='N' and therefore
+-- fall back to the French base text; the German wording is a terminology question for a human.
+--
+-- AD_Table_ID for C_BPartner = 291 (verified via psql against the local stack).
+-- EntityType='D' (core dictionary metadata; C_BPartner is a core table).
+-- PersonalDataCategory='NP' for both -- administrative references to a public contract/market
+-- and a French State body, not personal data about a natural person.
+--
+-- IDs allocated from the central ID server:
+--   AD_MigrationScript 5821490  (this script's prefix)
+--   AD_Element  585397  (PublicProcurementServiceCode)
+--   AD_Column   593445  (C_BPartner.PublicProcurementServiceCode)
+--   AD_Element  585398  (PublicAuthoritySiret)
+--   AD_Column   593446  (C_BPartner.PublicAuthoritySiret)
+--
+-- Do NOT touch: any existing migration file; C_Order; C_Invoice; CommercialRegisterNumber;
+-- any window, tab or field row (those belong to later, separate tasks).
+
+-- ============================================================
+-- Column 1: C_BPartner.PublicProcurementServiceCode
+-- ============================================================
+
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585397 /*From ID Server*/,0,'PublicProcurementServiceCode',TO_TIMESTAMP('2026-09-01 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Code service','Code service',TO_TIMESTAMP('2026-09-01 11:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585397
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- English is the deliberately-translated language here (base column already carries the French
+-- statutory term); mark it translated. German is intentionally left IsTranslated='N' (falls back
+-- to the French base text) -- see header comment.
+UPDATE AD_Element_Trl SET Name='Public Procurement Service Code', PrintName='Public Procurement Service Code', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 11:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585397 AND AD_Language='en_US'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585397,'en_US')
+;
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,PersonalDataCategory,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593445 /*From ID Server*/,585397,0,10,291,'PublicProcurementServiceCode',TO_TIMESTAMP('2026-09-01 11:01:00','YYYY-MM-DD HH24:MI:SS'),100,'N','D',0,40,'Y','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N',0,'Code service','NP',0,0,TO_TIMESTAMP('2026-09-01 11:01:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=593445
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+/* DDL */ select update_Column_Translation_From_AD_Element(585397)
+;
+
+/* DDL */ SELECT public.db_alter_table('C_BPartner','ALTER TABLE public.C_BPartner ADD COLUMN PublicProcurementServiceCode VARCHAR(40)')
+;
+
+-- ============================================================
+-- Column 2: C_BPartner.PublicAuthoritySiret
+-- ============================================================
+
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585398 /*From ID Server*/,0,'PublicAuthoritySiret',TO_TIMESTAMP('2026-09-01 11:02:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','SIRET État','SIRET État',TO_TIMESTAMP('2026-09-01 11:02:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585398
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- English is the deliberately-translated language here (base column already carries the French
+-- statutory term); mark it translated. German is intentionally left IsTranslated='N' (falls back
+-- to the French base text) -- see header comment.
+UPDATE AD_Element_Trl SET Name='Public Authority SIRET', PrintName='Public Authority SIRET', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 11:02:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585398 AND AD_Language='en_US'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585398,'en_US')
+;
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,PersonalDataCategory,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593446 /*From ID Server*/,585398,0,10,291,'PublicAuthoritySiret',TO_TIMESTAMP('2026-09-01 11:03:00','YYYY-MM-DD HH24:MI:SS'),100,'N','D',0,20,'Y','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N',0,'SIRET État','NP',0,0,TO_TIMESTAMP('2026-09-01 11:03:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=593446
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+/* DDL */ select update_Column_Translation_From_AD_Element(585398)
+;
+
+/* DDL */ SELECT public.db_alter_table('C_BPartner','ALTER TABLE public.C_BPartner ADD COLUMN PublicAuthoritySiret VARCHAR(20)')
+;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5821620_sys_PublicProcurement_French_Translations.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5821620_sys_PublicProcurement_French_Translations.sql
@@ -1,0 +1,123 @@
+-- Mark the fr_FR and fr_CH translations of the four French public-procurement AD_Elements as
+-- actually translated (IsTranslated='Y'), so they are authoritative French rather than an
+-- accidental fallback.
+--
+-- Background: AD_Element 585393 (PublicProcurementMarketNo), 585394 (PublicProcurementCommitmentNo)
+-- and 585398 (PublicAuthoritySiret) were created by 5821370_sys_PublicProcurement_C_Order_Columns.sql
+-- and 5821490_sys_PublicProcurement_C_BPartner_Columns.sql with the FRENCH STATUTORY TERM in the
+-- BASE-language Name/PrintName ('Marché', 'Engagement', 'SIRET État'); element 585397
+-- (PublicProcurementServiceCode) likewise carries 'Code service'. Their skeleton AD_Element_Trl
+-- INSERT (in those same scripts) copied that base text into every active system language,
+-- including fr_FR and fr_CH, with IsTranslated='N' — correct text, but marked as an unverified
+-- fallback rather than a deliberate French translation.
+--
+-- This script does NOT change the French wording (already correct, sourced from a French
+-- public-procurement reference invoice, not invented here) — it only flips fr_FR/fr_CH to
+-- IsTranslated='Y' and re-propagates via update_TRL_Tables_On_AD_Element_TRL_Update() so the
+-- dependent AD_Column_Trl / AD_Field_Trl / AD_Tab_Trl rows pick up the now-authoritative French
+-- text.
+--
+-- de_DE / de_CH are intentionally NOT touched by this script and stay IsTranslated='N' — the
+-- German wording is a terminology/glossary question for a human. Do not invent or coin German
+-- wording for these four terms.
+--
+-- Out of scope: AD_Element 581038 (CommercialRegisterNumber, base 'FirmenbuchNR') is NOT touched
+-- here even though its fr_FR/fr_CH rows are in the same unverified state — it is shared far beyond
+-- this scope (1 AD_Column, 4 AD_Field / 4 AD_Tab references, verified via psql against a local
+-- stack). Left for a separate, explicitly human-approved change.
+--
+-- No new IDs needed (updating existing rows only).
+-- AD_MigrationScript 5821620 allocated from the central ID server.
+
+-- ============================================================
+-- AD_Element 585393 (PublicProcurementMarketNo) — 'Marché'
+-- ============================================================
+
+UPDATE AD_Element_Trl SET Name='Marché', PrintName='Marché', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585393 AND AD_Language='fr_FR'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585393,'fr_FR')
+;
+
+UPDATE AD_Element_Trl SET Name='Marché', PrintName='Marché', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 12:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585393 AND AD_Language='fr_CH'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585393,'fr_CH')
+;
+
+-- ============================================================
+-- AD_Element 585394 (PublicProcurementCommitmentNo) — 'Engagement'
+-- ============================================================
+
+UPDATE AD_Element_Trl SET Name='Engagement', PrintName='Engagement', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 12:00:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585394 AND AD_Language='fr_FR'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585394,'fr_FR')
+;
+
+UPDATE AD_Element_Trl SET Name='Engagement', PrintName='Engagement', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 12:00:06','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585394 AND AD_Language='fr_CH'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585394,'fr_CH')
+;
+
+-- ============================================================
+-- AD_Element 585397 (PublicProcurementServiceCode) — 'Code service'
+-- ============================================================
+
+UPDATE AD_Element_Trl SET Name='Code service', PrintName='Code service', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 12:00:08','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585397 AND AD_Language='fr_FR'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585397,'fr_FR')
+;
+
+UPDATE AD_Element_Trl SET Name='Code service', PrintName='Code service', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 12:00:10','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585397 AND AD_Language='fr_CH'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585397,'fr_CH')
+;
+
+-- ============================================================
+-- AD_Element 585398 (PublicAuthoritySiret) — 'SIRET État'
+-- ============================================================
+
+UPDATE AD_Element_Trl SET Name='SIRET État', PrintName='SIRET État', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 12:00:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585398 AND AD_Language='fr_FR'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585398,'fr_FR')
+;
+
+UPDATE AD_Element_Trl SET Name='SIRET État', PrintName='SIRET État', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 12:00:14','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585398 AND AD_Language='fr_CH'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585398,'fr_CH')
+;
+
+-- ============================================================
+-- AD_Element 581038 (CommercialRegisterNumber) — 'SIRET'
+-- ============================================================
+-- In scope as of 2026-09-01: CommercialRegisterNumber is the home of the invoiced partner's OWN
+-- SIRET (no dedicated column is added), so its FRENCH caption has to say so. Its fr_FR/fr_CH rows
+-- currently read 'FirmenbuchNR' with IsTranslated='N' — i.e. a French user sees a German word for
+-- the field they know as the SIRET.
+--
+-- Only the FRENCH translations change. The base Name and the German translations stay
+-- 'FirmenbuchNR', which is correct for German users; this is a translation, not a rename.
+--
+-- Blast radius, measured read-only before writing (not assumed): AD_Element 581038 backs exactly
+-- 1 AD_Column (C_BPartner.CommercialRegisterNumber, AD_Column_ID 583367) and 4 AD_Field rows, all
+-- of them on business-partner tabs (windows 541887, 542087, 540676 and 123). So the change is
+-- confined to the partner windows, and only in French.
+
+UPDATE AD_Element_Trl SET Name='SIRET', PrintName='SIRET', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 12:00:16','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=581038 AND AD_Language='fr_FR'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(581038,'fr_FR')
+;
+
+UPDATE AD_Element_Trl SET Name='SIRET', PrintName='SIRET', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 12:00:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=581038 AND AD_Language='fr_CH'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(581038,'fr_CH')
+;
+

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5821670_sys_PublicProcurement_C_BPartner_Siren.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5821670_sys_PublicProcurement_C_BPartner_Siren.sql
@@ -1,0 +1,91 @@
+-- New C_BPartner column for French public-procurement invoice references: the business
+-- partner's OWN SIREN, the French legal-entity identifier (9 digits). Optional
+-- (IsMandatory='N') -- it only applies to French partners.
+--
+-- Why SIREN is a NEW column but SIRET is NOT: an earlier version of this task also added a
+-- Siret column -- that was cancelled by the human. There is NO Siret column here. The
+-- partner's own SIRET already lives in the EXISTING C_BPartner.CommercialRegisterNumber
+-- (AD_Column 583367, VARCHAR(60), AD_Element 581038, label FirmenbuchNR), which is reused
+-- as-is; its French translation is handled by another, already-written script. This script
+-- adds Siren and nothing else -- it does NOT modify, re-label, resize, or drop
+-- CommercialRegisterNumber or AD_Element 581038.
+--
+-- Column is VARCHAR(20): a SIREN is a fixed 9 digits, but 20 chars leaves room for the usual
+-- grouping separators (e.g. '123 456 789', 11 chars) while still rejecting input that cannot
+-- be a SIREN at all -- same sizing rationale as the sibling PublicAuthoritySiret column
+-- (5821490_sys_PublicProcurement_C_BPartner_Columns.sql).
+--
+-- Captions: SIREN is a French statutory acronym, written identically in every language, so
+-- the base-language (de_DE) Name/PrintName is 'SIREN' itself -- no German neologism is
+-- coined. en_US, fr_FR and fr_CH are marked IsTranslated='Y' with the same 'SIREN' text
+-- (safe here precisely because the acronym is language-neutral). de_DE/de_CH are left
+-- IsTranslated='N' (they read 'SIREN' from the base column, which is correct).
+--
+-- AD_Table_ID for C_BPartner = 291 (verified via psql against the local stack: `SELECT
+-- ad_table_id FROM ad_table WHERE tablename='C_BPartner';` -> 291).
+-- EntityType='D' (core dictionary metadata; C_BPartner is a core table).
+-- PersonalDataCategory='P' -- matches the existing analogous CommercialRegisterNumber column
+-- (AD_Column 583367) on the same table: C_BPartner rows can represent a natural person /
+-- sole trader, whose own SIREN directly ties the business identity to that person.
+--
+-- IDs allocated from the central ID server:
+--   AD_MigrationScript 5821670  (this script's prefix)
+--   AD_Element  585403  (Siren)
+--   AD_Column   593462  (C_BPartner.Siren)
+--
+-- Do NOT touch: any existing migration file; C_Order; C_Invoice; CommercialRegisterNumber;
+-- AD_Element 581038; any window, tab or field row (window placement is a separate task).
+
+-- ============================================================
+-- Column: C_BPartner.Siren
+-- ============================================================
+
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585403 /*From ID Server*/,0,'Siren',TO_TIMESTAMP('2026-09-01 13:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','SIREN','SIREN',TO_TIMESTAMP('2026-09-01 13:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585403
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- SIREN is a language-neutral French statutory acronym: en_US, fr_FR and fr_CH all carry the
+-- same text as the base column, marked translated. de_DE/de_CH intentionally stay
+-- IsTranslated='N' (no German coinage -- they fall back to the 'SIREN' base text, which is
+-- correct here).
+UPDATE AD_Element_Trl SET Name='SIREN', PrintName='SIREN', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 13:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585403 AND AD_Language='en_US'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585403,'en_US')
+;
+
+UPDATE AD_Element_Trl SET Name='SIREN', PrintName='SIREN', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 13:00:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585403 AND AD_Language='fr_FR'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585403,'fr_FR')
+;
+
+UPDATE AD_Element_Trl SET Name='SIREN', PrintName='SIREN', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-01 13:00:06','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585403 AND AD_Language='fr_CH'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585403,'fr_CH')
+;
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,PersonalDataCategory,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593462 /*From ID Server*/,585403,0,10,291,'Siren',TO_TIMESTAMP('2026-09-01 13:01:00','YYYY-MM-DD HH24:MI:SS'),100,'N','D',0,20,'Y','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N',0,'SIREN','P',0,0,TO_TIMESTAMP('2026-09-01 13:01:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=593462
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+/* DDL */ select update_Column_Translation_From_AD_Element(585403)
+;
+
+/* DDL */ SELECT public.db_alter_table('C_BPartner','ALTER TABLE public.C_BPartner ADD COLUMN Siren VARCHAR(20)')
+;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5822150_sys_PublicProcurement_German_Captions.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5822150_sys_PublicProcurement_German_Captions.sql
@@ -1,0 +1,117 @@
+-- Mark the de_DE and de_CH translations of the four French public-procurement AD_Elements as
+-- actually translated (IsTranslated='Y'), carrying the FRENCH statutory term rather than an
+-- accidental fallback.
+--
+-- Background: AD_Element 585393 (PublicProcurementMarketNo), 585394 (PublicProcurementCommitmentNo),
+-- 585397 (PublicProcurementServiceCode) and 585398 (PublicAuthoritySiret) were created by
+-- 5821370_sys_PublicProcurement_C_Order_Columns.sql / 5821490_sys_PublicProcurement_C_BPartner_Columns.sql
+-- with the FRENCH STATUTORY TERM in the BASE-language Name/PrintName ('Marché', 'Engagement',
+-- 'Code service', 'SIRET État'). Their skeleton AD_Element_Trl INSERT copied that base text into
+-- every active system language, including de_DE and de_CH, with IsTranslated='N' — correct text
+-- (verified: it already equals the French statutory term), but marked as an unverified fallback.
+--
+-- Decision (human, 2026-09-03): German carries the French term for these four fields. The
+-- metasfresh terminology glossary has no entry for these French public-procurement statutory
+-- terms (Marché/Engagement/Code service/SIRET État are references to a specific French public
+-- tender document, not general business vocabulary), and rather than coining German wording for
+-- concepts that have no German equivalent, the French term is used as-is. This script does NOT
+-- change any wording — the text in AD_Element_Trl already equals the French statutory term — it
+-- only flips de_DE/de_CH to IsTranslated='Y' so the fallback becomes a deliberate translation, and
+-- re-propagates via update_TRL_Tables_On_AD_Element_TRL_Update() so the dependent AD_Column_Trl /
+-- AD_Field_Trl / AD_Tab_Trl rows pick up the now-authoritative status.
+--
+-- Out of scope, explicitly NOT touched by this script:
+--   * AD_Element 581038 (CommercialRegisterNumber) — German text 'FirmenbuchNR' is correct German
+--     and stays. Its French translation is already 'SIRET' (set by
+--     5821620_sys_PublicProcurement_French_Translations.sql). Overwriting German with French here
+--     would regress four business-partner windows (581038 backs 1 AD_Column + 4 AD_Field rows).
+--   * AD_Element 585403 (Siren) — its caption 'SIREN' is an acronym, identical in every language.
+--     Verified via psql against the local stack: de_DE/de_CH text is already 'SIREN' (matching
+--     fr_FR/fr_CH), only IsTranslated='N'. Flipped to 'Y' below with NO text change — this is not
+--     a French-into-German substitution, it is confirming an already-correct acronym.
+--
+-- No new IDs needed (updating existing rows only).
+-- AD_MigrationScript 5822150 allocated from the central ID server.
+
+-- ============================================================
+-- AD_Element 585393 (PublicProcurementMarketNo) — 'Marché'
+-- ============================================================
+
+UPDATE AD_Element_Trl SET Name='Marché', PrintName='Marché', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-03 09:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585393 AND AD_Language='de_DE'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585393,'de_DE')
+;
+
+UPDATE AD_Element_Trl SET Name='Marché', PrintName='Marché', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-03 09:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585393 AND AD_Language='de_CH'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585393,'de_CH')
+;
+
+-- ============================================================
+-- AD_Element 585394 (PublicProcurementCommitmentNo) — 'Engagement'
+-- ============================================================
+
+UPDATE AD_Element_Trl SET Name='Engagement', PrintName='Engagement', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-03 09:00:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585394 AND AD_Language='de_DE'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585394,'de_DE')
+;
+
+UPDATE AD_Element_Trl SET Name='Engagement', PrintName='Engagement', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-03 09:00:06','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585394 AND AD_Language='de_CH'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585394,'de_CH')
+;
+
+-- ============================================================
+-- AD_Element 585397 (PublicProcurementServiceCode) — 'Code service'
+-- ============================================================
+
+UPDATE AD_Element_Trl SET Name='Code service', PrintName='Code service', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-03 09:00:08','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585397 AND AD_Language='de_DE'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585397,'de_DE')
+;
+
+UPDATE AD_Element_Trl SET Name='Code service', PrintName='Code service', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-03 09:00:10','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585397 AND AD_Language='de_CH'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585397,'de_CH')
+;
+
+-- ============================================================
+-- AD_Element 585398 (PublicAuthoritySiret) — 'SIRET État'
+-- ============================================================
+
+UPDATE AD_Element_Trl SET Name='SIRET État', PrintName='SIRET État', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-03 09:00:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585398 AND AD_Language='de_DE'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585398,'de_DE')
+;
+
+UPDATE AD_Element_Trl SET Name='SIRET État', PrintName='SIRET État', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-03 09:00:14','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585398 AND AD_Language='de_CH'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585398,'de_CH')
+;
+
+-- ============================================================
+-- AD_Element 585403 (Siren) — acronym confirmation only, NO text change
+-- ============================================================
+-- de_DE/de_CH text is already 'SIREN' (verified via psql before writing this script) — this is
+-- the same acronym in every language, not a French-into-German substitution. Only IsTranslated is
+-- flipped, from 'N' (accidental fallback) to 'Y' (confirmed correct).
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-03 09:00:16','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585403 AND AD_Language='de_DE'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585403,'de_DE')
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-03 09:00:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585403 AND AD_Language='de_CH'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585403,'de_CH')
+;


### PR DESCRIPTION
French public bodies require a set of statutory references on the invoices they receive. This
adds the columns that hold them, so they can be captured once at their natural source and read
from there.

## What this adds

| Table | Column | Holds |
|---|---|---|
| `C_Order` | `PublicProcurementMarketNo` | the market number agreed for the contract |
| `C_Order` | `PublicProcurementCommitmentNo` | the commitment number |
| `C_BPartner` | `PublicProcurementServiceCode` | the code that routes the invoice inside the receiving authority |
| `C_BPartner` | `PublicAuthoritySiret` | the authority's own establishment identifier |
| `C_BPartner` | `Siren` | the partner's nine-digit legal-entity identifier |

The partner's own establishment identifier is **not** duplicated: `CommercialRegisterNumber`
already holds it and is reused unchanged.

All columns are optional, since they only apply to public-sector orders, and portal-neutral by
name so they survive a change of submission platform.

## Where the values are stored, and where they are not

Each value has exactly one writable home, on the order or on the partner. **Nothing is added to
`C_Invoice`** — no columns and no `ColumnSQL` columns. An order-sourced value is a per-transaction
fact and is corrected on the order; a partner-sourced value is master data and is corrected on the
partner. That leaves no way for an invoice to diverge from the record it bills.

## Captions

The terminology glossary has no entry for these French statutory terms, so no German wording is
coined here. Each element carries the French statutory term as its base-language name — taken
verbatim from the reference document, not composed — with an English caption alongside, and French
is marked as an actual translation rather than an accidental fallback of the base text.

German therefore falls back to the base text pending a glossary answer. That is deliberate and
recorded, not an oversight.

One shared element is also translated: the commercial-register number reads the German label in
French, so a French user was shown a German word for the field they know as the SIRET. Only the
French translations change; the base name and the German translations are untouched. That element
backs one column and four fields, all on business-partner tabs.

## Not included

Printing these values is deliberately **not** in this PR. No report or layout is changed here.

## Verification

Every migration was applied to a customer-flavoured database and the resulting state queried
directly — physical column types, non-null `AD_Column.Name`, table ids, and the per-language
`IsTranslated` state. CI's `db-apply-migrations` and `health check` jobs are the authoritative
verdict and are green.
