### PR TITLE
Delivery Planning: the address filters use a Search reference, not a Table one

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5822030_sys_M_Delivery_Planning_ShipFromTo_Location_Search_Reference.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5822030_sys_M_Delivery_Planning_ShipFromTo_Location_Search_Reference.sql
@@ -1,0 +1,36 @@
+-- 2026-09-02
+-- Delivery Planning: the two address columns become Search (30) instead of Table (18).
+--
+--   AD_Column 593414  M_Delivery_Planning.ShipFrom_Location_ID
+--   AD_Column 593415  M_Delivery_Planning.ShipTo_Location_ID
+--
+-- Both were added by 5821150 with AD_Reference_ID=18 (Table) and IsSelectionColumn='Y'.
+-- A Table reference PRELOADS the whole referenced list to render its widget; a Search
+-- reference queries on typed input and preloads nothing. On a production instance with
+-- ~80k business partners the preload makes the Delivery Planning window unusable as soon
+-- as either address filter is opened. The scrambled local stack carries only a few hundred
+-- C_BPartner_Location rows, which is why this never showed up in local testing.
+--
+-- Confirmed by the product owner: switching both columns to Search fixes the window.
+--
+-- Search is also what every sibling location column already uses, so this brings them into
+-- line rather than inventing a shape:
+--   M_ShipperTransportation.C_BPartner_Location_Loading_ID    ref=30, AD_Reference_Value_ID=159
+--   M_ShipperTransportation.C_BPartner_Location_Delivery_ID   ref=30, AD_Reference_Value_ID=159
+--   M_Delivery_Planning.C_BPartner_Location_ID                ref=30
+--
+-- AD_Reference_Value_ID stays 159 (C_BPartner Location) — correct for a Search reference as
+-- well, per the two M_ShipperTransportation columns above — so it is deliberately not touched.
+--
+-- IsSelectionColumn stays 'Y': the filters are KEPT. LoadingAddress and DeliveryAddress are
+-- two of the eight AggregationKeyField values (DeliveryPlanningList.AggregationKeyField), so a
+-- planner filters on them to find plannings that can be combined into one delivery instruction.
+-- Dropping the filters would have removed two of the eight dimensions that decide combinability.
+
+UPDATE AD_Column
+SET    AD_Reference_ID = 30,
+       Updated         = TO_TIMESTAMP('2026-09-02', 'YYYY-MM-DD'),
+       UpdatedBy       = 99
+WHERE  AD_Column_ID IN (593414 /* ShipFrom_Location_ID */, 593415 /* ShipTo_Location_ID */)
+AND    AD_Reference_ID <> 30
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5822030_sys_M_Delivery_Planning_ShipFromTo_Location_Search_Reference.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5822030_sys_M_Delivery_Planning_ShipFromTo_Location_Search_Reference.sql
@@ -1,36 +1,20 @@
--- 2026-09-02
--- Delivery Planning: the two address columns become Search (30) instead of Table (18).
+-- M_Delivery_Planning: ShipFrom_Location_ID (AD_Column 593414) and ShipTo_Location_ID
+-- (AD_Column 593415) become Search (30) instead of Table (18).
 --
---   AD_Column 593414  M_Delivery_Planning.ShipFrom_Location_ID
---   AD_Column 593415  M_Delivery_Planning.ShipTo_Location_ID
+-- A Table reference makes the filter widget a List, which the frontend preloads in full; a Search
+-- reference is typeahead-only and paged. Over C_BPartner_Location that preload is the whole table,
+-- which makes the window unusable wherever the partner count is large.
 --
--- Both were added by 5821150 with AD_Reference_ID=18 (Table) and IsSelectionColumn='Y'.
--- A Table reference PRELOADS the whole referenced list to render its widget; a Search
--- reference queries on typed input and preloads nothing. On a production instance with
--- ~80k business partners the preload makes the Delivery Planning window unusable as soon
--- as either address filter is opened. The scrambled local stack carries only a few hundred
--- C_BPartner_Location rows, which is why this never showed up in local testing.
+-- AD_Reference_Value_ID stays 159: neither column name follows the <Table>_ID convention, so the
+-- reference value is what identifies C_BPartner_Location. IsSelectionColumn stays 'Y' -- the
+-- columns remain filterable, which is the point.
 --
--- Confirmed by the product owner: switching both columns to Search fixes the window.
---
--- Search is also what every sibling location column already uses, so this brings them into
--- line rather than inventing a shape:
---   M_ShipperTransportation.C_BPartner_Location_Loading_ID    ref=30, AD_Reference_Value_ID=159
---   M_ShipperTransportation.C_BPartner_Location_Delivery_ID   ref=30, AD_Reference_Value_ID=159
---   M_Delivery_Planning.C_BPartner_Location_ID                ref=30
---
--- AD_Reference_Value_ID stays 159 (C_BPartner Location) — correct for a Search reference as
--- well, per the two M_ShipperTransportation columns above — so it is deliberately not touched.
---
--- IsSelectionColumn stays 'Y': the filters are KEPT. LoadingAddress and DeliveryAddress are
--- two of the eight AggregationKeyField values (DeliveryPlanningList.AggregationKeyField), so a
--- planner filters on them to find plannings that can be combined into one delivery instruction.
--- Dropping the filters would have removed two of the eight dimensions that decide combinability.
+-- Sequence number allocated from idserver.metas.de on 2026-09-02.
 
 UPDATE AD_Column
 SET    AD_Reference_ID = 30,
        Updated         = TO_TIMESTAMP('2026-09-02', 'YYYY-MM-DD'),
