### PR TITLE
MobileUI Picking — order the launcher caption product names by sales-order line

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJob.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJob.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableList;
+
+import java.util.Comparator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -588,10 +590,15 @@ public final class PickingJob implements PickingJobHeaderOrLine
 	@NonNull
 	public ImmutableList<ITranslatableString> getProductNameParts()
 	{
-		// distinct by ProductId (never by displayed text, so two distinct products sharing a name both appear);
-		// filter preserves encounter order, so the names read in line order.
+		// distinct by ProductId (never by displayed text, so two distinct products sharing a name both appear).
+		// Order by the sales-order line (C_OrderLine.Line, carried on each line as orderLineSeqNo — already loaded,
+		// no query here), tie-broken by the picking-job-line id: a stable, meaningful caption order that matches the
+		// order the picker reads off the sales document. Sorting happens HERE (caption-only) so PickingJob.lines'
+		// own order is left untouched for the workflow logic that iterates it.
 		return lines.stream()
 				.filter(StreamUtils.distinctByKey(PickingJobLine::getProductId))
+				.sorted(Comparator.comparingInt(PickingJobLine::getOrderLineSeqNo)
+						.thenComparingInt(line -> line.getId().getRepoId()))
 				.map(line -> line.getProductValueAndName().getName())
 				.collect(ImmutableList.toImmutableList());
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJob.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJob.java
@@ -26,8 +26,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableList;
-
-import java.util.Comparator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -63,6 +61,7 @@ import org.eevolution.api.PPOrderId;
 import javax.annotation.Nullable;
 import java.time.ZonedDateTime;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -584,8 +583,8 @@ public final class PickingJob implements PickingJobHeaderOrLine
 	}
 
 	/**
-	 * Un-joined product names, in encounter order. The caller decides the separator — see
-	 * {@link #getProductNamesJoined(String)}.
+	 * Un-joined product names, in sales-order line order (see the sort below). The caller decides the
+	 * separator — see {@link #getProductNamesJoined(String)}.
 	 */
 	@NonNull
 	public ImmutableList<ITranslatableString> getProductNameParts()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServices.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServices.java
@@ -68,6 +68,7 @@ public class DefaultPickingJobLoaderSupportingServices implements PickingJobLoad
 	private final HashMap<PickingSlotId, PickingSlotIdAndCaption> pickingSlotIdAndCaptionsCache = new HashMap<>();
 	private final HashMap<ProductId, ProductInfo> productInfoCache = new HashMap<>();
 	private final HashMap<LocatorId, String> locatorNamesCache = new HashMap<>();
+	private final HashMap<OrderAndLineId, Integer> salesOrderLineSeqNosCache = new HashMap<>();
 
 	@Override
 	public PickingJobOptions getPickingJobOptions(@Nullable final BPartnerId customerId) {return profileService.getPickingJobOptions(customerId);}
@@ -183,9 +184,15 @@ public class DefaultPickingJobLoaderSupportingServices implements PickingJobLoad
 	}
 
 	@Override
+	public void warmUpSalesOrderLineSeqNosCache(@NonNull final Set<OrderAndLineId> orderAndLineIds)
+	{
+		CollectionUtils.getAllOrLoad(salesOrderLineSeqNosCache, orderAndLineIds, orderService::getSalesOrderLineSeqNos);
+	}
+
+	@Override
 	public int getSalesOrderLineSeqNo(@NonNull final OrderAndLineId orderAndLineId)
 	{
-		return orderService.getSalesOrderLineSeqNo(orderAndLineId);
+		return salesOrderLineSeqNosCache.computeIfAbsent(orderAndLineId, orderService::getSalesOrderLineSeqNo);
 	}
 
 	//

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaver.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaver.java
@@ -221,6 +221,7 @@ class PickingJobLoaderAndSaver extends PickingJobSaver
 
 		loadingSupportingServices.warmUpSalesOrderDocumentNosCache(extractSalesOrderIdsFromCachedObjects());
 		loadingSupportingServices.warmUpBPartnerNamesCache(extractCustomerIdsFromCachedObjects());
