### PR TITLE
Traffic Management — jump from the Auftrags-Board, keeping already-assigned rows visible

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Process.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Process.java
@@ -839,6 +839,29 @@ date:yyyyMMdd_HHmmss}
 	String COLUMNNAME_IsUpdateExportDate = "IsUpdateExportDate";
 
 	/**
+	 * Set Apply target window's default filters.
+	 * When jumping into the target window, also apply that window's default filters. Switched off, the jump shows exactly the related rows.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsUseAutoFilters (boolean IsUseAutoFilters);
+
+	/**
+	 * Get Apply target window's default filters.
+	 * When jumping into the target window, also apply that window's default filters. Switched off, the jump shows exactly the related rows.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isUseAutoFilters();
+
+	ModelColumn<I_AD_Process, Object> COLUMN_IsUseAutoFilters = new ModelColumn<>(I_AD_Process.class, "IsUseAutoFilters", null);
+	String COLUMNNAME_IsUseAutoFilters = "IsUseAutoFilters";
+
+	/**
 	 * Set Use Business Partner Language.
 	 *
 	 * <br>Type: YesNo

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Process.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Process.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class X_AD_Process extends org.compiere.model.PO implements I_AD_Process, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 1719866973L;
+	private static final long serialVersionUID = 1215325079L;
 
     /** Standard Constructor */
     public X_AD_Process (final Properties ctx, final int AD_Process_ID, @Nullable final String trxName)
@@ -468,6 +468,18 @@ public class X_AD_Process extends org.compiere.model.PO implements I_AD_Process,
 	public boolean isUpdateExportDate() 
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsUpdateExportDate);
+	}
+
+	@Override
+	public void setIsUseAutoFilters (final boolean IsUseAutoFilters)
+	{
+		set_Value (COLUMNNAME_IsUseAutoFilters, IsUseAutoFilters);
+	}
+
+	@Override
+	public boolean isUseAutoFilters() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsUseAutoFilters);
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessInfo.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessInfo.java
@@ -128,6 +128,7 @@ public final class ProcessInfo implements Serializable
 		adProcessId = builder.getAD_Process_ID();
 		adRelationTypeId = builder.getAD_RelationType_ID();
 		openTarget = builder.getOpenTarget();
+		useAutoFilters = builder.isUseAutoFilters();
 		pinstanceId = builder.getPInstanceId();
 
 		clientId = builder.getAdClientId();
@@ -198,6 +199,7 @@ public final class ProcessInfo implements Serializable
 	@Getter private final AdProcessId adProcessId;
 	@Getter @Nullable private final RelationTypeId adRelationTypeId;
 	@Getter @Nullable private final ProcessOpenTarget openTarget;
+	@Getter private final boolean useAutoFilters;
 	private final int adTableId;
 	private final int recordId;
 	@Getter private final Set<TableRecordReference> selectedIncludedRecords;
@@ -808,6 +810,7 @@ public final class ProcessInfo implements Serializable
 
 		@Nullable private RelationTypeId adRelationTypeId;
 		@Nullable private ProcessOpenTarget openTarget;
+		@Nullable private Boolean useAutoFilters;
 
 		private ProcessInfoBuilder()
 		{
@@ -1158,6 +1161,27 @@ public final class ProcessInfo implements Serializable
 			return ProcessOpenTarget.ofNullableCode(process.getOpenTarget());
 		}
 