-       UpdatedBy       = 99
-WHERE  AD_Column_ID IN (593414 /* ShipFrom_Location_ID */, 593415 /* ShipTo_Location_ID */)
+       UpdatedBy       = 100
+WHERE  AD_Column_ID IN (593414, 593415)
 AND    AD_Reference_ID <> 30
 ;


### PR DESCRIPTION
## What

`M_Delivery_Planning.ShipFrom_Location_ID` and `ShipTo_Location_ID` change from `AD_Reference_ID=18` (Table) to `30` (Search). One `UPDATE`, two rows.

## Why

Both columns shipped with a **Table** reference. A Table reference preloads the entire referenced list to render its widget; a **Search** reference queries on typed input and preloads nothing.

On a production instance with roughly **80,000 business partners**, opening either address filter makes the Delivery Planning window unusable.

This did not surface during development because the scrambled local stack holds only a few hundred `C_BPartner_Location` rows. The local row count was never evidence about the instance that crashes — an assumption worth not repeating.

Confirmed working on the affected instance before this script was written.

### The mechanism, traced

Reference 18 and reference 30 diverge at the widget type, and the widget type decides which endpoint the frontend calls:

- `DescriptorsFactoryHelper.extractWidgetType` maps `DisplayType.Table` (18) to `DocumentFieldWidgetType.List`, and `DisplayType.Search` (30) to `Lookup`. A filter parameter inherits the field's widget type verbatim (`StandardDocumentFilterDescriptorsProviderFactory.extractFilterWidgetType`).
- `List` is served by `WidgetRenderer`'s `dropdownValuesSupplier`, and `List.requestListData` fires **eagerly on mount** for the panel's first non-date parameter — so the request goes out as soon as the filter panel renders, with no user interaction.
- That endpoint calls `LookupDataSource.findEntities(ctx)`, which passes `Integer.MAX_VALUE` as the page length, so the query runs as `LIMIT 2147483647` — the entire `C_BPartner_Location` table in one statement.
- `Lookup` (reference 30) has no dropdown code path at all. It is typeahead-only, capped at the descriptor's `pageLength`, default 10.

That also explains why the sibling virtual columns `IsAllocated` / `IsDelivered` are unaffected: they are reference 20, whose `AD_Ref_List` value set is inherently tiny.

Two candidates this rules out:

- **The virtual `ColumnSQL` plays no part.** For reference 18 with `AD_Reference_Value_ID` set, `MLookupFactory.getLookupInfo` builds the lookup purely from the `AD_Ref_Table` row — no join back to `M_Delivery_Planning`, no reference to the non-existent physical column. The filter-apply side resolves the ColumnSQL correctly via `getSqlSelectValue()`.
- **`AD_Column.IsLazyLoading` is irrelevant here** — it is read only by the legacy PO layer and appears nowhere under `de.metas.ui.web.*`.

## Why Search, specifically

It is what every sibling location column already uses, so this brings the two into line rather than inventing a shape:

| column | reference |
|---|---|
| `M_ShipperTransportation.C_BPartner_Location_Loading_ID` | 30, `AD_Reference_Value_ID=159` |
| `M_ShipperTransportation.C_BPartner_Location_Delivery_ID` | 30, `AD_Reference_Value_ID=159` |
| `M_Delivery_Planning.C_BPartner_Location_ID` | 30 |

`AD_Reference_Value_ID` stays `159` (C_BPartner Location) and is deliberately not touched — the two `M_ShipperTransportation` columns above show `159` is correct for a Search reference too, so the existing value carries over.

## The filters are kept

`IsSelectionColumn` stays `'Y'`. Removing the filters was considered and rejected: `LoadingAddress` and `DeliveryAddress` are two of the eight `AggregationKeyField` values (`DeliveryPlanningList.AggregationKeyField`), so a planner filters on them to find plannings that can be combined into one delivery instruction. Dropping them would have removed two of the eight dimensions that decide combinability — and `C_BPartner_Location_ID` is not a substitute, since it is the planning's own partner location rather than the direction-derived ship-from/ship-to.

## Verification

Applied against a local stack carrying the full migration chain:

```
ShipFrom_Location_ID | ref 30 | refval 159 | IsSelectionColumn Y
ShipTo_Location_ID   | ref 30 | refval 159 | IsSelectionColumn Y
```

`AD_Reference_Value_ID` and `IsSelectionColumn` unchanged, as intended. Re-applying the statement reports `UPDATE 0`, so the script is idempotent.

## Scope

One migration script. No DDL, no Java, no layout change — the columns keep their place in the window's "address" element group, in grid and form.