+		loadingSupportingServices.warmUpSalesOrderLineSeqNosCache(extractSalesOrderAndLineIdsFromCachedLines(pickingJobIds));
 
 		warmUpCarrierServicesByLineId(pickingJobIds);
 
@@ -315,11 +316,7 @@ class PickingJobLoaderAndSaver extends PickingJobSaver
 				.lines(pickingJobLines.get(pickingJobId)
 						.stream()
 						.map(lineRecord -> loadLine(lineRecord, pickingJobHeader.getAggregationType()))
-						// Order the caption's product names by the sales-order line (C_OrderLine.Line): stable AND matching
-						// the order the picker reads off the sales document. Tie-break by the picking-job-line id so the
-						// order is fully deterministic even when two lines share a sales-order-line SeqNo.
-						.sorted(Comparator.comparingInt(PickingJobLine::getOrderLineSeqNo)
-								.thenComparingInt(line -> line.getId().getRepoId()))
+						.sorted(Comparator.comparing(PickingJobLine::getId)) // make sure we have a predictable order
 						.collect(ImmutableList.toImmutableList()))
 				.pickFromAlternatives(pickingJobHUAlternatives.get(pickingJobId)
 						.stream()
@@ -611,9 +608,19 @@ class PickingJobLoaderAndSaver extends PickingJobSaver
 		return OrderAndLineId.ofRepoIds(extractSalesOrderId(record), record.getC_OrderLine_ID());
 	}
 
+	// Reads the sales-order-line SeqNo (C_OrderLine.Line) from the loader cache warmed by warmUpSalesOrderLineSeqNos
+	// in loadRecordsFromDB — a cache hit, no query, even when called from a comparator.
 	private int extractOrderLineSeqNo(final @NotNull I_M_Picking_Job_Line record)
 	{
 		return loadingSupportingServices.getSalesOrderLineSeqNo(extractSalesOrderAndLineId(record));
+	}
+
+	private ImmutableSet<OrderAndLineId> extractSalesOrderAndLineIdsFromCachedLines(@NonNull final Set<PickingJobId> pickingJobIds)
+	{
+		return pickingJobIds.stream()
+				.flatMap(pickingJobId -> pickingJobLines.get(pickingJobId).stream())
+				.map(PickingJobLoaderAndSaver::extractSalesOrderAndLineId)
+				.collect(ImmutableSet.toImmutableSet());
 	}
 
 	@NonNull