+		/**
+		 * Whether opening the target view (e.g. a relation-type overlay jump) shall also apply the target window's
+		 * own default filters ({@code AD_Process.IsUseAutoFilters}). When there is no {@code AD_Process} behind this
+		 * {@code ProcessInfo} (a programmatically-built one), this returns {@code true} — today's behaviour; only an
+		 * explicit {@code 'N'} on the AD_Process row turns filters off.
+		 */
+		public boolean isUseAutoFilters()
+		{
+			if (useAutoFilters != null)
+			{
+				return useAutoFilters;
+			}
+
+			final I_AD_Process process = getAD_ProcessOrNull();
+			if (process == null)
+			{
+				return true;
+			}
+			return process.isUseAutoFilters();
+		}
+
 		public ProcessInfoBuilder setAD_Process(final org.compiere.model.I_AD_Process adProcess)
 		{
 			this._adProcess = InterfaceWrapperHelper.create(adProcess, I_AD_Process.class);
@@ -1165,6 +1189,7 @@ public final class ProcessInfo implements Serializable
 			setAD_Process_ID(_adProcess.getAD_Process_ID());
 			setAdRelationTypeId(RelationTypeId.ofRepoIdOrNull(_adProcess.getAD_RelationType_ID()));
 			setOpenTarget(ProcessOpenTarget.ofNullableCode(_adProcess.getOpenTarget()));
+			setUseAutoFilters(_adProcess.isUseAutoFilters());
 			setNotifyUserAfterExecution(adProcess.isNotifyUserAfterExecution());
 			setLogWarning(adProcess.isLogWarning());
 			return this;
@@ -1179,6 +1204,12 @@ public final class ProcessInfo implements Serializable
 		public ProcessInfoBuilder setOpenTarget(@Nullable final ProcessOpenTarget openTarget)
 		{
 			this.openTarget = openTarget;
+			return this;
+		}
+
+		public ProcessInfoBuilder setUseAutoFilters(@Nullable final Boolean useAutoFilters)
+		{
+			this.useAutoFilters = useAutoFilters;
 			return this;
 		}
 

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5822090_sys_AD_Process_IsUseAutoFilters.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5822090_sys_AD_Process_IsUseAutoFilters.sql
@@ -1,0 +1,114 @@
+-- New AD_Process.IsUseAutoFilters (YesNo, default 'Y', mandatory) — controls whether opening the
+-- target window of a Type='RelationTypeInOverlay' process also applies that window's own default
+-- filters ('Y', today's behaviour, kept for every existing process) or shows exactly the rows the
+-- relation resolved ('N').
+--
+-- IDs, all from the central ID server:
+--   5822090 - this script's migration filename prefix
+--    585420 - AD_Element (IsUseAutoFilters)
+--    593467 - AD_Column  (AD_Process.IsUseAutoFilters)
+--    784914 - AD_Field   (Bericht & Prozess tab, AD_Tab 245)
+--    654684 - AD_UI_Element (element group 541397, SeqNo 100 — directly after OpenTarget at 90)
+--
+-- Modelled on 5804600_sys_gh29919_AD_Process_OpenTarget.sql (same table/tab/element group).
+
+-- Element: IsUseAutoFilters
+-- 2026-09-03T14:00:00.000Z
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,Description,EntityType,Help,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,585420 /*From ID Server*/,0,'IsUseAutoFilters',TO_TIMESTAMP('2026-09-03 14:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Beim Sprung in das Zielfenster dessen Standardfilter anwenden. Ausgeschaltet zeigt der Sprung genau die verknüpften Zeilen.','D','Beim Sprung in das Zielfenster dessen Standardfilter anwenden. Ausgeschaltet zeigt der Sprung genau die verknüpften Zeilen.','Y','Standardfilter des Zielfensters anwenden','Standardfilter des Zielfensters anwenden',TO_TIMESTAMP('2026-09-03 14:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2026-09-03T14:00:00.000Z
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Element_ID, t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585420 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- DE translation: IsUseAutoFilters element (base language text, flip IsTranslated)
+-- 2026-09-03T14:00:12.000Z
+UPDATE AD_Element_Trl SET Name='Standardfilter des Zielfensters anwenden', PrintName='Standardfilter des Zielfensters anwenden', Description='Beim Sprung in das Zielfenster dessen Standardfilter anwenden. Ausgeschaltet zeigt der Sprung genau die verknüpften Zeilen.', Help='Beim Sprung in das Zielfenster dessen Standardfilter anwenden. Ausgeschaltet zeigt der Sprung genau die verknüpften Zeilen.', IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-09-03 14:00:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE AD_Element_ID=585420 AND AD_Language='de_DE'
+;
+
+-- CH translation: same as DE (no ß, no Swiss term swap applies)
+-- 2026-09-03T14:00:14.000Z
+UPDATE AD_Element_Trl SET Name='Standardfilter des Zielfensters anwenden', PrintName='Standardfilter des Zielfensters anwenden', Description='Beim Sprung in das Zielfenster dessen Standardfilter anwenden. Ausgeschaltet zeigt der Sprung genau die verknüpften Zeilen.', Help='Beim Sprung in das Zielfenster dessen Standardfilter anwenden. Ausgeschaltet zeigt der Sprung genau die verknüpften Zeilen.', IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-09-03 14:00:14','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE AD_Element_ID=585420 AND AD_Language='de_CH'
+;
+
+-- English translation (en_US)
+-- 2026-09-03T14:00:16.000Z
+UPDATE AD_Element_Trl SET Name='Apply target window''s default filters', PrintName='Apply target window''s default filters', Description='When jumping into the target window, also apply that window''s default filters. Switched off, the jump shows exactly the related rows.', Help='When jumping into the target window, also apply that window''s default filters. Switched off, the jump shows exactly the related rows.', IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-09-03 14:00:16','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE AD_Element_ID=585420 AND AD_Language='en_US'
+;
+
+-- Column: AD_Process.IsUseAutoFilters — added NULLABLE first; backfilled and made mandatory below
+-- (YesNo column, no AD_Reference_Value_ID needed for AD_Reference_ID=20)
+-- 2026-09-03T14:01:00.000Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,CloningStrategy,ColumnName,Created,CreatedBy,DDL_NoForeignKey,Description,EntityType,FacetFilterSeqNo,FieldLength,Help,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterInactiveValues,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,PersonalDataCategory,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593467 /*From ID Server*/,585420,0,20,284,'XX','IsUseAutoFilters',TO_TIMESTAMP('2026-09-03 14:01:00','YYYY-MM-DD HH24:MI:SS'),100,'N','Beim Sprung in das Zielfenster dessen Standardfilter anwenden. Ausgeschaltet zeigt der Sprung genau die verknüpften Zeilen.','D',0,1,'Beim Sprung in das Zielfenster dessen Standardfilter anwenden. Ausgeschaltet zeigt der Sprung genau die verknüpften Zeilen.','Y','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N','Y','N',0,'Standardfilter des Zielfensters anwenden','NP',0,0,TO_TIMESTAMP('2026-09-03 14:01:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+-- 2026-09-03T14:01:00.000Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name,Description, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name,t.Description, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=593467 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2026-09-03T14:01:10.000Z
+/* DDL */ select update_Column_Translation_From_AD_Element(585420)
+;
+
+-- 2026-09-03T14:01:20.000Z
+/* DDL */ SELECT public.db_alter_table('AD_Process','ALTER TABLE public.AD_Process ADD COLUMN IsUseAutoFilters CHAR(1)')
+;
+
+-- 2026-09-03T14:01:21.000Z
+INSERT INTO t_alter_column values('ad_process','IsUseAutoFilters','CHAR(1)',null,null)
+;
+
+-- Backfill: today's behaviour ('Y') on every pre-existing AD_Process row, before making the column mandatory
+-- 2026-09-03T14:01:30.000Z
+UPDATE AD_Process SET IsUseAutoFilters='Y', Updated=TO_TIMESTAMP('2026-09-03 14:01:30','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=99 WHERE IsUseAutoFilters IS NULL
+;
+
+-- Now make the column mandatory with default 'Y'
+-- 2026-09-03T14:01:40.000Z
+INSERT INTO t_alter_column values('ad_process','IsUseAutoFilters','CHAR(1)','NOT NULL','Y')
+;
+
+-- 2026-09-03T14:01:41.000Z
+UPDATE AD_Column SET IsMandatory='Y', DefaultValue='Y', Updated=TO_TIMESTAMP('2026-09-03 14:01:41','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Column_ID=593467
+;
+
+-- Field: Bericht & Prozess(165,D) -> Bericht & Prozess(245,D) -> Standardfilter des Zielfensters anwenden
+-- Column: AD_Process.IsUseAutoFilters
+-- 2026-09-03T14:02:00.000Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,FacetFilterSeqNo,Help,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,593467,784914 /*From ID Server*/,0,245,0,TO_TIMESTAMP('2026-09-03 14:02:00','YYYY-MM-DD HH24:MI:SS'),100,'Beim Sprung in das Zielfenster dessen Standardfilter anwenden. Ausgeschaltet zeigt der Sprung genau die verknüpften Zeilen.',0,'D',0,'Beim Sprung in das Zielfenster dessen Standardfilter anwenden. Ausgeschaltet zeigt der Sprung genau die verknüpften Zeilen.',0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Standardfilter des Zielfensters anwenden',0,401,380,0,1,1,TO_TIMESTAMP('2026-09-03 14:02:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2026-09-03T14:02:00.000Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=784914 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-09-03T14:02:10.000Z
+/* DDL */ select update_FieldTranslation_From_AD_Name_Element(585420)
+;
+
+-- 2026-09-03T14:02:20.000Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=784914
+;
+
+-- 2026-09-03T14:02:21.000Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(784914)
+;
+
+-- Field: Bericht & Prozess(165,D) -> Bericht & Prozess(245,D) -> Standardfilter des Zielfensters anwenden
+-- Column: AD_Process.IsUseAutoFilters
+-- 2026-09-03T14:02:30.000Z
+UPDATE AD_Field SET DisplayLogic='@Type@=''RelationTypeInOverlay''',Updated=TO_TIMESTAMP('2026-09-03 14:02:30','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=784914
+;
+
+-- UI Element: Bericht & Prozess(165,D) -> Bericht & Prozess(245,D) -> main -> 10 -> description.Standardfilter des Zielfensters anwenden
+-- Column: AD_Process.IsUseAutoFilters
+-- Placed directly after OpenTarget (AD_UI_Element 651843, SeqNo=90) in element group 541397
+-- 2026-09-03T14:03:00.000Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,784914,0,245,541397,654684 /*From ID Server*/,'F',TO_TIMESTAMP('2026-09-03 14:03:00','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','N','Y','N','N','N',0,'Standardfilter des Zielfensters anwenden',100,0,0,TO_TIMESTAMP('2026-09-03 14:03:00','YYYY-MM-DD HH24:MI:SS'),100)
+;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5822100_sys_OrderBoard_to_TrafficManagement.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5822100_sys_OrderBoard_to_TrafficManagement.sql
@@ -1,0 +1,124 @@
+-- Add a generic, declarative "Related Documents" (zoom-across) jump from the Auftrags-Board
+-- Uebersicht row (M_Picking_OrderBoard_Overview_v, AD_Table 542626) to Traffic Management
+-- (M_Picking_Job_Schedule_view, AD_Table 542514, AD_Window 541929), analogous to the existing
+-- QtyDemand_QtySupply_V -> M_Forecast_ProductQty_V jump (AD_Process 585515).
+--
+-- The relation matches the board row's own grouping key back onto the schedule view via an EXISTS
+-- back-join to the board view itself (M_Product_ID, C_UOM_ID, AD_Client_ID, AD_Org_ID, the
+-- delivery-date truncated to a date, and the delivery country via C_BPartner_Location ->
+-- C_Location). Joining back to the board view -- rather than restating its grouping/filter columns
+-- -- means the jump can never drift from what the board itself considers "this row's schedules",
+-- including the board's own `isassigned='Y' OR qtyonhand>0` restriction.
+--
+-- A plain @DeliveryDate@ context variable was considered and rejected: POZoomSource (the context a
+-- relation-type where-clause evaluates against) exports only Integer and String source-column
+-- values, so a Timestamp/Date column is silently dropped and the where-clause throws
+-- ExpressionEvaluationException at zoom time (OnVariableNotFound.Fail). The board row's own integer
+-- key (@M_Picking_OrderBoard_Overview_v_ID@) is the only context value this needs.
+--
+-- AD_Process.IsUseAutoFilters='N' (added by an earlier script in this branch) makes the jump show
+-- exactly the resolved rows without re-applying the target window's own "not assigned" default
+-- filter -- otherwise already-assigned schedules (board status "In Kommissionierung" / "Packen")
+-- would land on an apparently empty grid.
+--
+-- IDs allocated from idserver.metas.de on 2026-09-03:
+--   AD_Reference     542135 (source reference, board overview row)
+--   AD_Reference     542136 (target reference, schedule view)
+--   AD_RelationType  540506 (M_Picking_OrderBoard_Overview_v -> Traffic Management)
+--   AD_Process       585657 (the jump process itself)
+--   AD_Table_Process 541671 (wires the process onto AD_Table 542626 as a quick action)
+
+-- Source reference (ValidationType 'T' = Table): the Auftrags-Board Uebersicht row.
+INSERT INTO AD_Reference (AD_Client_ID,AD_Org_ID,AD_Reference_ID,Created,CreatedBy,EntityType,IsActive,IsOrderByValue,Name,Updated,UpdatedBy,ValidationType)
+VALUES (0,0,542135 /*From ID Server*/,TO_TIMESTAMP('2026-09-03 15:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N','Traffic Management Source for M_Picking_OrderBoard_Overview_v',TO_TIMESTAMP('2026-09-03 15:00:00','YYYY-MM-DD HH24:MI:SS'),100,'T')
+;
+
+INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Description,Help,Name, IsTranslated,IsActive,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Reference_ID, t.Description,t.Help,t.Name, 'N','Y',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Reference t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Reference_ID=542135
+  AND NOT EXISTS (SELECT * FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
+;
+
+-- Source ref-table: M_Picking_OrderBoard_Overview_v (AD_Table 542626), key
+-- M_Picking_OrderBoard_Overview_v_ID (AD_Column 592940).
+INSERT INTO AD_Ref_Table (AD_Client_ID,AD_Key,AD_Org_ID,AD_Reference_ID,AD_Table_ID,Created,CreatedBy,EntityType,IsActive,IsValueDisplayed,Updated,UpdatedBy)
+VALUES (0,592940,0,542135,542626,TO_TIMESTAMP('2026-09-03 15:00:01','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N',TO_TIMESTAMP('2026-09-03 15:00:01','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- The board overview row's key column must be usable as a relation-type SOURCE. A relation-type
+-- source only matches when the source zoom column carries IsGenericZoomOrigin='Y'
+-- (SpecificRelationTypeRelatedDocumentsProvider.matchesAsSource(), which otherwise short-circuits
+-- to "no related documents found" for any single-key-record zoom source). The two other existing
+-- RelationTypeInOverlay sources already carry it -- C_Order_ID (AD_Column 2161, used by the
+-- predecessor C_Order -> Traffic Management relation) and QtyDemand_QtySupply_V_ID (AD_Column
+-- 591429, the Material Cockpit v2 -> Forecast relation) -- so this is not a new column, just this
+-- table's key column catching up to the same precondition. AD_Column 592940 and its table
+-- (M_Picking_OrderBoard_Overview_v) are core, EntityType='D' -- this script's own rows use
+-- EntityType='de.metas.handlingunits', but this one UPDATEs a pre-existing core dictionary flag on
+-- an existing core column, so it is deliberately left at its own 'D' EntityType rather than
+-- reassigned.
+UPDATE AD_Column SET IsGenericZoomOrigin='Y', Updated=TO_TIMESTAMP('2026-09-03 15:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Column_ID=592940
+;
+
+-- Target reference: the Picking Job Schedule view.
+INSERT INTO AD_Reference (AD_Client_ID,AD_Org_ID,AD_Reference_ID,Created,CreatedBy,EntityType,IsActive,IsOrderByValue,Name,Updated,UpdatedBy,ValidationType)
+VALUES (0,0,542136 /*From ID Server*/,TO_TIMESTAMP('2026-09-03 15:00:02','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N','Traffic Management Target for M_Picking_OrderBoard_Overview_v',TO_TIMESTAMP('2026-09-03 15:00:02','YYYY-MM-DD HH24:MI:SS'),100,'T')
+;
+
+INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Description,Help,Name, IsTranslated,IsActive,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Reference_ID, t.Description,t.Help,t.Name, 'N','Y',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Reference t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Reference_ID=542136
+  AND NOT EXISTS (SELECT * FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
+;
+
+-- Target ref-table: M_Picking_Job_Schedule_view (AD_Table 542514), key M_ShipmentSchedule_ID
+-- (AD_Column 590664, non-null on every row -- the synthetic to-be-scheduled row carries
+-- M_Picking_Job_Schedule_ID=0, so that column is unsuitable as the zoom key), opening AD_Window
+-- 541929. WhereClause resolves via an EXISTS back-join to the board view itself, keyed on the
+-- board row's own integer id (the only context value POZoomSource makes available).
+INSERT INTO AD_Ref_Table (AD_Client_ID,AD_Key,AD_Org_ID,AD_Reference_ID,AD_Table_ID,AD_Window_ID,Created,CreatedBy,EntityType,IsActive,IsValueDisplayed,Updated,UpdatedBy,WhereClause)
+VALUES (0,590664,0,542136,542514,541929,TO_TIMESTAMP('2026-09-03 15:00:03','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N',TO_TIMESTAMP('2026-09-03 15:00:03','YYYY-MM-DD HH24:MI:SS'),100,
+'EXISTS (SELECT 1 FROM M_Picking_OrderBoard_Overview_v b JOIN C_BPartner_Location bl ON bl.C_BPartner_Location_ID = M_Picking_Job_Schedule_view.C_BPartner_Location_ID JOIN C_Location l ON l.C_Location_ID = bl.C_Location_ID WHERE b.M_Picking_OrderBoard_Overview_v_ID = @M_Picking_OrderBoard_Overview_v_ID/-1@ AND b.M_Product_ID = M_Picking_Job_Schedule_view.M_Product_ID AND b.C_UOM_ID = M_Picking_Job_Schedule_view.C_UOM_ID AND b.AD_Client_ID = M_Picking_Job_Schedule_view.AD_Client_ID AND b.AD_Org_ID = M_Picking_Job_Schedule_view.AD_Org_ID AND b.DeliveryDate = CAST(M_Picking_Job_Schedule_view.DeliveryDate AS date) AND b.C_Country_ID = l.C_Country_ID)')
+;
+
+-- The directed relation itself: board overview row (542135) -> Traffic Management (542136).
+INSERT INTO AD_RelationType (AD_Client_ID,AD_Org_ID,AD_RelationType_ID,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsActive,IsTableRecordIDTarget,Name,InternalName,AD_Reference_Source_ID,AD_Reference_Target_ID)
+VALUES (0,0,540506 /*From ID Server*/,TO_TIMESTAMP('2026-09-03 15:00:04','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-03 15:00:04','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N','Auftrags-Board -> Traffic Management','M_Picking_OrderBoard_Overview_v_to_TrafficManagement',542135,542136)
+;
+
+-- The jump process. Type and Classname are both set explicitly because the interceptor that
+-- derives one from the other does not run for migration SQL. IsUseAutoFilters='N' is the whole
+-- point of this jump: show exactly the resolved schedules, not the target window's own default
+-- "not assigned" filter. Value is pinned to a fixed, human-readable string (rather than left to
+-- default to the numeric AD_Process_ID) because the WebUI quick-action data-testid is derived from
+-- it (ADProcessDescriptorsFactory -> InternalName.ofString(adProcess.getValue())).
+-- AD_Process has no AD_Element_ID -- Name/Description/Help are self-owned; the base row and its
+-- AD_Process_Trl rows are set directly and in sync below. This process gets no AD_Menu entry.
+INSERT INTO AD_Process (AccessLevel,AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_RelationType_ID,AllowProcessReRun,Classname,CopyFromProcess,Created,CreatedBy,EntityType,IsActive,IsApplySecuritySettings,IsBetaFunctionality,IsDirectPrint,IsFormatExcelFile,IsLogWarning,IsNotifyUserAfterExecution,IsOneInstanceOnly,IsReport,IsTranslateExcelHeaders,IsUpdateExportDate,IsUseAutoFilters,IsUseBPartnerLanguage,LockWaitTimeout,Name,PostgrestResponseFormat,RefreshAllAfterExecution,ShowHelp,SpreadsheetFormat,Type,Updated,UpdatedBy,Value)
+VALUES ('3',0,0,585657 /*From ID Server*/,540506,'Y','de.metas.ui.web.view.process.RelationTypeInOverlayProcess','N',TO_TIMESTAMP('2026-09-03 15:00:05','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N','N','N','N','Y','N','N','N','N','N','N','Y',0,'Sprung zu Traffic Management','json','N','N','xls','RelationTypeInOverlay',TO_TIMESTAMP('2026-09-03 15:00:05','YYYY-MM-DD HH24:MI:SS'),100,'M_Picking_OrderBoard_Overview_v_to_TrafficManagement')
+;
+
+INSERT INTO AD_Process_Trl (AD_Language,AD_Process_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Process t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_ID=585657
+  AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_ID=t.AD_Process_ID)
+;
+
+-- de_DE / de_CH already carry the correct text via the generic copy above; only en_US differs.
+UPDATE AD_Process_Trl SET Name='Go to Traffic Management',Updated=TO_TIMESTAMP('2026-09-03 15:00:06','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Process_ID=585657
+;
+
+UPDATE AD_Process base SET Name=trl.Name, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy
+FROM AD_Process_Trl trl
+WHERE trl.AD_Process_ID=base.AD_Process_ID AND trl.AD_Language='en_US' AND trl.AD_Language=getBaseLanguage()
+;
+
+-- Wire the process onto the board's Uebersicht table as a quick action.
+INSERT INTO AD_Table_Process (AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_Table_ID,AD_Table_Process_ID,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,WEBUI_DocumentAction,WEBUI_IncludedTabTopAction,WEBUI_ViewAction,WEBUI_ViewQuickAction,WEBUI_ViewQuickAction_Default)
+VALUES (0,0,585657,542626,541671 /*From ID Server*/,TO_TIMESTAMP('2026-09-03 15:00:07','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y',TO_TIMESTAMP('2026-09-03 15:00:07','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','Y')
+;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5822100_sys_OrderBoard_to_TrafficManagement.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5822100_sys_OrderBoard_to_TrafficManagement.sql
@@ -6,9 +6,13 @@
 -- The relation matches the board row's own grouping key back onto the schedule view via an EXISTS
 -- back-join to the board view itself (M_Product_ID, C_UOM_ID, AD_Client_ID, AD_Org_ID, the
 -- delivery-date truncated to a date, and the delivery country via C_BPartner_Location ->
--- C_Location). Joining back to the board view -- rather than restating its grouping/filter columns
--- -- means the jump can never drift from what the board itself considers "this row's schedules",
--- including the board's own `isassigned='Y' OR qtyonhand>0` restriction.
+-- C_Location). The EXISTS only constrains that a board aggregate row with this id and this grouping
+-- tuple exists -- it says nothing about the *target* schedule row being matched. The board view's
+-- own `isassigned='Y' OR qtyonhand>0` restriction governs which schedule rows form that aggregate,
+-- not which target rows share its tuple, so the same test is repeated as a trailing AND on the
+-- target row below; without it, a target row sharing the tuple but failing that test (e.g. an
+-- unassigned, no-stock schedule alongside an assigned one for the same product/UOM/date/country)
+-- would still be returned, even though it is invisible on the board.
 --
 -- A plain @DeliveryDate@ context variable was considered and rejected: POZoomSource (the context a
 -- relation-type where-clause evaluates against) exports only Integer and String source-column
@@ -81,7 +85,7 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.
 -- board row's own integer id (the only context value POZoomSource makes available).
 INSERT INTO AD_Ref_Table (AD_Client_ID,AD_Key,AD_Org_ID,AD_Reference_ID,AD_Table_ID,AD_Window_ID,Created,CreatedBy,EntityType,IsActive,IsValueDisplayed,Updated,UpdatedBy,WhereClause)
 VALUES (0,590664,0,542136,542514,541929,TO_TIMESTAMP('2026-09-03 15:00:03','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N',TO_TIMESTAMP('2026-09-03 15:00:03','YYYY-MM-DD HH24:MI:SS'),100,
-'EXISTS (SELECT 1 FROM M_Picking_OrderBoard_Overview_v b JOIN C_BPartner_Location bl ON bl.C_BPartner_Location_ID = M_Picking_Job_Schedule_view.C_BPartner_Location_ID JOIN C_Location l ON l.C_Location_ID = bl.C_Location_ID WHERE b.M_Picking_OrderBoard_Overview_v_ID = @M_Picking_OrderBoard_Overview_v_ID/-1@ AND b.M_Product_ID = M_Picking_Job_Schedule_view.M_Product_ID AND b.C_UOM_ID = M_Picking_Job_Schedule_view.C_UOM_ID AND b.AD_Client_ID = M_Picking_Job_Schedule_view.AD_Client_ID AND b.AD_Org_ID = M_Picking_Job_Schedule_view.AD_Org_ID AND b.DeliveryDate = CAST(M_Picking_Job_Schedule_view.DeliveryDate AS date) AND b.C_Country_ID = l.C_Country_ID)')
+'EXISTS (SELECT 1 FROM M_Picking_OrderBoard_Overview_v b JOIN C_BPartner_Location bl ON bl.C_BPartner_Location_ID = M_Picking_Job_Schedule_view.C_BPartner_Location_ID JOIN C_Location l ON l.C_Location_ID = bl.C_Location_ID WHERE b.M_Picking_OrderBoard_Overview_v_ID = @M_Picking_OrderBoard_Overview_v_ID/-1@ AND b.M_Product_ID = M_Picking_Job_Schedule_view.M_Product_ID AND b.C_UOM_ID = M_Picking_Job_Schedule_view.C_UOM_ID AND b.AD_Client_ID = M_Picking_Job_Schedule_view.AD_Client_ID AND b.AD_Org_ID = M_Picking_Job_Schedule_view.AD_Org_ID AND b.DeliveryDate = CAST(M_Picking_Job_Schedule_view.DeliveryDate AS date) AND b.C_Country_ID = l.C_Country_ID) AND (M_Picking_Job_Schedule_view.IsAssigned = ''Y'' OR M_Picking_Job_Schedule_view.QtyOnHand > 0)')
 ;
 
 -- The directed relation itself: board overview row (542135) -> Traffic Management (542136).
@@ -98,7 +102,7 @@ VALUES (0,0,540506 /*From ID Server*/,TO_TIMESTAMP('2026-09-03 15:00:04','YYYY-M
 -- AD_Process has no AD_Element_ID -- Name/Description/Help are self-owned; the base row and its
 -- AD_Process_Trl rows are set directly and in sync below. This process gets no AD_Menu entry.
 INSERT INTO AD_Process (AccessLevel,AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_RelationType_ID,AllowProcessReRun,Classname,CopyFromProcess,Created,CreatedBy,EntityType,IsActive,IsApplySecuritySettings,IsBetaFunctionality,IsDirectPrint,IsFormatExcelFile,IsLogWarning,IsNotifyUserAfterExecution,IsOneInstanceOnly,IsReport,IsTranslateExcelHeaders,IsUpdateExportDate,IsUseAutoFilters,IsUseBPartnerLanguage,LockWaitTimeout,Name,PostgrestResponseFormat,RefreshAllAfterExecution,ShowHelp,SpreadsheetFormat,Type,Updated,UpdatedBy,Value)
-VALUES ('3',0,0,585657 /*From ID Server*/,540506,'Y','de.metas.ui.web.view.process.RelationTypeInOverlayProcess','N',TO_TIMESTAMP('2026-09-03 15:00:05','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N','N','N','N','Y','N','N','N','N','N','N','Y',0,'Sprung zu Traffic Management','json','N','N','xls','RelationTypeInOverlay',TO_TIMESTAMP('2026-09-03 15:00:05','YYYY-MM-DD HH24:MI:SS'),100,'M_Picking_OrderBoard_Overview_v_to_TrafficManagement')
+VALUES ('3',0,0,585657 /*From ID Server*/,540506,'Y','de.metas.ui.web.view.process.RelationTypeInOverlayProcess','N',TO_TIMESTAMP('2026-09-03 15:00:05','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N','N','N','N','N','N','N','N','N','N','N','Y',0,'Sprung zu Traffic Management','json','N','N','xls','RelationTypeInOverlay',TO_TIMESTAMP('2026-09-03 15:00:05','YYYY-MM-DD HH24:MI:SS'),100,'M_Picking_OrderBoard_Overview_v_to_TrafficManagement')
 ;
 
 INSERT INTO AD_Process_Trl (AD_Language,AD_Process_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcess.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcess.java
@@ -80,6 +80,10 @@ import static de.metas.ui.web.view.SqlViewFactory.MSG_NO_RELATED_DOCS_FOUND;
  * (see {@link ProcessOpenTarget}): modal overlay (default — historical behaviour
  * when the column is NULL) or new browser tab.
  * <p>
+ * Whether the jump also applies the target window's own default filters is configured per AD_Process via
+ * {@code AD_Process.IsUseAutoFilters}: {@code 'Y'} (default — historical behaviour) applies them; {@code 'N'}
+ * shows exactly the rows the relation resolved, ignoring the target window's default filters.
+ * <p>
  * This process is automatically assigned when AD_Process.Type='RelationTypeInOverlay'.
  */
 public class RelationTypeInOverlayProcess extends JavaProcess implements IProcessPrecondition
@@ -299,7 +303,7 @@ public class RelationTypeInOverlayProcess extends JavaProcess implements IProces
 		final CreateViewRequest request = CreateViewRequest.builder(targetWindowId, JSONViewDataType.grid)
 				.setDocumentReferenceId(WebuiDocumentReferenceId.ofRelatedDocumentsId(relatedDocumentsId))
 				.addStickyFilters(unionFilter)
-				.setUseAutoFilters(true)
+				.setUseAutoFilters(getProcessInfo().isUseAutoFilters())
 				.build();
 		return viewsRepo.createView(request);
 	}
@@ -396,7 +400,7 @@ public class RelationTypeInOverlayProcess extends JavaProcess implements IProces
 		final CreateViewRequest request = CreateViewRequest.builder(targetWindowId, JSONViewDataType.grid)
 				.setReferencingDocumentPaths(ImmutableSet.of(srcDocument))
 				.setDocumentReferenceId(WebuiDocumentReferenceId.ofRelatedDocumentsId(relatedDocumentsId))
-				.setUseAutoFilters(true)
+				.setUseAutoFilters(getProcessInfo().isUseAutoFilters())
 				.build();
 
 		return viewsRepo.createView(request);

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcessTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcessTest.java
@@ -30,8 +30,10 @@ import de.metas.util.Services;
 import de.metas.util.lang.Priority;
 import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_AD_Process;
 import org.compiere.util.Env;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -643,6 +645,56 @@ class RelationTypeInOverlayProcessTest
 					.isEqualTo("(PC.C_OrderLine_ID=1)");
 		}
 
+		@Test
+		void createsCombinedView_withAutoFiltersEnabled_whenAD_Process_IsUseAutoFiltersIsY()
+		{
+			final CreateViewRequest request = doIt_multiSelection_capturingRequest(/* isUseAutoFilters */ true);
+
+			assertThat(request.isUseAutoFilters()).isTrue();
+		}
+
+		@Test
+		void createsCombinedView_withAutoFiltersDisabled_whenAD_Process_IsUseAutoFiltersIsN()
+		{
+			final CreateViewRequest request = doIt_multiSelection_capturingRequest(/* isUseAutoFilters */ false);
+
+			assertThat(request.isUseAutoFilters()).isFalse();
+		}
+
+		private CreateViewRequest doIt_multiSelection_capturingRequest(final boolean isUseAutoFilters)
+		{
+			final RelationTypeId relationTypeId = RelationTypeId.ofRepoId(42);
+			final WindowId targetWindow = WindowId.of(AdWindowId.ofRepoId(200));
+
+			final TableRecordReference ref1 = TableRecordReference.of("C_OrderLine", 1);
+			final TableRecordReference ref2 = TableRecordReference.of("C_OrderLine", 2);
+			final IZoomSource zoom1 = mock(IZoomSource.class);
+			final IZoomSource zoom2 = mock(IZoomSource.class);
+
+			final SpecificRelationTypeRelatedDocumentsProvider provider = mock(SpecificRelationTypeRelatedDocumentsProvider.class);
+			when(providerFactory.findRelatedDocumentsProvider(eq(relationTypeId))).thenReturn(Optional.of(provider));
+			when(provider.retrieveRelatedDocumentsCandidates(eq(zoom1), any()))
+					.thenReturn(ImmutableList.of(buildCandidateGroupWithQuery(targetWindow, "PC.C_OrderLine_ID=1")));
+			when(provider.retrieveRelatedDocumentsCandidates(eq(zoom2), any()))
+					.thenReturn(ImmutableList.of(buildCandidateGroupWithQuery(targetWindow, "PC.C_OrderLine_ID=2")));
+
+			final IView mockView = mock(IView.class);
+			when(viewsRepo.createView(any())).thenReturn(mockView);
+			when(mockView.getViewId()).thenReturn(ViewId.ofViewIdString("200-someViewId"));
+
+			final ProcessInfo processInfo = buildMultiProcessInfoWithAD_Process(relationTypeId, isUseAutoFilters);
+			final RelationTypeInOverlayProcess process = RelationTypeInOverlayProcess.newInstanceForUnitTesting(
+					providerFactory, viewsRepo, processInfo,
+					ImmutableList.of(ref1, ref2),
+					ImmutableMap.of(ref1, zoom1, ref2, zoom2));
+
+			process.doIt();
+
+			final ArgumentCaptor<CreateViewRequest> captor = ArgumentCaptor.forClass(CreateViewRequest.class);
+			verify(viewsRepo).createView(captor.capture());
+			return captor.getValue();
+		}
+
 		private RelationTypeInOverlayProcess buildMultiProcess(
 				final RelationTypeRelatedDocumentsProvidersFactory factory,
 				final IViewsRepository viewsRepo,
@@ -659,6 +711,27 @@ class RelationTypeInOverlayProcessTest
 					.build();
 
 			return RelationTypeInOverlayProcess.newInstanceForUnitTesting(factory, viewsRepo, processInfo, selectedRecordRefs, zoomSourcesByRecordRef);
+		}
+
+		/**
+		 * Builds a multi-selection {@link ProcessInfo} backed by a real {@link I_AD_Process} row (via
+		 * {@link ProcessInfo.ProcessInfoBuilder#setAD_Process}), so {@code AD_Process.IsUseAutoFilters} actually drives
+		 * {@link ProcessInfo#isUseAutoFilters()} the way it does in production.
+		 */
+		private ProcessInfo buildMultiProcessInfoWithAD_Process(final RelationTypeId relationTypeId, final boolean isUseAutoFilters)
+		{
+			final I_AD_Process adProcess = InterfaceWrapperHelper.newInstance(I_AD_Process.class);
+			adProcess.setAD_Process_ID(1);
+			adProcess.setType(org.compiere.model.X_AD_Process.TYPE_RelationTypeInOverlay);
+			adProcess.setAD_RelationType_ID(relationTypeId.getRepoId());
+			adProcess.setIsUseAutoFilters(isUseAutoFilters);
+
+			return ProcessInfo.builder()
+					.setCtx(Env.getCtx())
+					.setAD_Process(adProcess)
+					.setAdWindowId(AdWindowId.ofRepoId(100))
+					// no single record set -> multi selection
+					.build();
 		}
 
 		private RelatedDocumentsCandidateGroup buildCandidateGroupWithBlankWhereClause(final WindowId targetWindowId)
@@ -766,6 +839,50 @@ class RelationTypeInOverlayProcessTest
 			assertThat(process.getSelectedSourceRecordRefs()).containsExactly(ref);
 		}
 
+		@Test
+		void createsView_withAutoFiltersEnabled_whenAD_Process_IsUseAutoFiltersIsY()
+		{
+			final CreateViewRequest request = doIt_singleSelection_capturingRequest(/* isUseAutoFilters */ true);
+
+			assertThat(request.isUseAutoFilters()).isTrue();
+		}
+
+		@Test
+		void createsView_withAutoFiltersDisabled_whenAD_Process_IsUseAutoFiltersIsN()
+		{
+			final CreateViewRequest request = doIt_singleSelection_capturingRequest(/* isUseAutoFilters */ false);
+
+			assertThat(request.isUseAutoFilters()).isFalse();
+		}
+
+		private CreateViewRequest doIt_singleSelection_capturingRequest(final boolean isUseAutoFilters)
+		{
+			final RelationTypeId relationTypeId = RelationTypeId.ofRepoId(42);
+			final SpecificRelationTypeRelatedDocumentsProvider provider = mock(SpecificRelationTypeRelatedDocumentsProvider.class);
+			final RelatedDocumentsCandidateGroup group = buildCandidateGroupWithOneEntry(WindowId.of(AdWindowId.ofRepoId(200)));
+			final IView mockView = mock(IView.class);
+
+			when(providerFactory.findRelatedDocumentsProvider(eq(relationTypeId))).thenReturn(Optional.of(provider));
+			when(provider.retrieveRelatedDocumentsCandidates(any(), any())).thenReturn(ImmutableList.of(group));
+			when(viewsRepo.createView(any())).thenReturn(mockView);
+			when(mockView.getViewId()).thenReturn(ViewId.ofViewIdString("200-someViewId"));
+
+			final TableRecordReference ref = TableRecordReference.of("C_OrderLine", 101);
+			final IZoomSource zoomSource = mock(IZoomSource.class);
+			final ProcessInfo processInfo = buildProcessInfoWithAD_Process(relationTypeId, isUseAutoFilters);
+
+			final RelationTypeInOverlayProcess process = RelationTypeInOverlayProcess.newInstanceForUnitTesting(
+					providerFactory, viewsRepo, processInfo,
+					ImmutableList.of(ref),
+					ImmutableMap.of(ref, zoomSource));
+
+			process.doIt();
+
+			final ArgumentCaptor<CreateViewRequest> captor = ArgumentCaptor.forClass(CreateViewRequest.class);
+			verify(viewsRepo).createView(captor.capture());
+			return captor.getValue();
+		}
+
 		private ProcessInfo buildProcessInfo(final RelationTypeId relationTypeId)
 		{
 			return ProcessInfo.builder()
@@ -773,6 +890,25 @@ class RelationTypeInOverlayProcessTest
 					.setAD_Process_ID(1)
 					.setAdWindowId(AdWindowId.ofRepoId(100))
 					.setAdRelationTypeId(relationTypeId)
+					.build();
+		}
+
+		/**
+		 * Builds a {@link ProcessInfo} backed by a real {@link I_AD_Process} row (via {@link ProcessInfo.ProcessInfoBuilder#setAD_Process}),
+		 * so {@code AD_Process.IsUseAutoFilters} actually drives {@link ProcessInfo#isUseAutoFilters()} the way it does in production.
+		 */
+		private ProcessInfo buildProcessInfoWithAD_Process(final RelationTypeId relationTypeId, final boolean isUseAutoFilters)
+		{
+			final I_AD_Process adProcess = InterfaceWrapperHelper.newInstance(I_AD_Process.class);
+			adProcess.setAD_Process_ID(1);
+			adProcess.setType(org.compiere.model.X_AD_Process.TYPE_RelationTypeInOverlay);
+			adProcess.setAD_RelationType_ID(relationTypeId.getRepoId());
+			adProcess.setIsUseAutoFilters(isUseAutoFilters);
+
+			return ProcessInfo.builder()
+					.setCtx(Env.getCtx())
+					.setAD_Process(adProcess)
+					.setAdWindowId(AdWindowId.ofRepoId(100))
 					.build();
 		}
 	}

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcessTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcessTest.java
@@ -158,17 +158,9 @@ class RelationTypeInOverlayProcessTest
 		@Test
 		void throws_whenNoRelatedDocumentsFound()
 		{
-			// This is also the sanctioned JUnit-only proof (metasfresh-test-integrity "a layer that provably
-			// cannot REACH the change is a regression check, never coverage of it") of the single-selection
-			// half of the Auftrags-Board -> Traffic Management jump's "no related documents" guarantee:
-			// M_Picking_OrderBoard_Overview_v is built directly on m_picking_job_schedule_view and groups by
-			// the SAME key (m_product_id, c_uom_id, deliverydate::date, c_country_id, ad_client_id,
-			// ad_org_id) that the jump's related-documents lookup uses, so a board row that is still
-			// selectable in the UI always has at least one resolvable schedule -- the empty-groups branch
-			// this test exercises can never fire from a live selection through the WebUI/REST. Do not
-			// "upgrade" this to an e2e for that caller; see
-			// order-board-jump-to-traffic-management.spec.js's last test for the reachable half of the same
-			// promise (a valid selection must open cleanly).
+			// Also the sanctioned JUnit-only proof of the single-selection "no related documents" branch
+			// for the Auftrags-Board -> Traffic Management jump; see order-board-jump-to-traffic-management.spec.js
+			// for why a live UI selection cannot reach it and for the reachable-half coverage.
 			final RelationTypeId relationTypeId = RelationTypeId.ofRepoId(42);
 			final SpecificRelationTypeRelatedDocumentsProvider provider = mock(SpecificRelationTypeRelatedDocumentsProvider.class);
 
@@ -462,11 +454,8 @@ class RelationTypeInOverlayProcessTest
 		@Test
 		void throws_whenNoRelatedDocsForAnySelectedRow()
 		{
-			// This is also the sanctioned JUnit-only proof of the COMBINED-selection half of the same
-			// Auftrags-Board -> Traffic Management jump guarantee documented on
-			// DoIt#throws_whenNoRelatedDocumentsFound above (single-selection half) -- see that comment for
-			// the structural reason a live multi-row board selection can never actually resolve to an empty
-			// where-clauses union through the WebUI/REST, so this branch is unreachable there too.
+			// Also the sanctioned JUnit-only proof of the combined-selection half of the same
+			// Auftrags-Board -> Traffic Management jump guarantee; see order-board-jump-to-traffic-management.spec.js.
 			final RelationTypeId relationTypeId = RelationTypeId.ofRepoId(42);
 
 			final TableRecordReference ref1 = TableRecordReference.of("C_OrderLine", 1);

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcessTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcessTest.java
@@ -158,6 +158,17 @@ class RelationTypeInOverlayProcessTest
 		@Test
 		void throws_whenNoRelatedDocumentsFound()
 		{
+			// This is also the sanctioned JUnit-only proof (metasfresh-test-integrity "a layer that provably
+			// cannot REACH the change is a regression check, never coverage of it") of the single-selection
+			// half of the Auftrags-Board -> Traffic Management jump's "no related documents" guarantee:
+			// M_Picking_OrderBoard_Overview_v is built directly on m_picking_job_schedule_view and groups by
+			// the SAME key (m_product_id, c_uom_id, deliverydate::date, c_country_id, ad_client_id,
+			// ad_org_id) that the jump's related-documents lookup uses, so a board row that is still
+			// selectable in the UI always has at least one resolvable schedule -- the empty-groups branch
+			// this test exercises can never fire from a live selection through the WebUI/REST. Do not
+			// "upgrade" this to an e2e for that caller; see
+			// order-board-jump-to-traffic-management.spec.js's last test for the reachable half of the same
+			// promise (a valid selection must open cleanly).
 			final RelationTypeId relationTypeId = RelationTypeId.ofRepoId(42);
 			final SpecificRelationTypeRelatedDocumentsProvider provider = mock(SpecificRelationTypeRelatedDocumentsProvider.class);
 
@@ -451,6 +462,11 @@ class RelationTypeInOverlayProcessTest
 		@Test
 		void throws_whenNoRelatedDocsForAnySelectedRow()
 		{
+			// This is also the sanctioned JUnit-only proof of the COMBINED-selection half of the same
+			// Auftrags-Board -> Traffic Management jump guarantee documented on
+			// DoIt#throws_whenNoRelatedDocumentsFound above (single-selection half) -- see that comment for
+			// the structural reason a live multi-row board selection can never actually resolve to an empty
+			// where-clauses union through the WebUI/REST, so this branch is unreachable there too.
 			final RelationTypeId relationTypeId = RelationTypeId.ofRepoId(42);
 
 			final TableRecordReference ref1 = TableRecordReference.of("C_OrderLine", 1);
@@ -597,6 +613,33 @@ class RelationTypeInOverlayProcessTest
 			final RelationTypeInOverlayProcess process = buildMultiProcess(
 					providerFactory, viewsRepo, relationTypeId,
 					ImmutableList.of(ref1, ref2),
+					ImmutableMap.of());
+
+			assertThatThrownBy(process::doIt)
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("NO_RELATED_DOCS_FOUND");
+		}
+
+		@Test
+		void throws_whenSelectionResolvesToZeroRecords()
+		{
+			// Covers doIt()'s OWN top-level guard (sourceRecordRefs.isEmpty(), before either the single- or
+			// combined-selection path is chosen) -- distinct from throws_whenAllSourceRowsAreUnloadable
+			// above (which has >0 selected refs that each fail to LOAD) and from
+			// throws_whenNoRelatedDocsForAnySelectedRow (which has >0 loadable refs whose related documents
+			// are empty). Here the selection itself already resolves to zero records, e.g. a multi-row
+			// AD_PInstance selection re-run at process time against rows that vanished in the meantime.
+			//
+			// Also a sanctioned JUnit-only case for the Auftrags-Board -> Traffic Management jump: if every
+			// selected board row's identity has changed by the time the process runs, the re-resolved
+			// selection is empty here rather than "unloadable" or "no related docs" -- see
+			// DoIt#throws_whenNoRelatedDocumentsFound above for why a live UI selection cannot otherwise
+			// reach the "no related documents" branches.
+			final RelationTypeId relationTypeId = RelationTypeId.ofRepoId(42);
+
+			final RelationTypeInOverlayProcess process = buildMultiProcess(
+					providerFactory, viewsRepo, relationTypeId,
+					ImmutableList.of(), // empty selection (not null -- null would fall through to the real, unmocked resolution)
 					ImmutableMap.of());
 
 			assertThatThrownBy(process::doIt)

--- a/e2e/frontend-webui/tests/spec/order-board-jump-to-traffic-management.spec.js
+++ b/e2e/frontend-webui/tests/spec/order-board-jump-to-traffic-management.spec.js
@@ -1,0 +1,764 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import { FRONTEND_BASE_URL } from '../utils/common';
+
+/**
+ * Confirm the dashboard rendered, without gating on networkidle: the dashboard's STOMP/websocket +
+ * KPI polling keep the network permanently active, so DashboardPage.expectVisible() (which awaits
+ * page.waitForLoadState('networkidle')) never settles here and times out -- see the playwright-run
+ * skill's "Writing steps that don't flake" section. A deterministic DOM signal is used instead.
+ */
+async function expectDashboardVisible(page) {
+  await page.locator('.app-content, .dashboard').waitFor({ state: 'visible', timeout: 20000 });
+}
+
+/**
+ * Auftrags-Board -> Traffic Management jump.
+ *
+ * The Auftrags-Board's Uebersicht tab aggregates M_Picking_Job_Schedule_view rows by product / UOM /
+ * delivery date / delivery country / client / org (M_Picking_OrderBoard_Overview_v). This spec proves
+ * that selecting one or more board rows and running the (not-yet-existing) jump quick action opens
+ * Traffic Management scoped to exactly those rows' schedules -- including rows that are already fully
+ * assigned to a workplace, which is exactly the case the customer originally reported as an empty grid.
+ *
+ * RED-by-construction: the AD_Process / AD_RelationType / AD_Table_Process wiring that offers the jump
+ * on the board does not exist yet (a follow-up migration script adds it). Tests 1-4 are therefore
+ * expected to FAIL because the Aktionen dropdown never offers
+ * [data-testid="quick-action-M_Picking_OrderBoard_Overview_v_to_TrafficManagement"]. Test 5 does not
+ * depend on that action at all -- it guards the Traffic Management window's OWN default filter and must
+ * pass from the start.
+ *
+ * Everything is asserted through data-testid / data-cy / REST JSON field names -- never localized UI
+ * text (e2e/frontend-webui/CLAUDE.md "Specs MUST be language-independent").
+ */
+
+const ORDER_BOARD_WINDOW_ID = 542168; // AD_Window "Auftrags-Board", Uebersicht tab (root), table M_Picking_OrderBoard_Overview_v (542626)
+const TRAFFIC_MANAGEMENT_WINDOW_ID = 541929; // AD_Window "Traffic Management", table M_Picking_Job_Schedule_view (542514)
+
+// AD_Process.Value the follow-up migration is required to use so this data-testid is stable.
+// QuickActionsDropdown.js renders data-testid="quick-action-" + (action.internalName || action.processId).
+const JUMP_ACTION_TESTID = 'quick-action-M_Picking_OrderBoard_Overview_v_to_TrafficManagement';
+
+// frontend/src/utils/documentListHelper.js DEFAULT_PAGE_LENGTH -- the grid page size a window falls
+// back to when its own layout does not set one (neither the board nor Traffic Management does here).
+const GRID_DEFAULT_PAGE_LENGTH = 15;
+
+/**
+ * Poll a grid view (board or Traffic Management) until a row matching `predicate` appears.
+ *
+ * Neither window has a server-side "default" filter PARAMETER to narrow the fetch to one product
+ * (verified against the running stack: the board's Uebersicht tab has no AD_Field marked
+ * IsFilterField='Y'), so -- unlike the Material Cockpit v2 / forecast specs -- a single unfiltered
+ * fetch (pageLength=500) is used to LOCATE the row via REST. That fetch's order matches what the grid
+ * renders (verified: a requested `orderBy` override on the create-view call is silently ignored -- the
+ * response always echoes back M_Picking_OrderBoard_Overview_v_ID ascending), so the row's index in it
+ * also tells us which GRID PAGE (GRID_DEFAULT_PAGE_LENGTH per page) the UI will show it on -- see
+ * `pageNumber` below and selectRow(). Both views can and do accumulate more than one page's worth of
+ * rows over a spec run (each test seeds its own uniquely-named product), so this must not assume page 1.
+ */
+async function waitForViewRow(page, windowId, predicate, { timeout = 60000 } = {}) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const view = await page.evaluate(async ({ windowId }) => {
+      // config.API_URL is the SAME base URL the app's own redux/api layer uses (set by
+      // config.js) -- a bare relative "/rest/api/..." only works when the frontend origin proxies
+      // that path (e.g. the webpack dev server); a statically-served production build does not, and
+      // silently answers with index.html (SyntaxError: Unexpected token '<' when parsed as JSON).
+      const apiUrl = config.API_URL;
+      const created = await fetch(`${apiUrl}/documentView/${windowId}`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ windowId: String(windowId), viewType: 'grid' }),
+      });
+      if (!created.ok) return null;
+      const { viewId } = await created.json();
+      const rows = await fetch(`${apiUrl}/documentView/${windowId}/${viewId}?firstRow=0&pageLength=500`, {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+      });
+      if (!rows.ok) return null;
+      const body = await rows.json();
+      return { viewId, result: body.result };
+    }, { windowId });
+
+    const rowIndex = view?.result?.findIndex(predicate) ?? -1;
+    if (rowIndex >= 0) {
+      const row = view.result[rowIndex];
+      // The grid renders GRID_DEFAULT_PAGE_LENGTH rows per page (frontend/src/utils/documentListHelper.js
+      // DEFAULT_PAGE_LENGTH); the Overview/Traffic Management views accept no client-requested `orderBy`
+      // override (verified against the running stack -- the create-view response always echoes back
+      // M_Picking_OrderBoard_Overview_v_ID ascending regardless of what is requested), so a freshly-seeded
+      // row can land on any page once this window accumulates more than one page's worth of rows. Compute
+      // which page it is on so selectRow() can navigate there instead of assuming page 1.
+      const pageNumber = Math.floor(rowIndex / GRID_DEFAULT_PAGE_LENGTH) + 1;
+      return { viewId: view.viewId, rowId: row.id, row, pageNumber };
+    }
+    await page.waitForTimeout(2000);
+  }
+  throw new Error(`No row matched within ${timeout}ms on window ${windowId}`);
+}
+
+const byProduct = (productId) => (r) => String(r.fieldsByName?.M_Product_ID?.value?.key) === String(productId);
+
+/** Poll the Auftrags-Board Uebersicht view until a row for `productId` appears. */
+async function waitForBoardRow(page, productId, opts) {
+  return waitForViewRow(page, ORDER_BOARD_WINDOW_ID, byProduct(productId), opts);
+}
+
+/**
+ * Create a NEW board view scoped to exactly `rowIds`, via the generic `filterOnlyIds` mechanism
+ * (JSONCreateViewRequest.filterOnlyIds -> SqlViewFactory: a server-side sticky `keyColumn IN (...)`
+ * filter -- de.metas.ui.web.base SqlViewFactory.java "if (!request.getFilterOnlyIds().isEmpty())";
+ * already used the same way by picking-terminal.spec.js). Needed because the Uebersicht tab exposes
+ * no AD_Field filter parameter to narrow by product (see waitForViewRow()), so two freshly-seeded rows
+ * can otherwise land on different grid pages once the board accumulates more than
+ * GRID_DEFAULT_PAGE_LENGTH rows from earlier runs. A view containing only `rowIds` makes their page
+ * co-location deterministic (both always fit on page 1) regardless of how many unrelated rows exist
+ * in the unfiltered board view. This is a server-side filter on the SAME underlying table/rows, not a
+ * different data set -- RelationTypeInOverlayProcess#getSelectedSourceRecordRefs() resolves the
+ * selected records from the AD_PInstance selection where-clause, not from the view's own filters, so
+ * selecting from this filtered view is equivalent to selecting from the unfiltered one.
+ */
+async function createFilteredBoardView(page, rowIds) {
+  return page.evaluate(async ({ windowId, rowIds }) => {
+    const apiUrl = config.API_URL; // see waitForViewRow() for why an absolute base URL is required
+    const created = await fetch(`${apiUrl}/documentView/${windowId}`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ windowId: String(windowId), viewType: 'grid', filterOnlyIds: rowIds }),
+    });
+    if (!created.ok) throw new Error(`create filtered board view failed: ${created.status}`);
+    const { viewId } = await created.json();
+    return viewId;
+  }, { windowId: ORDER_BOARD_WINDOW_ID, rowIds });
+}
+
+/**
+ * Poll Traffic Management's OWN default view (its "not assigned" filter -- see test 5 -- already shows
+ * a freshly-created, not-yet-assigned schedule) until the row for `productId` has a resolved
+ * Carrier_Product_ID. Needed before the "Schedule" quick action can run: assigning a workplace requires
+ * the schedule's carrier already resolved (CreateOrUpdatePickingJobSchedulesCommand.assumeCarrierProductSet,
+ * gated by AD_SysConfig de.metas.handlingunits.picking.job_schedule.RequireCarrierProductSet='Y' on this
+ * stack) -- and that resolution runs on a separate async workpackage
+ * (AdviseDeliveryOrderWorkpackageProcessor), so it is NOT guaranteed to have completed by the time the
+ * seeding request returns (verified: reliably present for a single-line order, but a race for a
+ * multi-line one -- this poll removes the race instead of depending on incidental timing).
+ */
+async function waitForScheduleCarrierResolved(page, productId, opts) {
+  return waitForViewRow(
+    page,
+    TRAFFIC_MANAGEMENT_WINDOW_ID,
+    (r) => byProduct(productId)(r) && !!r.fieldsByName?.Carrier_Product_ID?.value?.key,
+    opts
+  );
+}
+
+/** Navigate to a window/view and select a single row (mirrors material-cockpit-v2-jump-preconditions.spec.js). */
+async function selectRow(page, windowId, viewId, rowId, { pageNumber = 1 } = {}) {
+  await page.goto(`${FRONTEND_BASE_URL}/window/${windowId}?viewId=${viewId}`);
+  if (pageNumber > 1) {
+    await goToGridPage(page, pageNumber);
+  }
+  const row = page.locator(`tbody tr[data-testid="table-row-${rowId}"]`);
+  await row.waitFor({ state: 'visible', timeout: 30000 });
+  // A click right after the grid renders does not always land as a selection -- assert it, retrying.
+  await expect(async () => {
+    await row.click();
+    await expect(row).toHaveClass(/row-selected/, { timeout: 2000 });
+  }).toPass({ timeout: 30000 });
+  return row;
+}
+
+/** Board-scoped convenience wrapper around selectRow(). */
+async function selectBoardRow(page, viewId, rowId, opts) {
+  return selectRow(page, ORDER_BOARD_WINDOW_ID, viewId, rowId, opts);
+}
+
+/**
+ * Navigate the currently-loaded grid to `pageNumber` (1-based). Needed because a freshly-seeded row can
+ * land beyond page 1 once a view accumulates more than GRID_DEFAULT_PAGE_LENGTH rows -- see
+ * waitForViewRow(). TablePagination.js renders every page number directly (no "..." compression) for
+ * up to 7 pages (`pages < 8`); this deliberately does not handle the compressed/goToPage case, since 7
+ * pages (105 rows) is well beyond what this spec's own seeding accumulates in the window's lifetime.
+ */
+async function goToGridPage(page, pageNumber) {
+  const pageLink = page.locator('.pagination-wrapper li.page-item a').filter({ hasText: new RegExp(`^${pageNumber}$`) });
+  await pageLink.first().click({ timeout: 15000 });
+}
+
+/**
+ * Navigate to the board and select TWO rows via ctrl-click (Table.js:191 `e.metaKey || e.ctrlKey` ->
+ * "select more"). No precedent for multi-row selection exists anywhere in e2e/frontend-webui (both
+ * material-cockpit-v2-jump-preconditions.spec.js and forecast-overlay-qty.spec.js select a single row);
+ * this gesture was derived from frontend/src/components/table/Table.js and is verified by this test run
+ * itself (both rows must show the row-selected class, independent of whether the jump action exists).
+ */
+async function selectTwoBoardRows(page, viewId, rowIdFirst, rowIdSecond, { pageNumberFirst = 1, pageNumberSecond = 1 } = {}) {
+  // Both rows must render on the SAME grid page for a ctrl-click to add the second to the first's
+  // selection -- selection state is not verified to survive a page-to-page navigation in this suite
+  // (no precedent), so a cross-page pair is a genuine limitation of this helper, surfaced explicitly
+  // rather than silently attempted. See waitForViewRow() for why a row's page can vary at all.
+  if (pageNumberFirst !== pageNumberSecond) {
+    throw new Error(
+      `Cannot multi-select: row ${rowIdFirst} is on grid page ${pageNumberFirst} but row ${rowIdSecond} is on page ${pageNumberSecond}. ` +
+      'This helper only supports ctrl-clicking two rows on the same page.'
+    );
+  }
+
+  await page.goto(`${FRONTEND_BASE_URL}/window/${ORDER_BOARD_WINDOW_ID}?viewId=${viewId}`);
+  if (pageNumberFirst > 1) {
+    await goToGridPage(page, pageNumberFirst);
+  }
+
+  const firstRow = page.locator(`tbody tr[data-testid="table-row-${rowIdFirst}"]`);
+  await firstRow.waitFor({ state: 'visible', timeout: 30000 });
+  await expect(async () => {
+    await firstRow.click();
+    await expect(firstRow).toHaveClass(/row-selected/, { timeout: 2000 });
+  }).toPass({ timeout: 30000 });
+
+  const secondRow = page.locator(`tbody tr[data-testid="table-row-${rowIdSecond}"]`);
+  await secondRow.waitFor({ state: 'visible', timeout: 30000 });
+  await expect(async () => {
+    await secondRow.click({ modifiers: ['Control'] });
+    await expect(secondRow).toHaveClass(/row-selected/, { timeout: 2000 });
+  }).toPass({ timeout: 30000 });
+
+  // The ctrl-click must ADD to the selection, not replace it -- assert the first row is still selected.
+  await expect(firstRow, 'ctrl-click on a second row must keep the first row selected too').toHaveClass(/row-selected/);
+
+  return { firstRow, secondRow };
+}
+
+/** Open the Aktionen (quick-actions) dropdown for the currently selected row(s). */
+async function openQuickActionsDropdown(page) {
+  // The whole quick-actions bar (including this toggle) renders only when actions.length > 0
+  // (frontend/src/components/app/QuickActions.js:155). The board currently has ZERO AD_Table_Process
+  // rows for table 542626 (verified against the running stack), so before the jump is wired the toggle
+  // never appears at all -- an explicit, short timeout here turns that into a fast, clear failure
+  // instead of hanging until the enclosing test's own (120s) timeout.
+  await page.locator('[data-testid="quick-action-dropdown-toggle"]').first().click({ timeout: 10000 });
+  const dropdown = page.locator('.quick-actions-dropdown');
+  await dropdown.waitFor({ state: 'visible', timeout: 15000 });
+  return dropdown;
+}
+
+// AD_Process.Value of Traffic Management's OWN, pre-existing "Schedule" quick action
+// (PickingJobScheduleView_Schedule, AD_Process_ID 585493, AD_Table_Process on table 542514) -- unrelated
+// to the jump this spec is testing; used only as test SETUP, to reach a genuinely assigned schedule
+// exactly the way a real Traffic Management user would (rather than via the frontend-testing masterdata
+// API's `workplace` shortcut, whose own createSchedules() call races the same async carrier-advise
+// workpackage this setup already waits out -- see waitForScheduleCarrierResolved()).
+const SCHEDULE_ACTION_TESTID = 'quick-action-PickingJobScheduleView_Schedule';
+
+/**
+ * Assign the given Traffic Management row to `workplaceName` via the window's own "Schedule" quick
+ * action -- a NEW pattern in this suite (no existing spec fills a process-parameter dialog). Process
+ * parameters render through the same WidgetWrapper machinery as window fields
+ * (frontend/src/components/Process.js -> dataSource="process"), so the lookup fill/select gesture is
+ * identical to a window field (`#lookup_<Column> input` + pick the first `.input-dropdown-list-option`,
+ * as compensation-group-bundle.spec.js already does for a window's own product lookup); the modal's
+ * start button carries a stable data-testid (frontend/src/components/app/Modal.js:743).
+ */
+async function assignWorkplaceViaScheduleAction(page, viewId, rowId, workplaceName, { pageNumber = 1 } = {}) {
+  await selectRow(page, TRAFFIC_MANAGEMENT_WINDOW_ID, viewId, rowId, { pageNumber });
+  const dropdown = await openQuickActionsDropdown(page);
+  const entry = dropdown.getByTestId(SCHEDULE_ACTION_TESTID);
+  await expect(entry, `${SCHEDULE_ACTION_TESTID} must be offered on Traffic Management (pre-existing action)`).toBeVisible({ timeout: 10000 });
+  await entry.click();
+
+  const startButton = page.locator('[data-testid="process-modal-start-button"]');
+  await startButton.waitFor({ state: 'visible', timeout: 15000 });
+
+  const workplaceField = page.locator('#lookup_C_Workplace_ID input');
+  await workplaceField.waitFor({ state: 'visible', timeout: 15000 });
+  await workplaceField.fill(workplaceName);
+  await page.waitForTimeout(800);
+  await page.locator('.input-dropdown-list-option').first().click();
+  await page.waitForTimeout(500);
+
+  await startButton.click();
+  await startButton.waitFor({ state: 'detached', timeout: 20000 });
+}
+
+/**
+ * Fetch the rows of an already-created view via REST (used to inspect the Traffic Management grid the
+ * jump opens, whose viewId we learn from the intercepted documentView response).
+ */
+async function fetchViewRows(page, windowId, viewId) {
+  return page.evaluate(async ({ windowId, viewId }) => {
+    const apiUrl = config.API_URL; // see waitForBoardRow() for why an absolute base URL is required
+    const resp = await fetch(`${apiUrl}/documentView/${windowId}/${viewId}?firstRow=0&pageLength=500`, {
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+    });
+    if (!resp.ok) throw new Error(`fetch view rows failed: ${resp.status}`);
+    return resp.json();
+  }, { windowId, viewId });
+}
+
+/**
+ * Click the jump entry and wait for the target grid's rows GET to fire, for any window other than the
+ * board itself (the overlay is a same-tab modal, so page.url() never changes -- see
+ * material-cockpit-v2-jump-preconditions.spec.js:152-171, whose race-and-retry shape this mirrors).
+ * Returns the matched window id and view id parsed out of the intercepted URL.
+ */
+async function clickJumpAndCaptureTargetView(page, entry) {
+  const targetViewResponsePromise = page.waitForResponse((response) => {
+    if (response.request().method() !== 'GET') return false;
+    const match = response.url().match(/\/documentView\/(\d+)\/([^/?]+)\?firstRow=/);
+    return !!match && match[1] !== String(ORDER_BOARD_WINDOW_ID);
+  }, { timeout: 30000 });
+
+  await entry.click();
+  const targetViewResponse = await targetViewResponsePromise;
+  const match = targetViewResponse.url().match(/\/documentView\/(\d+)\/([^/?]+)\?firstRow=/);
+  return { windowId: match[1], viewId: decodeURIComponent(match[2]) };
+}
+
+/**
+ * Click the jump entry and prove the REACHABLE half of the "readable message, no Oops/500" promise for
+ * a valid selection: it must open cleanly, with no error toast and no 5xx response anywhere in-flight.
+ * Delegates the positive navigation proof to clickJumpAndCaptureTargetView() (a working jump is itself
+ * the primary evidence -- a broken one hangs there for 30s instead of silently "passing"), then checks
+ * the negative side-channels an error path would have left behind.
+ */
+async function clickJumpAndExpectNoError(page, entry) {
+  const serverErrors = [];
+  const onResponse = (response) => {
+    if (response.status() >= 500) serverErrors.push(`${response.status()} ${response.url()}`);
+  };
+  page.on('response', onResponse);
+  try {
+    const target = await clickJumpAndCaptureTargetView(page, entry);
+    const errorToastVisible = await page
+      .locator('.Toastify div[role="alert"].Toastify__toast-body')
+      .isVisible()
+      .catch(() => false);
+    expect(errorToastVisible, 'no error toast may be shown once the jump opened a target grid').toBe(false);
+    expect(serverErrors, 'no 5xx response may occur while opening the jump target').toEqual([]);
+    return target;
+  } finally {
+    page.off('response', onResponse);
+  }
+}
+
+test.describe('Auftrags-Board -> Traffic Management jump', () => {
+  test('single waiting board row: the jump lists exactly that row\'s schedules', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00245: Traffic Management');
+    allure.tag('F00245');
+    allure.story('Jump from a single, not-yet-assigned board row');
+    allure.severity('critical');
+    allure.description(`
+### Scenario
+1. Seed a sales-order line for a fresh product, with on-hand stock (needed so the still-unassigned
+   schedule row clears the board's own \`isassigned='Y' OR qtyonhand>0\` filter) but no workplace.
+2. Select that Auftrags-Board row and run the jump.
+3. Traffic Management opens; every visible row carries that product, and the row count equals the
+   board row's OrderLineCount.
+
+Proves AC1 (the action is offered) and AC2 (single row -> exactly its schedules).
+    `);
+    test.setTimeout(120000);
+
+    const datePromised = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const masterdata = await Backend.createMasterdata({
+      request: {
+        login: { user: { language: 'de_DE', firstname: 'orderboard', lastname: 'jump1' } },
+        bpartners: { bp: { isVendor: false, isCustomer: true, isSoPriceList: true, name: 'OrderBoardJump-Waiting-Partner' } },
+        warehouses: { wh: {} },
+        // M_Picking_Job_Schedule_view's OWN base_schedule CTE excludes every row -- assigned or not --
+        // that has no Carrier_Product_ID, whenever AD_SysConfig RequireCarrierProductSet='Y' (verified
+        // against the running stack: `WHERE s.carrier_product_id > 0 OR get_sysconfig_value(...) = 'N'`
+        // in M_Picking_Job_Schedule_view.sql). Without a shipper this row would not just be hidden by the
+        // board's own OR-filter -- it would not exist in the source view at all. See the
+        // "fully-assigned board row" test for why IsApiCarrierAdvise='Y' (no gateway) is the reliable,
+        // no-external-dependency way to resolve it.
+        shippers: { ship1: { name: 'NoGwCarrier', isApiCarrierAdvise: true } },
+        products: { p1: { name: 'OrderBoardJump-Waiting-Product', prices: [{ price: 10 }] } },
+        // Real on-hand stock (via a virtual-inventory-backed HU), independent of the sales order below --
+        // an unassigned schedule row is dropped from the board entirely unless qtyonhand>0
+        // (M_Picking_OrderBoard_Overview_v.sql WHERE clause).
+        handlingUnits: { hu1: { product: 'p1', warehouse: 'wh', qty: 50 } },
+        salesOrders: {
+          so1: {
+            bpartner: 'bp',
+            warehouse: 'wh',
+            shipper: 'ship1',
+            datePromised,
+            lines: [{ product: 'p1', qty: 5 }], // no workplace -> IsAssigned='N' ("waiting")
+          },
+        },
+      },
+    });
+    allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+
+    const productId = masterdata.products.p1.id;
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await expectDashboardVisible(page);
+
+    const { viewId, rowId, row, pageNumber } = await waitForBoardRow(page, productId);
+    const expectedOrderLineCount = row.fieldsByName.OrderLineCount.value;
+
+    await selectBoardRow(page, viewId, rowId, { pageNumber });
+    const dropdown = await openQuickActionsDropdown(page);
+    const entry = dropdown.getByTestId(JUMP_ACTION_TESTID);
+
+    // --- EXPECTED RED: the migration that wires the jump has not been applied yet, so the Aktionen menu
+    // offers no jump entry at all. This is the assertion that must fail right now, for exactly this reason.
+    await expect(entry, `${JUMP_ACTION_TESTID} must be offered once the jump is wired`).toBeVisible({ timeout: 10000 });
+    await expect(entry, `${JUMP_ACTION_TESTID} must not be disabled for a valid single-row selection`).not.toHaveClass(/quick-actions-item-disabled/);
+
+    // --- Once the jump is wired, the rest of this test proves AC1/AC2 without further changes.
+    const { windowId: targetWindowId, viewId: targetViewId } = await clickJumpAndCaptureTargetView(page, entry);
+    expect(targetWindowId, 'the jump must open a window other than the board itself').not.toBe(String(ORDER_BOARD_WINDOW_ID));
+
+    const targetView = await fetchViewRows(page, targetWindowId, targetViewId);
+    expect(targetView.result.length, 'row count must equal the board row\'s OrderLineCount').toBe(expectedOrderLineCount);
+    for (const targetRow of targetView.result) {
+      expect(
+        String(targetRow.fieldsByName?.M_Product_ID?.value?.key),
+        'every row opened by the jump must carry the selected board row\'s product'
+      ).toBe(String(productId));
+    }
+  });
+
+  test('fully-assigned board row: its rows stay visible after the jump (regression guard)', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00245: Traffic Management');
+    allure.tag('F00245');
+    allure.story('Jump from a fully-assigned board row must not land on an empty grid');
+    allure.severity('critical');
+    allure.description(`
+### Scenario
+1. Seed a sales-order line assigned to a workplace, so its schedule is IsAssigned='Y' and QtyWaiting=0
+   (the board's "In Kommissionierung" bucket).
+2. Select that board row and run the jump.
+3. Traffic Management opens WITH those rows visible -- not an empty grid, and not a grid whose only
+   content is hidden behind the "not assigned" default filter.
+
+This is the exact failure the customer was shown by the predecessor delivery: the
+RelationTypeInOverlayProcess.setUseAutoFilters(true) default re-applied Traffic Management's own
+"Filter nach: Not Zugeordnet" filter on top of an already-assigned selection, hiding every row. Proves
+AC4, and is the regression guard for the AD_Process.IsUseAutoFilters='N' plumbing.
+    `);
+    test.setTimeout(120000);
+
+    const datePromised = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const masterdata = await Backend.createMasterdata({
+      request: {
+        login: { user: { language: 'de_DE', firstname: 'orderboard', lastname: 'jump2' } },
+        bpartners: { bp: { isVendor: false, isCustomer: true, isSoPriceList: true, name: 'OrderBoardJump-Assigned-Partner' } },
+        warehouses: { wh: {} },
+        workplaces: { wp1: { warehouse: 'wh' } },
+        // A workplace assignment requires the schedule's Carrier_Product_ID already resolved
+        // (CreateOrUpdatePickingJobSchedulesCommand.assumeCarrierProductSet, gated by AD_SysConfig
+        // RequireCarrierProductSet='Y' on this stack) -- verified: a fresh order with no shipper never
+        // even requests a carrier advise (Carrier_Advising_Status stays 'NR'), so any assignment attempt
+        // throws CarrierProductNotSet. IsApiCarrierAdvise='Y' with no gateway makes CarrierAdviseCommand
+        // synthesize the advise LOCALLY (carrier product = shipper name) -- no external shipper-gateway
+        // dependency -- but it still runs on a separate async workpackage (see
+        // waitForScheduleCarrierResolved()), so the line below is seeded WITHOUT a workplace and gets
+        // assigned afterwards via the real "Schedule" UI action once the advise has settled.
+        shippers: { ship1: { name: 'NoGwCarrier', isApiCarrierAdvise: true } },
+        products: { p2: { name: 'OrderBoardJump-Assigned-Product', prices: [{ price: 10 }] } },
+        salesOrders: {
+          so2: {
+            bpartner: 'bp',
+            warehouse: 'wh',
+            shipper: 'ship1',
+            datePromised,
+            lines: [{ product: 'p2', qty: 8 }],
+          },
+        },
+      },
+    });
+    allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+
+    const productId = masterdata.products.p2.id;
+    const workplaceName = masterdata.workplaces.wp1.name;
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await expectDashboardVisible(page);
+
+    const scheduleRow = await waitForScheduleCarrierResolved(page, productId);
+    await assignWorkplaceViaScheduleAction(page, scheduleRow.viewId, scheduleRow.rowId, workplaceName, { pageNumber: scheduleRow.pageNumber });
+
+    const { viewId, rowId, row, pageNumber } = await waitForBoardRow(page, productId);
+    expect(row.fieldsByName.QtyWaiting.value, 'the seeded row must be entirely assigned (QtyWaiting=0)').toBe('0');
+
+    await selectBoardRow(page, viewId, rowId, { pageNumber });
+    const dropdown = await openQuickActionsDropdown(page);
+    const entry = dropdown.getByTestId(JUMP_ACTION_TESTID);
+
+    // --- EXPECTED RED: no jump entry yet.
+    await expect(entry, `${JUMP_ACTION_TESTID} must be offered once the jump is wired`).toBeVisible({ timeout: 10000 });
+    await expect(entry, `${JUMP_ACTION_TESTID} must not be disabled for a valid single-row selection`).not.toHaveClass(/quick-actions-item-disabled/);
+
+    // --- Once the jump is wired: the grid must NOT be empty despite every schedule being assigned.
+    const { windowId: targetWindowId, viewId: targetViewId } = await clickJumpAndCaptureTargetView(page, entry);
+    const targetView = await fetchViewRows(page, targetWindowId, targetViewId);
+    expect(targetView.result.length, 'the fully-assigned board row must not open an empty Traffic Management grid').toBeGreaterThan(0);
+    for (const targetRow of targetView.result) {
+      expect(String(targetRow.fieldsByName?.M_Product_ID?.value?.key)).toBe(String(productId));
+    }
+  });
+
+  test('two board rows selected: one grid holds the union, nothing from a third product', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00245: Traffic Management');
+    allure.tag('F00245');
+    allure.story('Multi-row selection opens one combined grid');
+    allure.severity('normal');
+    allure.description(`
+### Scenario
+1. Seed three products on one order, each getting its own board row (grouping is per-product).
+2. Select TWO of the three rows (ctrl-click) and run the jump.
+3. Expected: one Traffic Management grid holding the union of the two selected rows' schedules, and
+   nothing belonging to the third, unselected product.
+
+Proves AC3 (RelationTypeInOverlayProcess.createCombinedFilterView's OR-union path).
+    `);
+    test.setTimeout(120000);
+
+    const datePromised = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const masterdata = await Backend.createMasterdata({
+      request: {
+        login: { user: { language: 'de_DE', firstname: 'orderboard', lastname: 'jump3' } },
+        bpartners: { bp: { isVendor: false, isCustomer: true, isSoPriceList: true, name: 'OrderBoardJump-Multi-Partner' } },
+        warehouses: { wh: {} },
+        workplaces: { wp1: { warehouse: 'wh' } },
+        // See the "fully-assigned board row" test above for why a shipper with a local (no-gateway)
+        // carrier advise is required before any line can carry a workplace.
+        shippers: { ship1: { name: 'NoGwCarrier', isApiCarrierAdvise: true } },
+        products: {
+          pA: { name: 'OrderBoardJump-Multi-A', prices: [{ price: 10 }] },
+          pB: { name: 'OrderBoardJump-Multi-B', prices: [{ price: 10 }] },
+          pC: { name: 'OrderBoardJump-Multi-C', prices: [{ price: 10 }] },
+        },
+        salesOrders: {
+          so3: {
+            bpartner: 'bp',
+            warehouse: 'wh',
+            shipper: 'ship1',
+            datePromised,
+            // No `workplace` here -- see the "fully-assigned board row" test for why the assignment is
+            // done afterwards via the real "Schedule" UI action instead. Product C is NOT selected for
+            // the jump below, but is assigned too: it must be a genuine, visible board row (assigned or
+            // stocked) for "nothing from a third product" to prove anything -- an invisible row would
+            // trivially satisfy that assertion without exercising the union filter at all.
+            lines: [
+              { product: 'pA', qty: 3 },
+              { product: 'pB', qty: 4 },
+              { product: 'pC', qty: 2 },
+            ],
+          },
+        },
+      },
+    });
+    allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+
+    const productIdA = masterdata.products.pA.id;
+    const productIdB = masterdata.products.pB.id;
+    const productIdC = masterdata.products.pC.id;
+    const workplaceName = masterdata.workplaces.wp1.name;
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await expectDashboardVisible(page);
+
+    for (const productId of [productIdA, productIdB, productIdC]) {
+      const scheduleRow = await waitForScheduleCarrierResolved(page, productId);
+      await assignWorkplaceViaScheduleAction(page, scheduleRow.viewId, scheduleRow.rowId, workplaceName, { pageNumber: scheduleRow.pageNumber });
+    }
+
+    const rowA = await waitForBoardRow(page, productIdA);
+    const rowB = await waitForBoardRow(page, productIdB);
+    // Sanity: the third product's own row must also exist and be excludable -- otherwise "nothing from
+    // a third product" would be true only because there is no third row to leak in the first place.
+    await waitForBoardRow(page, productIdC);
+
+    // Narrow to exactly rows A and B via a server-side filterOnlyIds view (see
+    // createFilteredBoardView()) so both are guaranteed to land on the SAME grid page (page 1 -- only
+    // two rows exist in this view), regardless of how many unrelated rows the unfiltered board view has
+    // accumulated across this stack's test history.
+    const filteredViewId = await createFilteredBoardView(page, [rowA.rowId, rowB.rowId]);
+    await selectTwoBoardRows(page, filteredViewId, rowA.rowId, rowB.rowId);
+    const dropdown = await openQuickActionsDropdown(page);
+    const entry = dropdown.getByTestId(JUMP_ACTION_TESTID);
+
+    // --- EXPECTED RED: no jump entry yet.
+    await expect(entry, `${JUMP_ACTION_TESTID} must be offered once the jump is wired`).toBeVisible({ timeout: 10000 });
+    await expect(entry, `${JUMP_ACTION_TESTID} must not be disabled for a valid multi-row selection`).not.toHaveClass(/quick-actions-item-disabled/);
+
+    // --- Once the jump is wired: one combined grid, union of A+B, nothing from C.
+    const { windowId: targetWindowId, viewId: targetViewId } = await clickJumpAndCaptureTargetView(page, entry);
+    const targetView = await fetchViewRows(page, targetWindowId, targetViewId);
+    expect(targetView.result.length, 'the combined grid must not be empty').toBeGreaterThan(0);
+
+    const targetProductIds = new Set(targetView.result.map((r) => String(r.fieldsByName?.M_Product_ID?.value?.key)));
+    expect(targetProductIds.has(String(productIdA)), 'the union must include product A').toBe(true);
+    expect(targetProductIds.has(String(productIdB)), 'the union must include product B').toBe(true);
+    expect(targetProductIds.has(String(productIdC)), 'the union must NOT include the unselected product C').toBe(false);
+  });
+
+  test('selection still valid after a concurrent update (no reload): the jump opens cleanly, no Oops/500', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00245: Traffic Management');
+    allure.tag('F00245');
+    allure.story('A valid selection that outlives a concurrent update still opens cleanly');
+    allure.severity('normal');
+    allure.description(`
+### Scenario
+1. Seed a fully-assigned board row and select it in the browser.
+2. WITHOUT reloading the page, create a DRAFT (not completed) shipment against the sales order's
+   schedule via the Backend API (chained onto the same masterdata context) -- a concurrent update
+   landing after the row was selected but before the jump is clicked. A draft shipment binds the
+   schedule's picked-quantity rows without completing the document, so the schedule stays open
+   (QtyToDeliver > 0) and keeps its place in Traffic Management -- unlike completing/fully shipping it,
+   which would legitimately (and correctly) remove it from Traffic Management's own grid, a different,
+   unrelated behaviour this test must not conflate with an error.
+3. Run the jump on that selection.
+4. Expected: the jump opens Traffic Management scoped to the row's product, with no error toast and no
+   5xx response anywhere in-flight, and the row is still there.
+
+### Why this asserts success, not the original "stale selection -> readable error" idea
+\`M_Picking_OrderBoard_Overview_v\` is built directly on \`m_picking_job_schedule_view\` and groups by the
+same key \`(m_product_id, c_uom_id, deliverydate::date, c_country_id, ad_client_id, ad_org_id)\` that the
+jump's own zoom-source lookup uses -- so a board row that is still live in the grid always has at least
+one resolvable schedule; the two can never diverge for a selection that has not been reloaded away. That
+makes the "selection whose schedules no longer resolve" case structurally unreachable through this UI
+flow. The error path itself (\`RelationTypeInOverlayProcess\` surfacing \`MSG_NO_RELATED_DOCS_FOUND\`
+instead of a raw failure when the relation resolves zero related documents) is covered where it IS
+reachable: JUnit \`RelationTypeInOverlayProcessTest.DoIt#throws_whenNoRelatedDocumentsFound\` (single
+selection) and \`RelationTypeInOverlayProcessTest.DoItMultiSelection#throws_whenNoRelatedDocsForAnySelectedRow\`
+(combined selection). What THIS e2e test instead proves is the reachable half of the same promise: a
+concurrent update landing between selection and click must never surface an error for a selection that
+is (and remains) valid.
+    `);
+    test.setTimeout(120000);
+
+    const datePromised = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const masterdata = await Backend.createMasterdata({
+      request: {
+        login: { user: { language: 'de_DE', firstname: 'orderboard', lastname: 'jump4' } },
+        bpartners: { bp: { isVendor: false, isCustomer: true, isSoPriceList: true, name: 'OrderBoardJump-ConcurrentUpdate-Partner' } },
+        warehouses: { wh: {} },
+        workplaces: { wp1: { warehouse: 'wh' } },
+        // See the "fully-assigned board row" test above for why a shipper with a local (no-gateway)
+        // carrier advise is required before any line can carry a workplace.
+        shippers: { ship1: { name: 'NoGwCarrier', isApiCarrierAdvise: true } },
+        products: { p4: { name: 'OrderBoardJump-ConcurrentUpdate-Product', prices: [{ price: 10 }] } },
+        salesOrders: {
+          so4: {
+            bpartner: 'bp',
+            warehouse: 'wh',
+            shipper: 'ship1',
+            datePromised,
+            lines: [{ product: 'p4', qty: 6 }], // assigned afterwards via the "Schedule" UI action, not the masterdata shortcut
+          },
+        },
+      },
+    });
+    allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+
+    const productId = masterdata.products.p4.id;
+    const workplaceName = masterdata.workplaces.wp1.name;
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await expectDashboardVisible(page);
+
+    const scheduleRow = await waitForScheduleCarrierResolved(page, productId);
+    await assignWorkplaceViaScheduleAction(page, scheduleRow.viewId, scheduleRow.rowId, workplaceName, { pageNumber: scheduleRow.pageNumber });
+
+    const { viewId, rowId, pageNumber } = await waitForBoardRow(page, productId);
+    await selectBoardRow(page, viewId, rowId, { pageNumber });
+    const dropdown = await openQuickActionsDropdown(page);
+    const entry = dropdown.getByTestId(JUMP_ACTION_TESTID);
+
+    // Update the schedule WITHOUT navigating away, between selecting the row and clicking the jump --
+    // exactly the race a real user can hit. Chains onto the FIRST call's context
+    // (JsonCreateMasterdataRequest.context / MasterdataContext#putFromJson-#toJson round-trip) so
+    // `salesOrder: 'so4'` resolves -- an established, plain-JSON mechanism, though not previously
+    // exercised by any spec in this suite. `complete: false` leaves the shipment as DRAFT (not
+    // completed) so the schedule stays open and visible in Traffic Management -- see the description
+    // above for why completing it instead would be a different, unrelated (and correct) disappearance.
+    await Backend.createMasterdata({
+      request: {
+        context: masterdata.context,
+        shipments: { draftShip: { salesOrder: 'so4', complete: false } },
+      },
+    });
+
+    await expect(entry, `${JUMP_ACTION_TESTID} must be offered for a valid single-row selection`).toBeVisible({ timeout: 10000 });
+    await expect(entry, `${JUMP_ACTION_TESTID} must not be disabled for a valid single-row selection`).not.toHaveClass(/quick-actions-item-disabled/);
+
+    // The selection is still valid (see the description above for why it structurally cannot go stale
+    // this way) -- the jump must open Traffic Management scoped to the row's product, cleanly.
+    const { windowId: targetWindowId, viewId: targetViewId } = await clickJumpAndExpectNoError(page, entry);
+    expect(targetWindowId, 'the jump must open a window other than the board itself').not.toBe(String(ORDER_BOARD_WINDOW_ID));
+
+    const targetView = await fetchViewRows(page, targetWindowId, targetViewId);
+    expect(targetView.result.length, 'the jump target grid must not be empty for a still-valid selection').toBeGreaterThan(0);
+    for (const targetRow of targetView.result) {
+      expect(
+        String(targetRow.fieldsByName?.M_Product_ID?.value?.key),
+        'every row opened by the jump must carry the selected board row\'s product'
+      ).toBe(String(productId));
+    }
+  });
+
+  test('Traffic Management opened from the menu still applies its default not-assigned filter', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00245: Traffic Management');
+    allure.tag('F00245');
+    allure.story('Opening Traffic Management normally is unaffected by the jump\'s IsUseAutoFilters override');
+    allure.severity('critical');
+    allure.description(`
+### Scenario
+Open Traffic Management directly (as the menu / breadcrumb would), with no jump involved. Expected: the
+view-creation response still carries the "not assigned" default filter (AD_Column 591490,
+FilterDefaultValue='N') -- verified live against this window: creating a documentView for window 541929
+returns \`filters: [{filterId:"default", parameters:[{parameterName:"IsAssigned", value:false}]}]\`.
+
+This test must PASS from the start: it exercises the window's OWN default-filter plumbing, not the jump
+action a follow-up migration adds, and it guards the IsUseAutoFilters routing against over-reach into
+ordinary window navigation. Proves AC5.
+    `);
+    test.setTimeout(60000);
+
+    const masterdata = await Backend.createMasterdata({
+      request: {
+        login: { user: { language: 'de_DE', firstname: 'orderboard', lastname: 'jump5' } },
+      },
+    });
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await expectDashboardVisible(page);
+
+    const viewCreateResponsePromise = page.waitForResponse(
+      (response) => response.request().method() === 'POST' && new RegExp(`/documentView/${TRAFFIC_MANAGEMENT_WINDOW_ID}$`).test(response.url())
+    );
+    await page.goto(`${FRONTEND_BASE_URL}/window/${TRAFFIC_MANAGEMENT_WINDOW_ID}`);
+    const viewCreateResponse = await viewCreateResponsePromise;
+    const body = await viewCreateResponse.json();
+
+    const isAssignedFilterParam = (body.filters || [])
+      .flatMap((filter) => filter.parameters || [])
+      .find((param) => param.parameterName === 'IsAssigned');
+
+    expect(isAssignedFilterParam, 'Traffic Management opened from the menu must still carry its default IsAssigned filter parameter').toBeTruthy();
+    expect(isAssignedFilterParam.value, 'the default filter must be "not assigned" (IsAssigned=false), unchanged').toBe(false);
+  });
+});

--- a/e2e/frontend-webui/tests/spec/order-board-jump-to-traffic-management.spec.js
+++ b/e2e/frontend-webui/tests/spec/order-board-jump-to-traffic-management.spec.js
@@ -110,6 +110,33 @@ async function waitForBoardRow(page, productId, opts) {
 }
 
 /**
+ * Distinguish two Traffic Management schedule rows for the SAME product by their QtyOrdered.
+ * Needed when one board row aggregates more than one schedule for one product (the mixed-tuple
+ * case: an assigned line and an unassigned, unstocked sibling line for the same product/UOM/date/
+ * country) and each schedule must be resolved individually -- e.g. to assign only ONE of the two
+ * same-product lines to a workplace. QtyOrdered is present in fieldsByName even though
+ * IsDisplayed='N' on this tab (verified against the running stack, AD_Field 752539) -- the JSON view
+ * payload is not limited to rendered fields; see waitForBoardRow()'s use of M_Product_ID (also
+ * IsDisplayed='N' on this tab, AD_Field 752536) for the same pattern already relied on above.
+ */
+const byProductAndQty = (productId, qty) => (r) =>
+  byProduct(productId)(r) && Number(r.fieldsByName?.QtyOrdered?.value) === qty;
+
+/**
+ * Poll Traffic Management until the schedule for `productId` carrying exactly `qty` has its carrier
+ * resolved -- see waitForScheduleCarrierResolved() below for why this wait is needed; this variant
+ * disambiguates by QtyOrdered when more than one schedule row exists for the same product.
+ */
+async function waitForScheduleCarrierResolvedByQty(page, productId, qty, opts) {
+  return waitForViewRow(
+    page,
+    TRAFFIC_MANAGEMENT_WINDOW_ID,
+    (r) => byProductAndQty(productId, qty)(r) && !!r.fieldsByName?.Carrier_Product_ID?.value?.key,
+    opts
+  );
+}
+
+/**
  * Create a NEW board view scoped to exactly `rowIds`, via the generic `filterOnlyIds` mechanism
  * (JSONCreateViewRequest.filterOnlyIds -> SqlViewFactory: a server-side sticky `keyColumn IN (...)`
  * filter -- de.metas.ui.web.base SqlViewFactory.java "if (!request.getFilterOnlyIds().isEmpty())";
@@ -716,6 +743,120 @@ is (and remains) valid.
         'every row opened by the jump must carry the selected board row\'s product'
       ).toBe(String(productId));
     }
+  });
+
+  test('mixed-tuple board row: an unassigned, unstocked sibling schedule must not leak through the jump', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00245: Traffic Management');
+    allure.tag('F00245');
+    allure.story('The jump excludes target rows the board itself would not include');
+    allure.severity('critical');
+    allure.description(`
+### Scenario
+1. Seed ONE sales order with TWO lines for the SAME product/UOM/delivery-date/country tuple (so both
+   schedules fall under one Auftrags-Board row): one line gets assigned to a workplace, the other gets
+   NO workplace and NO on-hand stock.
+2. The unassigned, unstocked line fails the board's own \`isassigned='Y' OR qtyonhand>0\` inclusion
+   test, so it does not count towards the board row's OrderLineCount -- but it DOES share the exact
+   grouping tuple the jump's EXISTS back-join matches on.
+3. Select that board row and run the jump.
+4. Expected: the target grid holds EXACTLY the assigned line's schedule -- row count equal to the
+   board row's OrderLineCount (1), never 2 -- and the unassigned/unstocked sibling is absent.
+
+### Why this is the defect this suite was missing
+The jump's WhereClause is an EXISTS back-join to \`M_Picking_OrderBoard_Overview_v\` on the grouping
+tuple, plus a trailing \`AND (IsAssigned='Y' OR QtyOnHand>0)\` on the TARGET row. The EXISTS alone only
+proves "a board aggregate row with this id and this tuple exists" -- it says nothing about whether the
+specific target row would itself have counted towards that aggregate. Without the trailing AND, a
+target row sharing the tuple but failing the board's own inclusion test is still returned, so the jump
+can list more schedules than the board row it was launched from claims to hold (OrderLineCount).
+None of the other five tests in this file seeds two schedules under one tuple with different
+IsAssigned/QtyOnHand outcomes, so none of them can catch a regression here.
+    `);
+    test.setTimeout(120000);
+
+    const datePromised = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const assignedQty = 5;
+    const unassignedQty = 3;
+    const masterdata = await Backend.createMasterdata({
+      request: {
+        login: { user: { language: 'de_DE', firstname: 'orderboard', lastname: 'jump6' } },
+        bpartners: { bp: { isVendor: false, isCustomer: true, isSoPriceList: true, name: 'OrderBoardJump-MixedTuple-Partner' } },
+        warehouses: { wh: {} },
+        workplaces: { wp1: { warehouse: 'wh' } },
+        // See the "fully-assigned board row" test above for why a shipper with a local (no-gateway)
+        // carrier advise is required before any line can carry a workplace -- and, on this stack, before
+        // ANY line (assigned or not) even appears in M_Picking_Job_Schedule_view at all
+        // (RequireCarrierProductSet='Y').
+        shippers: { ship1: { name: 'NoGwCarrier', isApiCarrierAdvise: true } },
+        // ONE product for BOTH lines -- this is what makes them share the board's grouping tuple
+        // (M_Product_ID, C_UOM_ID, DeliveryDate::date, C_Country_ID, AD_Client_ID, AD_Org_ID).
+        products: { p6: { name: 'OrderBoardJump-MixedTuple-Product', prices: [{ price: 10 }] } },
+        // Deliberately NO handlingUnits here -- the unassigned line must have qtyonhand=0. Both lines
+        // are seeded WITHOUT a workplace (see the "fully-assigned board row" test above for why the
+        // workplace shortcut races the async carrier advise for a multi-line order); only the first
+        // line is assigned afterwards, via the real "Schedule" UI action.
+        salesOrders: {
+          so6: {
+            bpartner: 'bp',
+            warehouse: 'wh',
+            shipper: 'ship1',
+            datePromised,
+            lines: [
+              { product: 'p6', qty: assignedQty },   // assigned afterwards -> IsAssigned='Y', counts on the board
+              { product: 'p6', qty: unassignedQty }, // stays unassigned, no stock -> invisible to the board
+            ],
+          },
+        },
+      },
+    });
+    allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+
+    const productId = masterdata.products.p6.id;
+    const workplaceName = masterdata.workplaces.wp1.name;
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await expectDashboardVisible(page);
+
+    // Resolve and assign ONLY the assignedQty line's schedule -- the unassignedQty sibling is left
+    // exactly as seeded (no workplace, no stock).
+    const assignedScheduleRow = await waitForScheduleCarrierResolvedByQty(page, productId, assignedQty);
+    await assignWorkplaceViaScheduleAction(
+      page, assignedScheduleRow.viewId, assignedScheduleRow.rowId, workplaceName, { pageNumber: assignedScheduleRow.pageNumber }
+    );
+    // Sanity: the unassigned sibling's own schedule must genuinely exist (carrier-resolved, so it is not
+    // simply "not created yet") -- otherwise "the sibling is absent from the jump" would be trivially true
+    // because there is no sibling to leak in the first place.
+    await waitForScheduleCarrierResolvedByQty(page, productId, unassignedQty);
+
+    const { viewId, rowId, row, pageNumber } = await waitForBoardRow(page, productId);
+    const expectedOrderLineCount = row.fieldsByName.OrderLineCount.value;
+    expect(expectedOrderLineCount, 'only the assigned line must count towards the board row\'s OrderLineCount').toBe(1);
+
+    await selectBoardRow(page, viewId, rowId, { pageNumber });
+    const dropdown = await openQuickActionsDropdown(page);
+    const entry = dropdown.getByTestId(JUMP_ACTION_TESTID);
+
+    await expect(entry, `${JUMP_ACTION_TESTID} must be offered for a valid single-row selection`).toBeVisible({ timeout: 10000 });
+    await expect(entry, `${JUMP_ACTION_TESTID} must not be disabled for a valid single-row selection`).not.toHaveClass(/quick-actions-item-disabled/);
+
+    const { windowId: targetWindowId, viewId: targetViewId } = await clickJumpAndCaptureTargetView(page, entry);
+    expect(targetWindowId, 'the jump must open a window other than the board itself').not.toBe(String(ORDER_BOARD_WINDOW_ID));
+
+    const targetView = await fetchViewRows(page, targetWindowId, targetViewId);
+    expect(
+      targetView.result.length,
+      'the jump must return exactly the board row\'s OrderLineCount -- not the unassigned, unstocked sibling too'
+    ).toBe(expectedOrderLineCount);
+
+    const [onlyRow] = targetView.result;
+    expect(String(onlyRow.fieldsByName?.M_Product_ID?.value?.key), 'the single returned row must carry the seeded product').toBe(String(productId));
+    expect(
+      Number(onlyRow.fieldsByName?.QtyOrdered?.value),
+      'the single returned row must be the ASSIGNED line, not the unassigned/unstocked sibling'
+    ).toBe(assignedQty);
+    expect(onlyRow.fieldsByName?.C_Workplace_ID?.value?.key, 'the single returned row must carry the assigned workplace').toBeTruthy();
   });
 
   test('Traffic Management opened from the menu still applies its default not-assigned filter', async ({ page }) => {


### PR DESCRIPTION
Gives the Auftrags-Board *Übersicht* tab an *Aktionen* entry that opens Traffic Management showing exactly the picking-job-schedule rows behind the selected board row(s) — **including rows already assigned to a workplace**.

## Why a new switch was needed

The jump reuses the existing generic overlay mechanism (`AD_Process` with `Type='RelationTypeInOverlay'` + an `AD_RelationType`, served by `RelationTypeInOverlayProcess`). That mechanism previously always requested the target window's auto-filters — both call sites hardcoded `.setUseAutoFilters(true)` — so arriving in Traffic Management re-applied its own `IsAssigned='N'` default filter and hid every already-assigned row, landing the user on an empty grid.

Rather than dropping auto-filters unconditionally (which would have removed a reachable behaviour), this adds a per-process switch.

## What changed

**`AD_Process.IsUseAutoFilters`** — new Yes/No column, `CHAR(1)`, mandatory, `DefaultValue='Y'`, backfilled `'Y'` onto every existing row, so no existing jump changes behaviour. Maintained on the AD_Process configuration window, shown only for `Type='RelationTypeInOverlay'` (the same scoping `OpenTarget` uses).

| Value | Meaning |
|---|---|
| `'Y'` (default) | opening the target window also applies that window's own default filters — today's behaviour |
| `'N'` | the jump shows exactly the rows the relation resolved |

**`ProcessInfo` / `RelationTypeInOverlayProcess`** — `ProcessInfo` gains a `useAutoFilters` field mirroring the existing `openTarget` pattern, with a getter that falls back to the backing `AD_Process` row and returns `true` when there is no `AD_Process` behind the `ProcessInfo`. Both `CreateViewRequest` builders now pass `getProcessInfo().isUseAutoFilters()` instead of a hardcoded `true`.

**The board jump** — a new relation type, its source/target references, and the `AD_Process` (`IsUseAutoFilters='N'`) wired onto the board's *Übersicht* table via `AD_Table_Process` with `WEBUI_ViewAction='Y'` / `WEBUI_ViewQuickAction='Y'`. The migration also sets `IsGenericZoomOrigin='Y'` on the board's key column, which `SpecificRelationTypeRelatedDocumentsProvider.matchesAsSource()` requires — both pre-existing overlay-jump sources already carry it.

The relation's target where-clause keys off the board row's own integer id via an `EXISTS` back-join to the board view, matching its grouping tuple, **plus** its own `IsAssigned='Y' OR QtyOnHand > 0` test. That second term is load-bearing: the `EXISTS` proves only that a board aggregate row with that id and tuple exists, not that the target row itself belongs to it, so without it the jump could list schedules the board deliberately excludes.

## Backward compatibility

The three existing `Type='RelationTypeInOverlay'` processes all read `IsUseAutoFilters='Y'`, and the WebUI process launcher builds `ProcessInfo` via `setAD_Process_ID(int)` — so the flag resolves through the DB-load fallback and every existing jump keeps today's behaviour.

## Tests

- **Playwright** (`e2e/frontend-webui/tests/spec/order-board-jump-to-traffic-management.spec.js`, 6 tests, all green): a single waiting row resolves exactly its schedules; a **fully-assigned** row keeps its rows visible after the jump (the regression guard for the empty-grid failure); two selected rows produce one union grid with nothing from a third product; an unassigned, unstocked sibling sharing a tuple does **not** leak through; a valid selection opens cleanly with no error; and opening Traffic Management from the menu still applies its own default filter — proving the `'Y'` default was not over-reached.
- **JUnit** (`RelationTypeInOverlayProcessTest`, 29 green): four new tests pin the switch on and off across both the single-selection and combined-selection paths. The "no related documents" path stays covered by unit tests because it is unreachable from the UI — a board row and its schedules are the same data, so a live board row always resolves.
