### PR TITLE
MobileUI job start: complete the browserless recovery harness fake page

### DIFF
--- a/e2e/mobile-webui/tests/harness/jobStartRecovery.test.js
+++ b/e2e/mobile-webui/tests/harness/jobStartRecovery.test.js
@@ -30,6 +30,12 @@ let afterTap = {};
 let tapped = [];
 
 const fakePage = {
+    // setCurrentPage attaches a console recorder to whatever page it is given (see
+    // tests/utils/common.js startConsoleRecorder), so a page that cannot register a listener makes
+    // every test in this file throw in beforeEach, before its body runs. Inert is enough: nothing
+    // here asserts on console output.
+    on: () => {},
+    off: () => {},
     locator: (selector) => ({
         waitFor: async () => {
             if (!attached[selector]) {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
@@ -49,10 +49,10 @@ export const DistributionJobsListScreen = {
         return await test.step(`${NAME} Start job for testId "${launcherTestId}"`, async () => {
             for (let attempt = 1; attempt <= JOB_START_TAP_ATTEMPTS; attempt++) {
                 await page.getByTestId(launcherTestId).tap();
-                const arrived = await jobScreenElement()
+                const hasArrived = await jobScreenElement()
                     .waitFor({ state: 'attached', timeout: JOB_START_ARRIVAL_TIMEOUT })
                     .then(() => true, () => false);
-                if (arrived || attempt === JOB_START_TAP_ATTEMPTS) {
+                if (hasArrived || attempt === JOB_START_TAP_ATTEMPTS) {
                     break;
                 }
                 if ((await recoverToLauncherList({ applicationId: 'distribution' })) === 'unknown') {

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -96,10 +96,10 @@ export const PickingJobsListScreen = {
             return await test.step(`${NAME} - Start job by documentNo ${documentNo}`, async () => {
                 for (let attempt = 1; attempt <= JOB_START_TAP_ATTEMPTS; attempt++) {
                     await locateJobButtons({ documentNo }).tap();
-                    const arrived = await jobScreenElement()
+                    const hasArrived = await jobScreenElement()
                         .waitFor({ state: 'attached', timeout: JOB_START_ARRIVAL_TIMEOUT })
                         .then(() => true, () => false);
-                    if (arrived || attempt === JOB_START_TAP_ATTEMPTS) {
+                    if (hasArrived || attempt === JOB_START_TAP_ATTEMPTS) {
                         break;
                     }
                     if ((await recoverToLauncherList({ applicationId: 'picking' })) === 'unknown') {
@@ -201,10 +201,10 @@ const tapLauncherUntilJobScreen = async ({ index, qtyToDeliver, customerLocation
         const target = await resolveLauncherTapTarget({ index, qtyToDeliver, customerLocationId, settleTimeout });
         await target.tap();
 
-        const arrived = await jobScreenElement()
+        const hasArrived = await jobScreenElement()
             .waitFor({ state: 'attached', timeout: JOB_START_ARRIVAL_TIMEOUT })
             .then(() => true, () => false);
-        if (arrived || attempt === JOB_START_TAP_ATTEMPTS) {
+        if (hasArrived || attempt === JOB_START_TAP_ATTEMPTS) {
             break;
         }
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/launchers.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/launchers.js
@@ -103,7 +103,7 @@ export const useLaunchersWebsocket = ({
     // ws.disconnectClient is async, so a frame can still be delivered after this effect's cleanup ran and
     // the screen unmounted -- in the captured failure the STOMP DISCONNECT was logged BEFORE the deleting
     // MESSAGE. An unmounted subscription must not write to the store at all.
-    let subscriptionActive = true;
+    let isSubscriptionActive = true;
     if (enabled) {
       const topic = `/v2/userWorkflows/launchers/?${toQueryString({
         userToken,
@@ -119,7 +119,7 @@ export const useLaunchersWebsocket = ({
         topic,
         debug: !!window?.debug_ws,
         onWebsocketMessage: (message) => {
-          if (!subscriptionActive) return;
+          if (!isSubscriptionActive) return;
           const applicationLaunchers = JSON.parse(message.body);
           onWebsocketMessage({ applicationId, applicationLaunchers });
         },
@@ -127,7 +127,7 @@ export const useLaunchersWebsocket = ({
     }
 
     return () => {
-      subscriptionActive = false;
+      isSubscriptionActive = false;
       if (client) {
         ws.disconnectClient(client);
         client = null;


### PR DESCRIPTION
Two commits, both confined to naming and to a test double. No functional change anywhere.

## 1. Complete the browserless recovery harness fake page (test-only)

`e2e/mobile-webui/tests/harness/jobStartRecovery.test.js` installs a scripted fake page via `setCurrentPage(fakePage)` in `beforeEach`. The fake implements only `locator()`. This commit gives it inert `on()` / `off()` as well.

### Why — a semantic merge conflict, fixed at the origin

`setCurrentPage` (in `e2e/mobile-webui/tests/utils/common.js`) diverged between branches:

- on this branch it is a bare assignment, so a fake implementing only `locator()` is sufficient;
- on `new_dawn_uat` the same function was independently extended to attach a console recorder, which calls `currentPage.on('console', handler)` and `currentPage.off(handler)`.

So the incomplete fake is only latently broken here. When the harness file reached `new_dawn_uat` the merge was **textually clean** but semantically broken: `beforeEach` called `setCurrentPage(fakePage)`, the recorder tried to register a listener on a page that has none, and all four tests failed deterministically with `TypeError: currentPage.on is not a function` — before any test body ran.

Caught on the merge PR https://github.com/metasfresh/metasfresh/pull/25703 (`mobile test`: 372 passed, 4 failed).

This harness file exists **only** on this branch, which makes this branch the single origin of the trap. Completing the fake here closes it for every branch that later receives the file, instead of repairing it once per destination. The same hunk is already applied and verified on the merge branch, so the two will not conflict when they meet.

Inert is sufficient: nothing in this file asserts on console output, and inert `on`/`off` satisfy both variants of `setCurrentPage`.

## 2. Boolean predicate prefixes (raised in review)

`docs/coding-rules/javascript-general.md` § 1 requires every boolean in JS/JSX/TS — including a plain `const`/`let` in mobile-webui or the `e2e/` suites — to carry an affirmative-predicate prefix (`is`/`has`/`can`/`should`/`was`/`did`/`will`). A bare participle reads as a noun at the call site: `if (arrived)` is ambiguous where `if (hasArrived)` is a question. Past participle takes `has`.

Nine references across three files, renamed at the branch the code was authored on so the names do not diverge from their source and conflict on every future merge train:

| File | Rename | Refs |
|---|---|---|
| `misc/services/mobile-webui/mobile-webui-frontend/src/api/launchers.js` | `subscriptionActive` → `isSubscriptionActive` | 3 |
| `e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js` | `arrived` → `hasArrived` (both sites) | 4 |
| `e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js` | `arrived` → `hasArrived` | 2 |

`launchers.js` is the only production file touched. `isSubscriptionActive` is a local `let` inside one `useEffect` closure with no exported surface, so behaviour is identical. In `PickingJobsListScreen.js` both call sites are renamed — the one in `startJobByDocumentNo` and the pre-existing one in `tapLauncherUntilJobScreen` — rather than leaving an inconsistent third behind. A grep for the old names over the three files returns nothing.

## Verification

Both run locally on this branch at the current HEAD.

**Browserless recovery harness** — `e2e/mobile-webui`, `playwright test tests/harness/jobStartRecovery.test.js --reporter=line`: **4 passed**. Also 4 passed on the unmodified branch tip before commit 1, since the added `on`/`off` are unused until the console recorder arrives — the value of commit 1 is on the destination branches, not here. The test is browserless (no app server, no database).

**mobile-webui frontend jest** — `CI=true react-scripts test --watchAll=false`, full suite unfiltered: **5 failed / 14 passed suites, 13 failed / 203 passed of 216 tests** — and **byte-for-byte identical before and after the renames** (same five suites, same counts), which is the evidence that the renames are behaviour-neutral. Those 13 failures are pre-existing on this branch and unrelated to this PR (QR-code parsing, the manufacturing-issue reducer, `PickLineScanScreen`, `bounceHome`). `launchersFrameAfterTeardownIgnored.test.js` — the suite that actually covers the renamed teardown guard in `launchers.js` — passes in both runs.

## No reformatting

The `e2e/mobile-webui` project ships no eslint or prettier config, and `jobStartRecovery.test.js` already fails default-prettier at HEAD, so everything outside the hunks above is left byte-identical deliberately — reformatting would only bloat the diff.