@@ -871,10 +878,11 @@ class PickingJobLoaderAndSaver extends PickingJobSaver
 	private PickingJobCandidateProducts extractProducts(final PickingJobId pickingJobId)
 	{
 		final PickingJobCandidateProductsCollector collector = new PickingJobCandidateProductsCollector();
-		// Sorted for the same reason loadPickingJob sorts its lines: this collection's iteration order becomes the
-		// order of the launcher caption's product names, so an unordered scan would render them differently run to run.
-		// The order is the sales-order line (C_OrderLine.Line), tie-broken by the picking-job-line id — same contract
-		// as loadPickingJob, so the launcher-list caption and the opened job's detail agree.
+		// This collection's iteration order becomes the order of the launcher-list caption's product names, so an
+		// unordered scan would render them differently run to run. Order by the sales-order line (C_OrderLine.Line),
+		// tie-broken by the picking-job-line id — the SAME order PickingJob.getProductNameParts uses for the opened
+		// job, so the launcher-list caption and the opened job's detail agree. The seq numbers are already batch-warmed
+		// into the loader cache by loadRecordsFromDB (see warmUpSalesOrderLineSeqNos), so this sort issues no query.
 		final ImmutableList<I_M_Picking_Job_Line> linesInPredictableOrder = this.pickingJobLines.get(pickingJobId)
 				.stream()
 				.sorted(Comparator.comparingInt(this::extractOrderLineSeqNo)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaver.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaver.java
@@ -315,7 +315,11 @@ class PickingJobLoaderAndSaver extends PickingJobSaver
 				.lines(pickingJobLines.get(pickingJobId)
 						.stream()
 						.map(lineRecord -> loadLine(lineRecord, pickingJobHeader.getAggregationType()))
-						.sorted(Comparator.comparing(PickingJobLine::getId)) // make sure we have a predictable order
+						// Order the caption's product names by the sales-order line (C_OrderLine.Line): stable AND matching
+						// the order the picker reads off the sales document. Tie-break by the picking-job-line id so the
+						// order is fully deterministic even when two lines share a sales-order-line SeqNo.
+						.sorted(Comparator.comparingInt(PickingJobLine::getOrderLineSeqNo)
+								.thenComparingInt(line -> line.getId().getRepoId()))
 						.collect(ImmutableList.toImmutableList()))
 				.pickFromAlternatives(pickingJobHUAlternatives.get(pickingJobId)
 						.stream()
@@ -607,6 +611,11 @@ class PickingJobLoaderAndSaver extends PickingJobSaver
 		return OrderAndLineId.ofRepoIds(extractSalesOrderId(record), record.getC_OrderLine_ID());
 	}
 
+	private int extractOrderLineSeqNo(final @NotNull I_M_Picking_Job_Line record)
+	{
+		return loadingSupportingServices.getSalesOrderLineSeqNo(extractSalesOrderAndLineId(record));
+	}
+
 	@NonNull
 	private static Quantity extractQtyToPick(final @NotNull I_M_Picking_Job_Line record)
 	{
@@ -864,9 +873,12 @@ class PickingJobLoaderAndSaver extends PickingJobSaver
 		final PickingJobCandidateProductsCollector collector = new PickingJobCandidateProductsCollector();
 		// Sorted for the same reason loadPickingJob sorts its lines: this collection's iteration order becomes the
 		// order of the launcher caption's product names, so an unordered scan would render them differently run to run.
+		// The order is the sales-order line (C_OrderLine.Line), tie-broken by the picking-job-line id — same contract
+		// as loadPickingJob, so the launcher-list caption and the opened job's detail agree.
 		final ImmutableList<I_M_Picking_Job_Line> linesInPredictableOrder = this.pickingJobLines.get(pickingJobId)
 				.stream()
-				.sorted(Comparator.comparingInt(I_M_Picking_Job_Line::getM_Picking_Job_Line_ID))
+				.sorted(Comparator.comparingInt(this::extractOrderLineSeqNo)
+						.thenComparingInt(I_M_Picking_Job_Line::getM_Picking_Job_Line_ID))
 				.collect(ImmutableList.toImmutableList());
 		for (final I_M_Picking_Job_Line line : linesInPredictableOrder)
 		{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderSupportingServices.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderSupportingServices.java
@@ -58,6 +58,9 @@ public interface PickingJobLoaderSupportingServices
 
 	int getSalesOrderLineSeqNo(@NonNull OrderAndLineId orderAndLineId);
 
+	/** Batch-load the sales-order-line SeqNos (C_OrderLine.Line) for these lines in ONE query, so later per-line reads are cache hits. */
+	void warmUpSalesOrderLineSeqNosCache(@NonNull Set<OrderAndLineId> orderAndLineIds);
+
 	ProductValueAndName getProductValueAndName(@NonNull ProductId productId);
 
 	HUPIItemProduct getPackingInfo(@NonNull HUPIItemProductId huPIItemProductId);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/salesorder/PickingJobSalesOrderService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/salesorder/PickingJobSalesOrderService.java
@@ -1,11 +1,11 @@
 package de.metas.handlingunits.picking.job.service.external.salesorder;
 
+import com.google.common.collect.ImmutableMap;
 import de.metas.order.IOrderBL;
 import de.metas.order.IOrderDAO;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderId;
 import de.metas.util.Services;
-import com.google.common.collect.ImmutableMap;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/salesorder/PickingJobSalesOrderService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/salesorder/PickingJobSalesOrderService.java
@@ -5,6 +5,7 @@ import de.metas.order.IOrderDAO;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderId;
 import de.metas.util.Services;
+import com.google.common.collect.ImmutableMap;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,5 +33,12 @@ public class PickingJobSalesOrderService
 	public int getSalesOrderLineSeqNo(@NonNull final OrderAndLineId orderAndLineId)
 	{
 		return orderDAO.getOrderLineById(orderAndLineId).getLine();
+	}
+
+	public Map<OrderAndLineId, Integer> getSalesOrderLineSeqNos(@NonNull final Collection<OrderAndLineId> orderAndLineIds)
+	{
+		return orderDAO.getOrderLinesByIds(orderAndLineIds)
+				.entrySet().stream()
+				.collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().getLine()));
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/MockedPickingJobLoaderSupportingServices.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/MockedPickingJobLoaderSupportingServices.java
@@ -39,6 +39,13 @@ public class MockedPickingJobLoaderSupportingServices implements PickingJobLoade
 {
 	public static final ZoneId ZONE_ID = ZoneId.of("Europe/London");
 	private final HashMap<HuId, HUQRCode> qrCodes = new HashMap<>();
+	/** Sales-order-line SeqNo (C_OrderLine.Line) per line, keyed as the loader keys it. Absent -> 0, so tests that don't care are unaffected. */
+	private final HashMap<OrderAndLineId, Integer> salesOrderLineSeqNos = new HashMap<>();
+
+	public void setSalesOrderLineSeqNo(@NonNull final OrderAndLineId orderAndLineId, final int seqNo)
+	{
+		salesOrderLineSeqNos.put(orderAndLineId, seqNo);
+	}
 
 	@Override
 	public PickingJobOptions getPickingJobOptions(@Nullable final BPartnerId customerId) {return MobileUIPickingUserProfile.DEFAULT.getDefaultPickingJobOptions();}
@@ -106,7 +113,7 @@ public class MockedPickingJobLoaderSupportingServices implements PickingJobLoade
 	@Override
 	public int getSalesOrderLineSeqNo(@NonNull final OrderAndLineId orderAndLineId)
 	{
-		return 0;
+		return salesOrderLineSeqNos.getOrDefault(orderAndLineId, 0);
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/MockedPickingJobLoaderSupportingServices.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/MockedPickingJobLoaderSupportingServices.java
@@ -111,6 +111,12 @@ public class MockedPickingJobLoaderSupportingServices implements PickingJobLoade
 	}
 
 	@Override
+	public void warmUpSalesOrderLineSeqNosCache(@NonNull final Set<OrderAndLineId> orderAndLineIds)
+	{
+		// no-op: getSalesOrderLineSeqNo already serves from the in-memory map
+	}
+
+	@Override
 	public int getSalesOrderLineSeqNo(@NonNull final OrderAndLineId orderAndLineId)
 	{
 		return salesOrderLineSeqNos.getOrDefault(orderAndLineId, 0);

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaverProductOrderTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaverProductOrderTest.java
@@ -6,9 +6,11 @@ import de.metas.business.BusinessTestHelper;
 import de.metas.handlingunits.model.I_M_Picking_Job;
 import de.metas.handlingunits.model.I_M_Picking_Job_Line;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobAggregationType;
+import de.metas.handlingunits.picking.job.model.PickingJob;
 import de.metas.handlingunits.picking.job.model.PickingJobDocStatus;
 import de.metas.handlingunits.picking.job.model.PickingJobId;
 import de.metas.handlingunits.picking.job.model.PickingJobReference;
+import de.metas.order.OrderAndLineId;
 import de.metas.organization.OrgId;
 import org.adempiere.ad.wrapper.POJOLookupMap;
 import org.adempiere.ad.wrapper.POJONextIdSuppliers;
@@ -26,7 +28,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * The launcher caption of an already-started picking job joins the job's product names, and that
  * order is the order {@code extractProducts} iterates the job's lines in. The lines arrive from a
  * query with no {@code ORDER BY}, so the loader has to impose the order itself — otherwise the same
- * job renders its products differently from one load to the next.
+ * job renders its products differently from one load to the next. The order it imposes is the
+ * sales-order line order (C_OrderLine.Line): stable AND matching the order the picker reads off the
+ * sales document, rather than the internal M_Picking_Job_Line_ID, which is stable but arbitrary.
  * <p>
  * JUnit is the right tier here rather than Playwright or Cucumber: the invariant is a pure in-memory
  * ordering contract of the loader, reachable without a database because {@code addAlreadyLoadedFromDB}
@@ -64,37 +68,55 @@ class PickingJobLoaderAndSaverProductOrderTest
 		return job;
 	}
 
-	private I_M_Picking_Job_Line createLine(final I_M_Picking_Job job, final int productRepoId, final int shipmentScheduleRepoId)
+	private static final int SALES_ORDER_ID = 500;
+
+	private I_M_Picking_Job_Line createLine(
+			final I_M_Picking_Job job,
+			final int productRepoId,
+			final int shipmentScheduleRepoId,
+			final int salesOrderLineRepoId,
+			final int salesOrderLineSeqNo)
 	{
 		final I_M_Picking_Job_Line line = InterfaceWrapperHelper.newInstance(I_M_Picking_Job_Line.class);
 		line.setAD_Org_ID(orgId.getRepoId());
 		line.setM_Picking_Job_ID(job.getM_Picking_Job_ID());
 		line.setM_Product_ID(productRepoId);
 		line.setM_ShipmentSchedule_ID(shipmentScheduleRepoId);
+		line.setC_Order_ID(SALES_ORDER_ID);
+		line.setC_OrderLine_ID(salesOrderLineRepoId);
+		// the full-job load path (loadById -> loadLine) needs a delivery BP location on each line
+		line.setC_BPartner_ID(700);
+		line.setC_BPartner_Location_ID(701);
 		line.setC_UOM_ID(uomEach.getC_UOM_ID());
 		line.setQtyToPick(BigDecimal.ONE);
 		line.setIsActive(true);
 		InterfaceWrapperHelper.saveRecord(line);
+		loadingSupportServices.setSalesOrderLineSeqNo(
+				OrderAndLineId.ofRepoIds(SALES_ORDER_ID, salesOrderLineRepoId),
+				salesOrderLineSeqNo);
 		return line;
 	}
 
 	@Test
-	void productNames_followLineIdOrder_whateverOrderTheLinesWereLoadedIn()
+	void productNames_followSalesOrderLineOrder_whateverOrderTheLinesWereLoadedIn()
 	{
 		final I_M_Picking_Job job = createJob();
-		// Product ids deliberately do NOT ascend with the line ids, so the expected string below is
-		// reached only by sorting on the LINE id: a sort on ProductId would yield 101,102,103 and a
-		// sort on nothing would yield the reversed feed order, and both differ from it.
-		final ImmutableList<I_M_Picking_Job_Line> linesInIdOrder = ImmutableList.of(
-				createLine(job, 103, 201),
-				createLine(job, 101, 202),
-				createLine(job, 102, 203));
+		// Three axes are deliberately made to disagree so only a sort on the SALES-ORDER-LINE SeqNo
+		// (C_OrderLine.Line) can yield the expected string:
+		//   creation / line-id order : 103, 101, 102   (the OLD behaviour — a sort on M_Picking_Job_Line_ID)
+		//   product-id order         : 101, 102, 103
+		//   sales-order-line SeqNo   :  20,  30,  10  -> ordered: 102(10), 103(20), 101(30)
+		// so the expected below matches none of the others.
+		final ImmutableList<I_M_Picking_Job_Line> linesInCreationOrder = ImmutableList.of(
+				createLine(job, 103, 201, 5031, 20),
+				createLine(job, 101, 202, 5032, 30),
+				createLine(job, 102, 203, 5033, 10));
 
 		final PickingJobLoaderAndSaver loader = PickingJobLoaderAndSaver.forLoading(loadingSupportServices);
 		loader.addAlreadyLoadedFromDB(job);
 		// fed in REVERSE: this is what an unordered query may hand back, and it is exactly what an
 		// unsorted implementation would leak into the caption
-		linesInIdOrder.reverse().forEach(loader::addAlreadyLoadedFromDB);
+		linesInCreationOrder.reverse().forEach(loader::addAlreadyLoadedFromDB);
 
 		final PickingJobId pickingJobId = PickingJobId.ofRepoId(job.getM_Picking_Job_ID());
 		final PickingJobReference reference = loader.streamPickingJobReferences(ImmutableSet.of(pickingJobId))
@@ -102,6 +124,27 @@ class PickingJobLoaderAndSaverProductOrderTest
 				.orElseThrow(() -> new AssertionError("no PickingJobReference loaded"));
 
 		assertThat(reference.getProducts().getProductNamesJoined(", ").getDefaultValue())
-				.isEqualTo("productName-103, productName-101, productName-102");
+				.isEqualTo("productName-102, productName-103, productName-101");
+	}
+
+	@Test
+	void openedJobProductNames_followSalesOrderLineOrder_matchingTheLauncherList()
+	{
+		// The opened job's ProductNames caption (PickingJob.getProductNamesJoined, DisplayValueProvider:225) must
+		// order the same way as the launcher-list caption above, so the two never disagree for the same job.
+		final I_M_Picking_Job job = createJob();
+		final ImmutableList<I_M_Picking_Job_Line> linesInCreationOrder = ImmutableList.of(
+				createLine(job, 103, 201, 5031, 20),
+				createLine(job, 101, 202, 5032, 30),
+				createLine(job, 102, 203, 5033, 10));
+
+		final PickingJobLoaderAndSaver loader = PickingJobLoaderAndSaver.forLoading(loadingSupportServices);
+		loader.addAlreadyLoadedFromDB(job);
+		linesInCreationOrder.reverse().forEach(loader::addAlreadyLoadedFromDB);
+
+		final PickingJob loaded = loader.loadById(PickingJobId.ofRepoId(job.getM_Picking_Job_ID()));
+
+		assertThat(loaded.getProductNamesJoined(", ").getDefaultValue())
+				.isEqualTo("productName-102, productName-103, productName-101");
 	}
 }


### PR DESCRIPTION
### What

Fix the **intermittent CI failures** of the MobileUI picking launcher-caption specs `e2e/mobile-webui/tests/spec/picking/productNamesDetail.spec.js` and `productNames.spec.js`, by making the launcher caption's product-name order **deterministic** — sales-order line (`C_OrderLine.Line`) instead of the arbitrary `M_Picking_Job_Line_ID`.

(This is a tracked known flaky test; the fix↔case linkage is recorded in the internal flaky-test registry — a public PR can't carry that private reference.)

### The flake

Both specs assert one exact caption string via a `hasText` filter on the launcher row (`.wflauncher-button[data-salesorderid=…].filter({hasText: '<docNo> | <bp> | P1, P2, P3'})`). The product-name order in that caption was **arbitrary**: the loader ordered the names by `M_Picking_Job_Line_ID`, which is assigned in the order the *unordered* packageable query returns the lines (`PickingJobCreateCommand.toPackageableQuery` sets no `orderBy`, and `PackagingDAO`'s sort keys don't include the sales-order line). So on a run where the order came out differently from what the spec created, the exact-string `hasText` never matched and the spec timed out — intermittently, once per unlucky data layout.

Evidence this is an ordering flake (not a row-settle/timing one): the failure-time page snapshot showed **all three product names present, in a different order** than asserted — run https://github.com/metasfresh/metasfresh/actions/runs/33594836356.

### Fix

Order both caption paths by `C_OrderLine.Line`, tie-broken by the picking-job-line id, so the caption is deterministic and matches the order the picker reads off the sales document:
- launcher list — `PickingJobLoaderAndSaver.extractProducts`
- opened job — `PickingJob.getProductNameParts` (consumed by `DisplayValueProvider`)

`PickingJob.lines`' own id-order is left untouched (workflow logic that iterates `getLines()` is unaffected). Zero new SQL: the seq numbers are batch-warmed once per load via `warmUpSalesOrderLineSeqNosCache` in `loadRecordsFromDB` (mirrors `warmUpSalesOrderDocumentNosCache`); every read is a cache hit — this also removes a pre-existing per-line query in `loadLine`.

### Tests + validation

`PickingJobLoaderAndSaverProductOrderTest` pins the sales-order-line order for both caption paths (three ordering axes — line-id, product-id, SeqNo — deliberately in disagreement so only a SeqNo sort passes; RED against the old id-sort, GREEN after). Local: `de.metas.handlingunits.base` 1062/0/0, `de.metas.picking.rest-api` 59/0/0, `de.metas.workflow.rest-api` 19/0/0. In CI here, the `mobile test` job — which runs these specs — has passed on every run of this branch, i.e. the flake has not recurred.
