### PR TITLE
Manufacturing issue — whole-HU pick across units and the catch weight on the issued HU

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertExpectationsCommandServices.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertExpectationsCommandServices.java
@@ -1,5 +1,6 @@
 package de.metas.frontend_testing.expectations;
 
+import com.google.common.collect.ImmutableList;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.IHandlingUnitsDAO;
@@ -108,6 +109,14 @@ public class AssertExpectationsCommandServices
 	public List<I_PP_Order_Qty> getPPOrderQtyForFinishedGoodsReceive(@NonNull final PPOrderId ppOrderId)
 	{
 		return huPPOrderQtyDAO.retrieveOrderQtyForFinishedGoodsReceive(ppOrderId);
+	}
+
+	public List<I_PP_Order_Qty> getPPOrderQtyForComponentIssue(@NonNull final PPOrderId ppOrderId)
+	{
+		return huPPOrderQtyDAO.retrieveOrderQtys(ppOrderId)
+				.stream()
+				.filter(candidate -> candidate.getPP_Order_BOMLine_ID() > 0)
+				.collect(ImmutableList.toImmutableList());
 	}
 
 	public List<I_M_HU> getIncludedHUs(@NonNull final HuId huId)

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertHUExpectationsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertHUExpectationsCommand.java
@@ -204,7 +204,6 @@ class AssertHUExpectationsCommand
 		return services.getHuIdByQRCode(HUQRCode.fromGlobalQRCodeJsonString(matcherStr));
 	}
 
-
 	private void assertTUs(@NonNull final List<JsonHUExpectation> expectations, @NonNull final HuId luId)
 	{
 		final ArrayList<I_M_HU> tus = new ArrayList<>(services.getIncludedHUs(luId));

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertHUExpectationsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertHUExpectationsCommand.java
@@ -1,7 +1,6 @@
 package de.metas.frontend_testing.expectations;
 
 import com.google.common.collect.ImmutableList;
-import de.metas.common.util.time.SystemTime;
 import de.metas.frontend_testing.expectations.request.JsonHUExpectation;
 import de.metas.frontend_testing.expectations.request.QtyAndUOMString;
 import de.metas.frontend_testing.masterdata.Identifier;
@@ -15,19 +14,12 @@ import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.storage.IHUProductStorage;
 import de.metas.product.ProductId;
 import de.metas.util.GuavaCollectors;
-import de.metas.util.NumberUtils;
 import lombok.Builder;
 import lombok.NonNull;
-import org.adempiere.mm.attributes.AttributeCode;
-import org.adempiere.mm.attributes.AttributeValueType;
-import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
-import org.compiere.util.TimeUtil;
 import org.jetbrains.annotations.NotNull;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -124,7 +116,7 @@ class AssertHUExpectationsCommand
 
 		if (expectation.getAttributes() != null)
 		{
-			assertAttributes(expectation.getAttributes(), huId);
+			HUAttributeAssertions.assertAttributes(services, expectation.getAttributes(), huId);
 		}
 
 		if (expectation.getTus() != null)
@@ -212,94 +204,6 @@ class AssertHUExpectationsCommand
 		return services.getHuIdByQRCode(HUQRCode.fromGlobalQRCodeJsonString(matcherStr));
 	}
 
-	private void assertAttributes(@NonNull final Map<String, String> expectations, @NonNull final HuId huId)
-	{
-		if (expectations.isEmpty())
-		{
-			return;
-		}
-
-		final I_M_HU hu = services.getHUById(huId);
-		assertAttributes(expectations, hu);
-	}
-
-	private void assertAttributes(@NonNull final Map<String, String> expectations, @NonNull final I_M_HU hu)
-	{
-		if (expectations.isEmpty())
-		{
-			return;
-		}
-
-		final ImmutableAttributeSet actualAttributes = services.getAttributes(hu);
-
-		softly(() -> {
-			softlyPutContext("expectedAttributes", expectations);
-			softlyPutContext("actualAttributes", actualAttributes);
-
-			expectations.forEach((attributeCodeStr, expectedValueStr) -> {
-				final AttributeCode attributeCode = AttributeCode.ofString(attributeCodeStr);
-				softlyPutContext("attributeCode", attributeCode);
-
-				if (actualAttributes.hasAttribute(attributeCode))
-				{
-					final AttributeValueType type = actualAttributes.getAttributeValueType(attributeCode);
-					switch (type)
-					{
-						case STRING:
-						case LIST:
-							assertAttributeValue_String(expectedValueStr, actualAttributes, attributeCode);
-							break;
-						case NUMBER:
-							assertAttributeValue_Number(expectedValueStr, actualAttributes, attributeCode);
-							break;
-						case DATE:
-							assertAttributeValue_Date(expectedValueStr, actualAttributes, attributeCode);
-							break;
-						default:
-							fail("Unknown attribute value type: " + type);
-					}
-				}
-				else if (expectedValueStr != null)
-				{
-					fail("Expected missing attribute " + attributeCode + " to be <" + expectedValueStr + ">");
-				}
-			});
-		});
-	}
-
-	private void assertAttributeValue_String(final String expectedValueStr, final ImmutableAttributeSet actualAttributes, final AttributeCode attributeCode)
-	{
-		final String actualValueStr = actualAttributes.getValueAsString(attributeCode);
-		assertThat(actualValueStr).as("String attribute " + attributeCode).isEqualTo(expectedValueStr);
-	}
-
-	private void assertAttributeValue_Number(final String expectedValueStr, final ImmutableAttributeSet actualAttributes, final AttributeCode attributeCode)
-	{
-		final BigDecimal actualValue = actualAttributes.getValueAsBigDecimal(attributeCode);
-		final BigDecimal expectedValue = NumberUtils.asBigDecimal(expectedValueStr);
-		assertThat(actualValue).as("Number attribute " + attributeCode).isEqualTo(expectedValue);
-	}
-
-	private void assertAttributeValue_Date(final String expectedValueStr, final ImmutableAttributeSet actualAttributes, final AttributeCode attributeCode)
-	{
-		final LocalDate actualValue = actualAttributes.getValueAsLocalDate(attributeCode);
-
-		final LocalDate expectedValue;
-		if (expectedValueStr == null || expectedValueStr.trim().equals("-"))
-		{
-			expectedValue = null;
-		}
-		else if (expectedValueStr.equalsIgnoreCase("today"))
-		{
-			expectedValue = SystemTime.asLocalDate();
-		}
-		else
-		{
-			expectedValue = TimeUtil.asLocalDate(expectedValueStr);
-		}
-
-		assertThat(actualValue).as("Date attribute " + attributeCode).isEqualTo(expectedValue);
-	}
 
 	private void assertTUs(@NonNull final List<JsonHUExpectation> expectations, @NonNull final HuId luId)
 	{
@@ -367,7 +271,7 @@ class AssertHUExpectationsCommand
 
 		if (expectation.getAttributes() != null)
 		{
-			assertAttributes(expectation.getAttributes(), cu);
+			HUAttributeAssertions.assertAttributes(services, expectation.getAttributes(), cu);
 		}
 	}
 

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertManufacturingExpectationsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertManufacturingExpectationsCommand.java
@@ -56,6 +56,48 @@ public class AssertManufacturingExpectationsCommand
 			final ArrayList<I_PP_Order_Qty> actuals = new ArrayList<>(services.getPPOrderQtyForFinishedGoodsReceive(ppOrderId));
 			assertReceivedHUs(expectation.getReceivedHUs(), actuals);
 		}
+
+		if (expectation.getIssuedHUs() != null)
+		{
+			final ArrayList<I_PP_Order_Qty> actuals = new ArrayList<>(services.getPPOrderQtyForComponentIssue(ppOrderId));
+			assertIssuedHUs(expectation.getIssuedHUs(), actuals);
+		}
+	}
+
+	private void assertIssuedHUs(final List<JsonManufacturingExpectation.IssuedHU> expectations, final ArrayList<I_PP_Order_Qty> actuals)
+	{
+		assertThat(actuals).hasSameSize(expectations);
+
+		// same ordering workaround as the receive side: the candidate id does not follow the issue order
+		actuals.sort(Comparator.comparing(I_PP_Order_Qty::getM_HU_ID));
+
+		softly(() -> {
+			softlyPutContext("expectations", expectations);
+			softlyPutContext("actuals", actuals);
+			for (int i = 0; i < expectations.size(); i++)
+			{
+				softlyPutContext("index", i);
+				assertIssuedHU(expectations.get(i), actuals.get(i));
+			}
+		});
+	}
+
+	private void assertIssuedHU(final JsonManufacturingExpectation.IssuedHU expectation, final I_PP_Order_Qty actual)
+	{
+		softly(() -> {
+			softlyPutContext("expectation", expectation);
+			softlyPutContext("actual", actual);
+
+			if (expectation.getQty() != null)
+			{
+				assertThat(getQty(actual)).as("qty").isEqualTo(expectation.getQty().toQuantity());
+			}
+
+			if (expectation.getAttributes() != null)
+			{
+				HUAttributeAssertions.assertAttributes(services, expectation.getAttributes(), HuId.ofRepoId(actual.getM_HU_ID()));
+			}
+		});
 	}
 
 	private PPOrderId getPPOrderIdByMatcherString(@NotNull final String matcherStr)

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/HUAttributeAssertions.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/HUAttributeAssertions.java
@@ -1,0 +1,123 @@
+package de.metas.frontend_testing.expectations;
+
+import de.metas.common.util.time.SystemTime;
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.util.NumberUtils;
+import lombok.NonNull;
+import org.adempiere.mm.attributes.AttributeCode;
+import org.adempiere.mm.attributes.AttributeValueType;
+import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
+import org.compiere.util.TimeUtil;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
+
+import static de.metas.frontend_testing.expectations.assertions.Assertions.assertThat;
+import static de.metas.frontend_testing.expectations.assertions.Assertions.fail;
+import static de.metas.frontend_testing.expectations.assertions.Assertions.softly;
+import static de.metas.frontend_testing.expectations.assertions.Assertions.softlyPutContext;
+
+/**
+ * Asserts an HU's attributes against a code -> expected-value map,
+ * shared by the HU and the manufacturing expectations.
+ */
+final class HUAttributeAssertions
+{
+	private HUAttributeAssertions() {}
+
+	public static void assertAttributes(
+			@NonNull final AssertExpectationsCommandServices services,
+			@NonNull final Map<String, String> expectations,
+			@NonNull final HuId huId)
+	{
+		if (expectations.isEmpty())
+		{
+			return;
+		}
+
+		assertAttributes(services, expectations, services.getHUById(huId));
+	}
+
+	public static void assertAttributes(
+			@NonNull final AssertExpectationsCommandServices services,
+			@NonNull final Map<String, String> expectations,
+			@NonNull final I_M_HU hu)
+	{
+		if (expectations.isEmpty())
+		{
+			return;
+		}
+
+		final ImmutableAttributeSet actualAttributes = services.getAttributes(hu);
+
+		softly(() -> {
+			softlyPutContext("expectedAttributes", expectations);
+			softlyPutContext("actualAttributes", actualAttributes);
+
+			expectations.forEach((attributeCodeStr, expectedValueStr) -> {
+				final AttributeCode attributeCode = AttributeCode.ofString(attributeCodeStr);
+				softlyPutContext("attributeCode", attributeCode);
+
+				if (actualAttributes.hasAttribute(attributeCode))
+				{
+					final AttributeValueType type = actualAttributes.getAttributeValueType(attributeCode);
+					switch (type)
+					{
+						case STRING:
+						case LIST:
+							assertAttributeValue_String(expectedValueStr, actualAttributes, attributeCode);
+							break;
+						case NUMBER:
+							assertAttributeValue_Number(expectedValueStr, actualAttributes, attributeCode);
+							break;
+						case DATE:
+							assertAttributeValue_Date(expectedValueStr, actualAttributes, attributeCode);
+							break;
+						default:
+							fail("Unknown attribute value type: " + type);
+					}
+				}
+				else if (expectedValueStr != null)
+				{
+					fail("Expected missing attribute " + attributeCode + " to be <" + expectedValueStr + ">");
+				}
+			});
+		});
+	}
+
+	private static void assertAttributeValue_String(final String expectedValueStr, final ImmutableAttributeSet actualAttributes, final AttributeCode attributeCode)
+	{
+		final String actualValueStr = actualAttributes.getValueAsString(attributeCode);
+		assertThat(actualValueStr).as("String attribute " + attributeCode).isEqualTo(expectedValueStr);
+	}
+
+	private static void assertAttributeValue_Number(final String expectedValueStr, final ImmutableAttributeSet actualAttributes, final AttributeCode attributeCode)
+	{
+		final BigDecimal actualValue = actualAttributes.getValueAsBigDecimal(attributeCode);
+		final BigDecimal expectedValue = NumberUtils.asBigDecimal(expectedValueStr);
+		assertThat(actualValue).as("Number attribute " + attributeCode).isEqualTo(expectedValue);
+	}
+
+	private static void assertAttributeValue_Date(final String expectedValueStr, final ImmutableAttributeSet actualAttributes, final AttributeCode attributeCode)
+	{
+		final LocalDate actualValue = actualAttributes.getValueAsLocalDate(attributeCode);
+
+		final LocalDate expectedValue;
+		if (expectedValueStr == null || expectedValueStr.trim().equals("-"))
+		{
+			expectedValue = null;
+		}
+		else if (expectedValueStr.equalsIgnoreCase("today"))
+		{
+			expectedValue = SystemTime.asLocalDate();
+		}
+		else
+		{
+			expectedValue = TimeUtil.asLocalDate(expectedValueStr);
+		}
+
+		assertThat(actualValue).as("Date attribute " + attributeCode).isEqualTo(expectedValue);
+	}
+}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/HUAttributeAssertions.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/HUAttributeAssertions.java
@@ -5,6 +5,7 @@ import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.util.NumberUtils;
 import lombok.NonNull;
+import lombok.experimental.UtilityClass;
 import org.adempiere.mm.attributes.AttributeCode;
 import org.adempiere.mm.attributes.AttributeValueType;
 import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
@@ -23,10 +24,9 @@ import static de.metas.frontend_testing.expectations.assertions.Assertions.softl
  * Asserts an HU's attributes against a code -> expected-value map,
  * shared by the HU and the manufacturing expectations.
  */
+@UtilityClass
 final class HUAttributeAssertions
 {
-	private HUAttributeAssertions() {}
-
 	public static void assertAttributes(
 			@NonNull final AssertExpectationsCommandServices services,
 			@NonNull final Map<String, String> expectations,

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/request/JsonManufacturingExpectation.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/request/JsonManufacturingExpectation.java
@@ -7,6 +7,7 @@ import lombok.extern.jackson.Jacksonized;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Map;
 
 @Value
 @Builder
@@ -14,6 +15,7 @@ import java.util.List;
 public class JsonManufacturingExpectation
 {
 	@Nullable List<ReceivedHU> receivedHUs;
+	@Nullable List<IssuedHU> issuedHUs;
 
 	//
  	//
@@ -27,6 +29,19 @@ public class JsonManufacturingExpectation
 		@Nullable Identifier lu;
 		@Nullable Identifier tu;
 		@Nullable QtyAndUOMString qty;
+	}
+
+	/**
+	 * An HU issued to one of the order's BOM lines. It is created by the issue itself, so it has no
+	 * masterdata identifier to address it by - the expectations are positional, ordered by HU id.
+	 */
+	@Value
+	@Builder
+	@Jacksonized
+	public static class IssuedHU
+	{
+		@Nullable QtyAndUOMString qty;
+		@Nullable Map<String, String> attributes;
 	}
 }
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/manufacturing/issue/plan/PPOrderIssuePlanCreateCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/manufacturing/issue/plan/PPOrderIssuePlanCreateCommand.java
@@ -213,20 +213,26 @@ public class PPOrderIssuePlanCreateCommand
 					allocatedQty = targetQty; // fully allocated
 				}
 				//
-				// Case 3: current HU has not enough qty to allocate the remaining Qty
+				// Case 3: current HU has not enough qty to allocate the remaining Qty, so this step
+				// consumes it whole. The quantity is taken in the HU's own UOM: the HU engine only
+				// re-parents a fully consumed CU when the requested UOM matches the HU's storage, and
+				// otherwise falls back to a split that cannot express the HU's content exactly.
 				else
 				{
+					final Quantity huQtyAvailableInHuUom = allocableHU.getQtyAvailableToAllocateInHuUom();
+
 					planStep = PPOrderIssuePlanStep.builder()
 							.orderBOMLineId(orderBOMLineId)
 							.productId(productId)
-							.qtyToIssue(huQtyAvailable)
-							//.isPickWholeHU(true)
+							.qtyToIssue(huQtyAvailableInHuUom)
 							.pickFromLocatorId(allocableHU.getLocatorId())
 							.pickFromTopLevelHU(allocableHU.getTopLevelHU())
 							.isAlternative(false)
 							.build();
 
-					allocableHU.addQtyAllocated(huQtyAvailable);
+					// addQtyAllocated converts into the HU's UOM itself, and the running total stays in
+					// the BOM line's UOM, so both are fed the quantity in the unit they expect.
+					allocableHU.addQtyAllocated(huQtyAvailableInHuUom);
 					allocatedQty = allocatedQty.add(huQtyAvailable);
 				}
 				planSteps.add(planStep);

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobService.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobService.java
@@ -660,21 +660,33 @@ public class ManufacturingJobService
 		Quantity qtyLeftToBeIssued = line.getQtyLeftToIssue().toZeroIfNegative();
 		final ImmutableList.Builder<RawMaterialsIssueStep> updatedStepsListBuilder = ImmutableList.builder();
 
+		final ProductId productId = line.getProductId();
+
 		for (final RawMaterialsIssueStep step : line.getSteps())
 		{
+			// A step consuming a whole HU is denominated in that HU's stocking UOM, which the line's
+			// remaining quantity is not, so neither the comparison nor the capping can use the two as
+			// they come.
+			final Quantity stepQtyToIssue = step.getQtyToIssue();
+			final Quantity stepQtyToIssueInLineUom = uomConversionBL.convertQuantityTo(stepQtyToIssue, productId, qtyLeftToBeIssued.getUomId());
+
 			if (step.isIssued())
 			{
 				updatedStepsListBuilder.add(step);
 			}
-			else if (qtyLeftToBeIssued.isGreaterThan(step.getQtyToIssue()))
+			else if (qtyLeftToBeIssued.isGreaterThan(stepQtyToIssueInLineUom))
 			{
 				updatedStepsListBuilder.add(step);
-				qtyLeftToBeIssued = qtyLeftToBeIssued.subtract(step.getQtyToIssue());
+				qtyLeftToBeIssued = qtyLeftToBeIssued.subtract(stepQtyToIssueInLineUom);
 			}
 			else
 			{
-				ppOrderIssueScheduleService.updateQtyToIssue(step.getId(), qtyLeftToBeIssued);
-				updatedStepsListBuilder.add(step.withQtyToIssue(qtyLeftToBeIssued));
+				// capping the step keeps it in its own UOM, so a whole-HU step is not silently
+				// re-denominated into the line's
+				final Quantity cappedQtyInStepUom = uomConversionBL.convertQuantityTo(qtyLeftToBeIssued, productId, stepQtyToIssue.getUomId());
+
+				ppOrderIssueScheduleService.updateQtyToIssue(step.getId(), cappedQtyInStepUom);
+				updatedStepsListBuilder.add(step.withQtyToIssue(cappedQtyInStepUom));
 				qtyLeftToBeIssued = qtyLeftToBeIssued.toZero();
 			}
 		}

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobService.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobService.java
@@ -665,8 +665,7 @@ public class ManufacturingJobService
 		for (final RawMaterialsIssueStep step : line.getSteps())
 		{
 			// A step consuming a whole HU is denominated in that HU's stocking UOM, which the line's
-			// remaining quantity is not, so neither the comparison nor the capping can use the two as
-			// they come.
+			// remaining quantity is not, so the comparison below has to convert before it can compare.
 			final Quantity stepQtyToIssue = step.getQtyToIssue();
 			final Quantity stepQtyToIssueInLineUom = uomConversionBL.convertQuantityTo(stepQtyToIssue, productId, qtyLeftToBeIssued.getUomId());
 
@@ -681,12 +680,11 @@ public class ManufacturingJobService
 			}
 			else
 			{
-				// capping the step keeps it in its own UOM, so a whole-HU step is not silently
-				// re-denominated into the line's
-				final Quantity cappedQtyInStepUom = uomConversionBL.convertQuantityTo(qtyLeftToBeIssued, productId, stepQtyToIssue.getUomId());
-
-				ppOrderIssueScheduleService.updateQtyToIssue(step.getId(), cappedQtyInStepUom);
-				updatedStepsListBuilder.add(step.withQtyToIssue(cappedQtyInStepUom));
+				// What is left no longer covers this HU, so the step stops being a whole-HU consume and
+				// becomes a partial issue. It therefore takes the line's UOM: a partial issue reduces the
+				// HU's quantity and weight and leaves it standing, where consuming it whole destroys it.
+				ppOrderIssueScheduleService.updateQtyToIssue(step.getId(), qtyLeftToBeIssued);
+				updatedStepsListBuilder.add(step.withQtyToIssue(qtyLeftToBeIssued));
 				qtyLeftToBeIssued = qtyLeftToBeIssued.toZero();
 			}
 		}

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
@@ -14,9 +14,17 @@ const HU_A_PIECES = 2;
 const HU_A_WEIGHT = '68.400'; // three decimals: that is how the attribute is stored and compared
 const HU_B_PIECES = 1;
 const HU_B_WEIGHT = '34.200';
+// a third HU holding more than the line still needs, so its step gets capped to the remainder
+const HU_C_PIECES = 2;
+const HU_C_WEIGHT = '69.000';
+// giving up one of its two pieces takes half of its weight with it
+const HU_C_PIECES_LEFT = HU_C_PIECES - 1;
+const HU_C_WEIGHT_LEFT = '34.500';
 
-// 105 kg is what all three pieces nominally weigh, so each HU is consumed whole by its own step
-const LINE_DEMAND_KG = (HU_A_PIECES + HU_B_PIECES) * NOMINAL_KG_PER_PIECE;
+// The line needs what HU_A and HU_B nominally weigh plus one piece more, so those two are consumed
+// whole while HU_C - which holds two pieces - can only give up part of itself
+const LINE_DEMAND_KG = (HU_A_PIECES + HU_B_PIECES + 1) * NOMINAL_KG_PER_PIECE;
+const REMAINDER_KG = NOMINAL_KG_PER_PIECE;
 
 const createMasterdata = async () => {
     return await Backend.createMasterdata({
@@ -39,6 +47,7 @@ const createMasterdata = async () => {
             handlingUnits: {
                 "HU_A": { product: 'COMP_CW', warehouse: 'wh', qty: HU_A_PIECES, weightNet: Number(HU_A_WEIGHT) },
                 "HU_B": { product: 'COMP_CW', warehouse: 'wh', qty: HU_B_PIECES, weightNet: Number(HU_B_WEIGHT) },
+                "HU_C": { product: 'COMP_CW', warehouse: 'wh', qty: HU_C_PIECES, weightNet: Number(HU_C_WEIGHT) },
             },
             manufacturingOrders: {
                 "PP1": {
@@ -82,6 +91,7 @@ test.describe('Manufacturing issue of whole catch-weight HUs across UOMs', () =>
                 hus: {
                     'HU_A': { huStatus: 'A', storages: { 'COMP_CW': `${HU_A_PIECES} PCE` }, attributes: { 'WeightNet': HU_A_WEIGHT } },
                     'HU_B': { huStatus: 'A', storages: { 'COMP_CW': `${HU_B_PIECES} PCE` }, attributes: { 'WeightNet': HU_B_WEIGHT } },
+                    'HU_C': { huStatus: 'A', storages: { 'COMP_CW': `${HU_C_PIECES} PCE` }, attributes: { 'WeightNet': HU_C_WEIGHT } },
                 },
             });
         });
@@ -103,15 +113,19 @@ test.describe('Manufacturing issue of whole catch-weight HUs across UOMs', () =>
             });
         });
 
-        await test.step('Final: both HUs are consumed and each kept its own weight', async () => {
+        await test.step('Both whole HUs consumed, each having kept its own weight', async () => {
             await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_B.qrCode });
-            await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: `${LINE_DEMAND_KG} kg` });
+            await ManufacturingJobScreen.expectIssueButton({
+                index: 1,
+                qtyIssued: `${(HU_A_PIECES + HU_B_PIECES) * NOMINAL_KG_PER_PIECE} kg`,
+            });
 
             await Backend.expect({
-                title: 'final weights',
+                title: 'weights after both whole HUs',
                 hus: {
                     'HU_A': { huStatus: 'D', attributes: { 'WeightNet': HU_A_WEIGHT } },
                     'HU_B': { huStatus: 'D', attributes: { 'WeightNet': HU_B_WEIGHT } },
+                    'HU_C': { huStatus: 'A', storages: { 'COMP_CW': `${HU_C_PIECES} PCE` }, attributes: { 'WeightNet': HU_C_WEIGHT } },
                 },
                 manufacturings: {
                     'PP1': {
@@ -119,6 +133,24 @@ test.describe('Manufacturing issue of whole catch-weight HUs across UOMs', () =>
                             { attributes: { 'WeightNet': HU_A_WEIGHT } },
                             { attributes: { 'WeightNet': HU_B_WEIGHT } },
                         ],
+                    },
+                },
+            });
+        });
+
+        // The line needs one more piece than HU_C's step was planned for, so that step is capped to the
+        // remainder and becomes a partial issue: HU_C gives up part of itself and stays on stock.
+        await test.step('Final: the capped step takes only part of the third HU, which survives', async () => {
+            await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_C.qrCode });
+            await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: `${LINE_DEMAND_KG} kg` });
+
+            await Backend.expect({
+                title: 'the partially issued HU is still on stock, with less quantity and less weight',
+                hus: {
+                    'HU_C': {
+                        huStatus: 'A',
+                        storages: { 'COMP_CW': `${HU_C_PIECES_LEFT} PCE` },
+                        attributes: { 'WeightNet': HU_C_WEIGHT_LEFT },
                     },
                 },
             });

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
@@ -5,7 +5,6 @@ import { LoginScreen } from '../../utils/screens/LoginScreen';
 import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
 import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
 import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
-import { RawMaterialIssueLineScreen } from '../../utils/screens/manufacturing/issue/RawMaterialIssueLineScreen';
 
 // The component is stocked in pieces but consumed by weight: the BOM line is in kg while the HU's
 // storage is in Stk. The HU also weighs less than its nominal 2 x 35 kg, as a real cheese pallet does.
@@ -76,11 +75,7 @@ test.describe('Manufacturing issue of a whole catch-weight HU across UOMs', () =
         await ManufacturingJobsListScreen.waitForScreen();
         await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
 
-        await test.step('Issue the whole HU', async () => {
-            await ManufacturingJobScreen.clickIssueButton({ index: 1 });
-            await RawMaterialIssueLineScreen.scanQRCode({ qrCode: masterdata.handlingUnits.HU_CW.qrCode });
-            await RawMaterialIssueLineScreen.goBack();
-        });
+        await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_CW.qrCode });
 
         await Backend.expect({
             title: 'the whole HU was issued, carrying its captured weight',

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
@@ -5,6 +5,7 @@ import { LoginScreen } from '../../utils/screens/LoginScreen';
 import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
 import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
 import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
+import { MaterialReceiptLineScreen } from '../../utils/screens/manufacturing/receipt/MaterialReceiptLineScreen';
 
 // The component is stocked in pieces but consumed by weight: the recipe line asks for kg while the
 // HUs' storage is in Stk. Both HUs weigh less than their nominal pieces x rate, as real cheese does.
@@ -24,7 +25,6 @@ const HU_C_WEIGHT_LEFT = '34.500';
 // The line needs what HU_A and HU_B nominally weigh plus one piece more, so those two are consumed
 // whole while HU_C - which holds two pieces - can only give up part of itself
 const LINE_DEMAND_KG = (HU_A_PIECES + HU_B_PIECES + 1) * NOMINAL_KG_PER_PIECE;
-const REMAINDER_KG = NOMINAL_KG_PER_PIECE;
 
 const createMasterdata = async () => {
     return await Backend.createMasterdata({
@@ -37,8 +37,16 @@ const createMasterdata = async () => {
                 "COMP_CW": {
                     uomConversions: [{ from: 'PCE', to: 'KGM', multiplyRate: NOMINAL_KG_PER_PIECE, isCatchUOMForProduct: true }],
                 },
+                // A second component that is only issued for what was received. Its presence is what makes
+                // a receipt recompute the steps of EVERY line of the job, the catch-weight one included.
+                "COMP_AUTO": {},
                 "FG": {
-                    bom: { lines: [{ product: 'COMP_CW', qty: LINE_DEMAND_KG, uom: 'KGM' }] },
+                    bom: {
+                        lines: [
+                            { product: 'COMP_CW', qty: LINE_DEMAND_KG, uom: 'KGM' },
+                            { product: 'COMP_AUTO', qty: 1, issueMethod: 'IssueOnlyForReceived' },
+                        ],
+                    },
                 },
             },
             packingInstructions: {
@@ -48,6 +56,7 @@ const createMasterdata = async () => {
                 "HU_A": { product: 'COMP_CW', warehouse: 'wh', qty: HU_A_PIECES, weightNet: Number(HU_A_WEIGHT) },
                 "HU_B": { product: 'COMP_CW', warehouse: 'wh', qty: HU_B_PIECES, weightNet: Number(HU_B_WEIGHT) },
                 "HU_C": { product: 'COMP_CW', warehouse: 'wh', qty: HU_C_PIECES, weightNet: Number(HU_C_WEIGHT) },
+                "HU_AUTO": { product: 'COMP_AUTO', warehouse: 'wh', qty: 1000, sourceHU: true },
             },
             manufacturingOrders: {
                 "PP1": {
@@ -135,6 +144,20 @@ test.describe('Manufacturing issue of whole catch-weight HUs across UOMs', () =>
                         ],
                     },
                 },
+            });
+        });
+
+        // Receiving finished goods auto-issues the received-only component and, on the way, recomputes the
+        // steps of every line - including this one, whose steps are denominated in pieces. That recompute
+        // used to throw on the mismatched units before the operator could issue anything else.
+        await test.step('A receipt recomputes the steps of a line denominated in pieces', async () => {
+            await ManufacturingJobScreen.clickReceiveButton({ index: 1 });
+            await MaterialReceiptLineScreen.selectNewLUTarget({ luPIItemTestId: masterdata.packingInstructions.PI.luPIItemTestId });
+            await MaterialReceiptLineScreen.receiveQty({ qtyEntered: '1' });
+
+            await ManufacturingJobScreen.expectIssueButton({
+                index: 1,
+                qtyIssued: `${(HU_A_PIECES + HU_B_PIECES) * NOMINAL_KG_PER_PIECE} kg`,
             });
         });
 

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
@@ -106,6 +106,19 @@ test.describe('Manufacturing issue of whole catch-weight HUs across UOMs', () =>
         });
 
         // Issuing a whole HU consumes its content and destroys the HU, so its end status is Destroyed
+        // Receiving finished goods auto-issues the received-only component and, on the way, recomputes the
+        // steps of every line - including this one, whose steps are denominated in pieces. That recompute
+        // used to throw on the mismatched units before the operator could issue anything else.
+        await test.step('A receipt recomputes the steps while they are still denominated in pieces', async () => {
+            await ManufacturingJobScreen.clickReceiveButton({ index: 1 });
+            await MaterialReceiptLineScreen.selectNewLUTarget({ luPIItemTestId: masterdata.packingInstructions.PI.luPIItemTestId });
+            await MaterialReceiptLineScreen.receiveQty({ qtyEntered: '1' });
+
+            // nothing has been issued on this line yet, so the recompute walked its unissued
+            // piece-denominated steps - which is the comparison that used to throw
+            await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: '0 kg' });
+        });
+
         await test.step('In progress: the first HU is consumed, the second is untouched', async () => {
             await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_A.qrCode });
             await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: `${HU_A_PIECES * NOMINAL_KG_PER_PIECE} kg` });
@@ -117,7 +130,8 @@ test.describe('Manufacturing issue of whole catch-weight HUs across UOMs', () =>
                     'HU_B': { huStatus: 'A', storages: { 'COMP_CW': `${HU_B_PIECES} PCE` }, attributes: { 'WeightNet': HU_B_WEIGHT } },
                 },
                 manufacturings: {
-                    'PP1': { issuedHUs: [{ attributes: { 'WeightNet': HU_A_WEIGHT } }] },
+                    // the received-only component was auto-issued by the receipt, so its row is here too
+                    'PP1': { issuedHUs: [{ attributes: { 'WeightNet': HU_A_WEIGHT } }, {}] },
                 },
             });
         });
@@ -136,28 +150,6 @@ test.describe('Manufacturing issue of whole catch-weight HUs across UOMs', () =>
                     'HU_B': { huStatus: 'D', attributes: { 'WeightNet': HU_B_WEIGHT } },
                     'HU_C': { huStatus: 'A', storages: { 'COMP_CW': `${HU_C_PIECES} PCE` }, attributes: { 'WeightNet': HU_C_WEIGHT } },
                 },
-                manufacturings: {
-                    'PP1': {
-                        issuedHUs: [
-                            { attributes: { 'WeightNet': HU_A_WEIGHT } },
-                            { attributes: { 'WeightNet': HU_B_WEIGHT } },
-                        ],
-                    },
-                },
-            });
-        });
-
-        // Receiving finished goods auto-issues the received-only component and, on the way, recomputes the
-        // steps of every line - including this one, whose steps are denominated in pieces. That recompute
-        // used to throw on the mismatched units before the operator could issue anything else.
-        await test.step('A receipt recomputes the steps of a line denominated in pieces', async () => {
-            await ManufacturingJobScreen.clickReceiveButton({ index: 1 });
-            await MaterialReceiptLineScreen.selectNewLUTarget({ luPIItemTestId: masterdata.packingInstructions.PI.luPIItemTestId });
-            await MaterialReceiptLineScreen.receiveQty({ qtyEntered: '1' });
-
-            await ManufacturingJobScreen.expectIssueButton({
-                index: 1,
-                qtyIssued: `${(HU_A_PIECES + HU_B_PIECES) * NOMINAL_KG_PER_PIECE} kg`,
             });
         });
 

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
@@ -86,14 +86,15 @@ test.describe('Manufacturing issue of whole catch-weight HUs across UOMs', () =>
             });
         });
 
-        await test.step('In progress: the first HU is issued, the second is untouched', async () => {
+        // Issuing a whole HU consumes its content and destroys the HU, so its end status is Destroyed
+        await test.step('In progress: the first HU is consumed, the second is untouched', async () => {
             await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_A.qrCode });
             await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: `${HU_A_PIECES * NOMINAL_KG_PER_PIECE} kg` });
 
             await Backend.expect({
                 title: 'weights with one HU issued',
                 hus: {
-                    'HU_A': { huStatus: 'I', attributes: { 'WeightNet': HU_A_WEIGHT } },
+                    'HU_A': { huStatus: 'D', attributes: { 'WeightNet': HU_A_WEIGHT } },
                     'HU_B': { huStatus: 'A', storages: { 'COMP_CW': `${HU_B_PIECES} PCE` }, attributes: { 'WeightNet': HU_B_WEIGHT } },
                 },
                 manufacturings: {
@@ -102,15 +103,15 @@ test.describe('Manufacturing issue of whole catch-weight HUs across UOMs', () =>
             });
         });
 
-        await test.step('Final: both HUs are issued and each kept its own weight', async () => {
+        await test.step('Final: both HUs are consumed and each kept its own weight', async () => {
             await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_B.qrCode });
             await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: `${LINE_DEMAND_KG} kg` });
 
             await Backend.expect({
                 title: 'final weights',
                 hus: {
-                    'HU_A': { huStatus: 'I', attributes: { 'WeightNet': HU_A_WEIGHT } },
-                    'HU_B': { huStatus: 'I', attributes: { 'WeightNet': HU_B_WEIGHT } },
+                    'HU_A': { huStatus: 'D', attributes: { 'WeightNet': HU_A_WEIGHT } },
+                    'HU_B': { huStatus: 'D', attributes: { 'WeightNet': HU_B_WEIGHT } },
                 },
                 manufacturings: {
                     'PP1': {

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
@@ -11,6 +11,8 @@ import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/Manufa
 const NOMINAL_KG_PER_PIECE = 35;
 const HU_PIECES = 2;
 const HU_WEIGHT_NET = 68.4;
+// the attribute is stored with 3 decimals and compared scale-sensitively
+const HU_WEIGHT_NET_ASSERTED = '68.400';
 
 const createMasterdata = async ({ componentAsLU = false } = {}) => {
     return await Backend.createMasterdata({
@@ -83,13 +85,19 @@ test.describe('Manufacturing issue of a whole catch-weight HU across UOMs', () =
         await ManufacturingJobsListScreen.waitForScreen();
         await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
 
+        await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyToIssue: '100 kg', qtyIssued: '0 kg' });
         await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_CW.qrCode });
+
+        // the whole HU holds 2 Stk at a nominal 35 kg, so 70 of the 100 kg are now issued.
+        // Without this the issue can fail server-side and the test would still pass: the failure is
+        // persisted to the issue log and the screen simply shows nothing was issued.
+        await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: '70 kg' });
 
         await Backend.expect({
             title: 'the whole HU was issued, carrying its captured weight',
             manufacturings: {
                 "PP1": {
-                    issuedHUs: [{ attributes: { 'WeightNet': String(HU_WEIGHT_NET) } }],
+                    issuedHUs: [{ attributes: { 'WeightNet': HU_WEIGHT_NET_ASSERTED } }],
                 },
             },
         });
@@ -116,12 +124,13 @@ test.describe('Manufacturing issue of a whole catch-weight HU across UOMs', () =
         await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
 
         await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_CW.qrCode });
+        await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: '70 kg' });
 
         await Backend.expect({
             title: 'the pieces issued off the LU carry the captured weight',
             manufacturings: {
                 "PP1": {
-                    issuedHUs: [{ attributes: { 'WeightNet': String(HU_WEIGHT_NET) } }],
+                    issuedHUs: [{ attributes: { 'WeightNet': HU_WEIGHT_NET_ASSERTED } }],
                 },
             },
         });

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
@@ -6,52 +6,41 @@ import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScre
 import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
 import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
 
-// The component is stocked in pieces but consumed by weight: the BOM line is in kg while the HU's
-// storage is in Stk. The HU also weighs less than its nominal 2 x 35 kg, as a real cheese pallet does.
+// The component is stocked in pieces but consumed by weight: the recipe line asks for kg while the
+// HUs' storage is in Stk. Both HUs weigh less than their nominal pieces x rate, as real cheese does.
 const NOMINAL_KG_PER_PIECE = 35;
-const HU_PIECES = 2;
-const HU_WEIGHT_NET = 68.4;
-// the attribute is stored with 3 decimals and compared scale-sensitively
-const HU_WEIGHT_NET_ASSERTED = '68.400';
 
-const createMasterdata = async ({ componentAsLU = false } = {}) => {
+const HU_A_PIECES = 2;
+const HU_A_WEIGHT = '68.400'; // three decimals: that is how the attribute is stored and compared
+const HU_B_PIECES = 1;
+const HU_B_WEIGHT = '34.200';
+
+// 105 kg is what all three pieces nominally weigh, so each HU is consumed whole by its own step
+const LINE_DEMAND_KG = (HU_A_PIECES + HU_B_PIECES) * NOMINAL_KG_PER_PIECE;
+
+const createMasterdata = async () => {
     return await Backend.createMasterdata({
         language: "en_US",
         request: {
-            login: {
-                user: { language: "en_US" },
-            },
+            login: { user: { language: "en_US" } },
             mobileConfig: {},
-            warehouses: {
-                "wh": {},
-            },
+            warehouses: { "wh": {} },
             products: {
                 "COMP_CW": {
                     uomConversions: [{ from: 'PCE', to: 'KGM', multiplyRate: NOMINAL_KG_PER_PIECE, isCatchUOMForProduct: true }],
                 },
                 "FG": {
-                    bom: {
-                        // in kg, so the issue plan is denominated in a different UOM than the HU's storage
-                        lines: [{ product: 'COMP_CW', qty: 100, uom: 'KGM' }],
-                    },
+                    bom: { lines: [{ product: 'COMP_CW', qty: LINE_DEMAND_KG, uom: 'KGM' }] },
                 },
             },
             packingInstructions: {
                 "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "FG", qtyCUsPerTU: 4 },
-                // one piece per TU, so an LU of two TUs holds the same two pieces as the flat HU -
-                // but the issue has to walk it one TU at a time
-                "CW_PI": { lu: "LU_CW", qtyTUsPerLU: HU_PIECES, tu: "TU_CW", product: "COMP_CW", qtyCUsPerTU: 1 },
             },
             handlingUnits: {
-                "HU_CW": componentAsLU
-                    ? { product: 'COMP_CW', warehouse: 'wh', packingInstructions: 'CW_PI', weightNet: HU_WEIGHT_NET }
-                    : { product: 'COMP_CW', warehouse: 'wh', qty: HU_PIECES, weightNet: HU_WEIGHT_NET },
-                // the order needs more than this one HU holds, and the job refuses to start unless the
-                // whole demand is covered - so a second HU carries the rest
-                "HU_REST": { product: 'COMP_CW', warehouse: 'wh', qty: 1 },
+                "HU_A": { product: 'COMP_CW', warehouse: 'wh', qty: HU_A_PIECES, weightNet: Number(HU_A_WEIGHT) },
+                "HU_B": { product: 'COMP_CW', warehouse: 'wh', qty: HU_B_PIECES, weightNet: Number(HU_B_WEIGHT) },
             },
             manufacturingOrders: {
-                // demand exceeds what HU_CW holds, so its step consumes it whole
                 "PP1": {
                     warehouse: 'wh',
                     product: 'FG',
@@ -63,18 +52,19 @@ const createMasterdata = async ({ componentAsLU = false } = {}) => {
     });
 }
 
-test.describe('Manufacturing issue of a whole catch-weight HU across UOMs', () => {
+test.describe('Manufacturing issue of whole catch-weight HUs across UOMs', () => {
     // noinspection JSUnusedLocalSymbols
-    test('Issuing a whole HU stocked in Stk to a BOM line in kg consumes it and keeps its weight', async ({ page }) => {
+    test('Issuing whole HUs stocked in Stk to a recipe line in kg keeps each HU weight through the flow', async ({ page }) => {
         allure.epic('E0160: Manufacturing Execution');
         allure.tag('F8030: MobileUI Manufacturing');
         allure.tag('F8030');
-        allure.story('Whole-HU issue when the stocking UOM differs from the BOM line UOM');
+        allure.story('Whole-HU issue when the stocking UOM differs from the recipe line UOM');
         allure.severity('critical');
         allure.description(
-            'The component is stocked in Stk and the BOM line asks for kg. Issuing the whole HU must ' +
-            'succeed rather than fail with "Could not issue the whole quantity required", and the HU ' +
-            'that ends up issued must still carry the weight that was captured on it.'
+            'Two handling units, each consumed whole by its own step, are issued one after the other. The ' +
+            'weights are checked three times - before anything is issued, with one HU issued and one still ' +
+            'on stock, and after both are issued - so a weight that is lost or overwritten at any point in ' +
+            'the flow shows up, not only at the end.'
         );
 
         const masterdata = await createMasterdata();
@@ -85,54 +75,52 @@ test.describe('Manufacturing issue of a whole catch-weight HU across UOMs', () =
         await ManufacturingJobsListScreen.waitForScreen();
         await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
 
-        await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyToIssue: '100 kg', qtyIssued: '0 kg' });
-        await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_CW.qrCode });
-
-        // the whole HU holds 2 Stk at a nominal 35 kg, so 70 of the 100 kg are now issued.
-        // Without this the issue can fail server-side and the test would still pass: the failure is
-        // persisted to the issue log and the screen simply shows nothing was issued.
-        await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: '70 kg' });
-
-        await Backend.expect({
-            title: 'the whole HU was issued, carrying its captured weight',
-            manufacturings: {
-                "PP1": {
-                    issuedHUs: [{ attributes: { 'WeightNet': HU_WEIGHT_NET_ASSERTED } }],
+        await test.step('Initial: both HUs are on stock with the weight they were captured at', async () => {
+            await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyToIssue: `${LINE_DEMAND_KG} kg`, qtyIssued: '0 kg' });
+            await Backend.expect({
+                title: 'initial weights',
+                hus: {
+                    'HU_A': { huStatus: 'A', storages: { 'COMP_CW': `${HU_A_PIECES} PCE` }, attributes: { 'WeightNet': HU_A_WEIGHT } },
+                    'HU_B': { huStatus: 'A', storages: { 'COMP_CW': `${HU_B_PIECES} PCE` }, attributes: { 'WeightNet': HU_B_WEIGHT } },
                 },
-            },
+            });
         });
-    });
 
-    // noinspection JSUnusedLocalSymbols
-    test('The same issue from an LU of several TUs keeps the weight on every piece it moves', async ({ page }) => {
-        allure.epic('E0160: Manufacturing Execution');
-        allure.tag('F8030: MobileUI Manufacturing');
-        allure.tag('F8030');
-        allure.story('Whole-HU issue when the stocking UOM differs from the BOM line UOM');
-        allure.severity('critical');
-        allure.description(
-            'Same issue as above, but the component arrives as an LU holding several TUs, which the issue ' +
-            'has to walk one TU at a time. Each of those steps must still carry the captured weight.'
-        );
+        await test.step('In progress: the first HU is issued, the second is untouched', async () => {
+            await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_A.qrCode });
+            await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: `${HU_A_PIECES * NOMINAL_KG_PER_PIECE} kg` });
 
-        const masterdata = await createMasterdata({ componentAsLU: true });
-
-        await LoginScreen.login(masterdata.login.user);
-        await ApplicationsListScreen.expectVisible();
-        await ApplicationsListScreen.startApplication('mfg');
-        await ManufacturingJobsListScreen.waitForScreen();
-        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
-
-        await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_CW.qrCode });
-        await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: '70 kg' });
-
-        await Backend.expect({
-            title: 'the pieces issued off the LU carry the captured weight',
-            manufacturings: {
-                "PP1": {
-                    issuedHUs: [{ attributes: { 'WeightNet': HU_WEIGHT_NET_ASSERTED } }],
+            await Backend.expect({
+                title: 'weights with one HU issued',
+                hus: {
+                    'HU_A': { huStatus: 'I', attributes: { 'WeightNet': HU_A_WEIGHT } },
+                    'HU_B': { huStatus: 'A', storages: { 'COMP_CW': `${HU_B_PIECES} PCE` }, attributes: { 'WeightNet': HU_B_WEIGHT } },
                 },
-            },
+                manufacturings: {
+                    'PP1': { issuedHUs: [{ attributes: { 'WeightNet': HU_A_WEIGHT } }] },
+                },
+            });
+        });
+
+        await test.step('Final: both HUs are issued and each kept its own weight', async () => {
+            await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_B.qrCode });
+            await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: `${LINE_DEMAND_KG} kg` });
+
+            await Backend.expect({
+                title: 'final weights',
+                hus: {
+                    'HU_A': { huStatus: 'I', attributes: { 'WeightNet': HU_A_WEIGHT } },
+                    'HU_B': { huStatus: 'I', attributes: { 'WeightNet': HU_B_WEIGHT } },
+                },
+                manufacturings: {
+                    'PP1': {
+                        issuedHUs: [
+                            { attributes: { 'WeightNet': HU_A_WEIGHT } },
+                            { attributes: { 'WeightNet': HU_B_WEIGHT } },
+                        ],
+                    },
+                },
+            });
         });
     });
 });

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
@@ -1,0 +1,94 @@
+import { Backend } from '../../utils/screens/Backend';
+import { test } from '../../../playwright.config';
+import { allure } from 'allure-playwright';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
+import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
+import { RawMaterialIssueLineScreen } from '../../utils/screens/manufacturing/issue/RawMaterialIssueLineScreen';
+
+// The component is stocked in pieces but consumed by weight: the BOM line is in kg while the HU's
+// storage is in Stk. The HU also weighs less than its nominal 2 x 35 kg, as a real cheese pallet does.
+const NOMINAL_KG_PER_PIECE = 35;
+const HU_PIECES = 2;
+const HU_WEIGHT_NET = 68.4;
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: {
+                user: { language: "en_US" },
+            },
+            mobileConfig: {},
+            warehouses: {
+                "wh": {},
+            },
+            products: {
+                "COMP_CW": {
+                    uomConversions: [{ from: 'PCE', to: 'KGM', multiplyRate: NOMINAL_KG_PER_PIECE, isCatchUOMForProduct: true }],
+                },
+                "FG": {
+                    bom: {
+                        // in kg, so the issue plan is denominated in a different UOM than the HU's storage
+                        lines: [{ product: 'COMP_CW', qty: 100, uom: 'KGM' }],
+                    },
+                },
+            },
+            packingInstructions: {
+                "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "FG", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU_CW": { product: 'COMP_CW', warehouse: 'wh', qty: HU_PIECES, weightNet: HU_WEIGHT_NET },
+            },
+            manufacturingOrders: {
+                // demand exceeds what the HU holds, so the whole HU is consumed by one step
+                "PP1": {
+                    warehouse: 'wh',
+                    product: 'FG',
+                    qty: 1,
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                },
+            },
+        }
+    });
+}
+
+test.describe('Manufacturing issue of a whole catch-weight HU across UOMs', () => {
+    // noinspection JSUnusedLocalSymbols
+    test('Issuing a whole HU stocked in Stk to a BOM line in kg consumes it and keeps its weight', async ({ page }) => {
+        allure.epic('E0160: Manufacturing Execution');
+        allure.tag('F8030: MobileUI Manufacturing');
+        allure.tag('F8030');
+        allure.story('Whole-HU issue when the stocking UOM differs from the BOM line UOM');
+        allure.severity('critical');
+        allure.description(
+            'The component is stocked in Stk and the BOM line asks for kg. Issuing the whole HU must ' +
+            'succeed rather than fail with "Could not issue the whole quantity required", and the HU ' +
+            'that ends up issued must still carry the weight that was captured on it.'
+        );
+
+        const masterdata = await createMasterdata();
+
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('mfg');
+        await ManufacturingJobsListScreen.waitForScreen();
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+
+        await test.step('Issue the whole HU', async () => {
+            await ManufacturingJobScreen.clickIssueButton({ index: 1 });
+            await RawMaterialIssueLineScreen.scanQRCode({ qrCode: masterdata.handlingUnits.HU_CW.qrCode });
+            await RawMaterialIssueLineScreen.goBack();
+        });
+
+        await Backend.expect({
+            title: 'the whole HU was issued, carrying its captured weight',
+            manufacturings: {
+                "PP1": {
+                    issuedHUs: [{ attributes: { 'WeightNet': String(HU_WEIGHT_NET) } }],
+                },
+            },
+        });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
@@ -105,7 +105,6 @@ test.describe('Manufacturing issue of whole catch-weight HUs across UOMs', () =>
             });
         });
 
-        // Issuing a whole HU consumes its content and destroys the HU, so its end status is Destroyed
         // Receiving finished goods auto-issues the received-only component and, on the way, recomputes the
         // steps of every line - including this one, whose steps are denominated in pieces. That recompute
         // used to throw on the mismatched units before the operator could issue anything else.
@@ -119,6 +118,7 @@ test.describe('Manufacturing issue of whole catch-weight HUs across UOMs', () =>
             await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: '0 kg' });
         });
 
+        // Issuing a whole HU consumes its content and destroys the HU, so its end status is Destroyed
         await test.step('In progress: the first HU is consumed, the second is untouched', async () => {
             await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_A.qrCode });
             await ManufacturingJobScreen.expectIssueButton({ index: 1, qtyIssued: `${HU_A_PIECES * NOMINAL_KG_PER_PIECE} kg` });

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_catchweight_wholeHU.spec.js
@@ -12,7 +12,7 @@ const NOMINAL_KG_PER_PIECE = 35;
 const HU_PIECES = 2;
 const HU_WEIGHT_NET = 68.4;
 
-const createMasterdata = async () => {
+const createMasterdata = async ({ componentAsLU = false } = {}) => {
     return await Backend.createMasterdata({
         language: "en_US",
         request: {
@@ -36,12 +36,20 @@ const createMasterdata = async () => {
             },
             packingInstructions: {
                 "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "FG", qtyCUsPerTU: 4 },
+                // one piece per TU, so an LU of two TUs holds the same two pieces as the flat HU -
+                // but the issue has to walk it one TU at a time
+                "CW_PI": { lu: "LU_CW", qtyTUsPerLU: HU_PIECES, tu: "TU_CW", product: "COMP_CW", qtyCUsPerTU: 1 },
             },
             handlingUnits: {
-                "HU_CW": { product: 'COMP_CW', warehouse: 'wh', qty: HU_PIECES, weightNet: HU_WEIGHT_NET },
+                "HU_CW": componentAsLU
+                    ? { product: 'COMP_CW', warehouse: 'wh', packingInstructions: 'CW_PI', weightNet: HU_WEIGHT_NET }
+                    : { product: 'COMP_CW', warehouse: 'wh', qty: HU_PIECES, weightNet: HU_WEIGHT_NET },
+                // the order needs more than this one HU holds, and the job refuses to start unless the
+                // whole demand is covered - so a second HU carries the rest
+                "HU_REST": { product: 'COMP_CW', warehouse: 'wh', qty: 1 },
             },
             manufacturingOrders: {
-                // demand exceeds what the HU holds, so the whole HU is consumed by one step
+                // demand exceeds what HU_CW holds, so its step consumes it whole
                 "PP1": {
                     warehouse: 'wh',
                     product: 'FG',
@@ -79,6 +87,38 @@ test.describe('Manufacturing issue of a whole catch-weight HU across UOMs', () =
 
         await Backend.expect({
             title: 'the whole HU was issued, carrying its captured weight',
+            manufacturings: {
+                "PP1": {
+                    issuedHUs: [{ attributes: { 'WeightNet': String(HU_WEIGHT_NET) } }],
+                },
+            },
+        });
+    });
+
+    // noinspection JSUnusedLocalSymbols
+    test('The same issue from an LU of several TUs keeps the weight on every piece it moves', async ({ page }) => {
+        allure.epic('E0160: Manufacturing Execution');
+        allure.tag('F8030: MobileUI Manufacturing');
+        allure.tag('F8030');
+        allure.story('Whole-HU issue when the stocking UOM differs from the BOM line UOM');
+        allure.severity('critical');
+        allure.description(
+            'Same issue as above, but the component arrives as an LU holding several TUs, which the issue ' +
+            'has to walk one TU at a time. Each of those steps must still carry the captured weight.'
+        );
+
+        const masterdata = await createMasterdata({ componentAsLU: true });
+
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('mfg');
+        await ManufacturingJobsListScreen.waitForScreen();
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+
+        await ManufacturingJobScreen.issueRawProduct({ index: 1, qrCode: masterdata.handlingUnits.HU_CW.qrCode });
+
+        await Backend.expect({
+            title: 'the pieces issued off the LU carry the captured weight',
             manufacturings: {
                 "PP1": {
                     issuedHUs: [{ attributes: { 'WeightNet': String(HU_WEIGHT_NET) } }],

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/RawMaterialIssueStepScanComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/RawMaterialIssueStepScanComponent.jsx
@@ -13,6 +13,8 @@ import { computeStepScanUserInfoQtys } from './computeStepScanUserInfoQtys';
 import PropTypes from 'prop-types';
 import { getActivityById, getStepByIdFromActivity } from '../../../../../reducers/wfProcesses';
 import { trl } from '../../../../../utils/translations';
+import { parseQRCodeString } from '../../../../../utils/qrCode/hu';
+import { ATTR_weightNet } from '../../../../../utils/qrCode/common';
 import { useBooleanSetting } from '../../../../../reducers/settings';
 import { useMobileNavigation } from '../../../../../hooks/useMobileNavigation';
 import {
@@ -143,6 +145,13 @@ const RawMaterialIssueStepScanComponent = ({ wfProcessId, activityId, lineId, st
     const stepId = resolvedBarcodeData.stepId;
     const isWeightable = !!resolvedBarcodeData.isWeightable;
     const isIssueWholeHU = qty >= resolvedBarcodeData.qtyHUCapacity;
+    // The quantity doubles as the HU's weight only while the step asks for kg. A step denominated in
+    // the HU's own stocking UOM is a piece count, and sending that as a weight makes the server
+    // re-weigh the HU to it - so in that case the HU's own captured net weight is sent instead.
+    const isQtyEnteredAsWeight = resolvedBarcodeData.uom === 'kg';
+    const huWeightNetCaptured = parseQRCodeString(resolvedBarcodeData.scannedBarcode, true)?.[ATTR_weightNet] ?? null;
+    const huWeightGrossBeforeIssue =
+      isWeightable && isIssueWholeHU ? (isQtyEnteredAsWeight ? qty : huWeightNetCaptured) : null;
 
     return dispatch(
       postManufacturingIssueEventThunk({
@@ -150,7 +159,7 @@ const RawMaterialIssueStepScanComponent = ({ wfProcessId, activityId, lineId, st
         activityId,
         lineId,
         stepId,
-        huWeightGrossBeforeIssue: isWeightable && isIssueWholeHU ? qty : null,
+        huWeightGrossBeforeIssue,
         qtyIssued: qty,
         qtyRejected: isIssueWholeHU ? qtyRejected : 0,
         qtyRejectedReasonCode: isIssueWholeHU ? reason : null,

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/RawMaterialIssueStepScanComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/RawMaterialIssueStepScanComponent.jsx
@@ -13,8 +13,6 @@ import { computeStepScanUserInfoQtys } from './computeStepScanUserInfoQtys';
 import PropTypes from 'prop-types';
 import { getActivityById, getStepByIdFromActivity } from '../../../../../reducers/wfProcesses';
 import { trl } from '../../../../../utils/translations';
-import { parseQRCodeString } from '../../../../../utils/qrCode/hu';
-import { ATTR_weightNet } from '../../../../../utils/qrCode/common';
 import { useBooleanSetting } from '../../../../../reducers/settings';
 import { useMobileNavigation } from '../../../../../hooks/useMobileNavigation';
 import {
@@ -145,13 +143,13 @@ const RawMaterialIssueStepScanComponent = ({ wfProcessId, activityId, lineId, st
     const stepId = resolvedBarcodeData.stepId;
     const isWeightable = !!resolvedBarcodeData.isWeightable;
     const isIssueWholeHU = qty >= resolvedBarcodeData.qtyHUCapacity;
-    // The quantity doubles as the HU's weight only while the step asks for kg. A step denominated in
-    // the HU's own stocking UOM is a piece count, and sending that as a weight makes the server
-    // re-weigh the HU to it - so in that case the HU's own captured net weight is sent instead.
+    // The quantity doubles as the HU's weight only while the step asks for kg, which is the case when
+    // part of an HU is issued: the HU survives and its qty and weight are reduced. A step denominated
+    // in the HU's own stocking UOM consumes the HU whole and destroys it, so there is no weight to
+    // correct - and sending the piece count as one makes the server inventory the HU's whole content
+    // in kg, which fails on the mismatched UOMs.
     const isQtyEnteredAsWeight = resolvedBarcodeData.uom === 'kg';
-    const huWeightNetCaptured = parseQRCodeString(resolvedBarcodeData.scannedBarcode, true)?.[ATTR_weightNet] ?? null;
-    const huWeightGrossBeforeIssue =
-      isWeightable && isIssueWholeHU ? (isQtyEnteredAsWeight ? qty : huWeightNetCaptured) : null;
+    const huWeightGrossBeforeIssue = isWeightable && isIssueWholeHU && isQtyEnteredAsWeight ? qty : null;
 
     return dispatch(
       postManufacturingIssueEventThunk({


### PR DESCRIPTION
Both findings reported after the previous iteration's demo have one root cause, so they ship together.

The mobile issue plan denominates the quantity in the recipe (BOM line) unit while the handling unit's
storage is in the stocking unit. That mismatch fails the same-unit test in `HUTransformService`, so a
"consume this HU whole" intent runs as a synthetic partial split. The split then

- under-delivers the quantity, so the issue fails with *"Could not issue the whole quantity required"*, and
- creates a brand-new virtual HU, which starts with no attributes — the captured net weight is lost.

## State of this PR

Failing test first. This branch currently carries only test-side changes, and the mobile suite is
**expected to be red**:

- a test-harness addition, so an expectation can address the HUs an order *consumed* and not just the
  ones it received (the issued HU is created by the issue itself and has no masterdata identifier, so
  the expectation is positional, ordered by HU id — the same convention the receive side uses);
- the failing spec: a component stocked in `Stk` with a `Stk -> kg` catch-weight conversion, a recipe
  line in `kg`, and a handling unit weighing less than its nominal quantity times rate, the way a real
  cheese pallet does.

The production fix follows once that red is observed and confirmed. It will be narrow: the whole-HU
plan step carries the HU's own stocking unit, and the issue path stamps the captured weight onto the
HU it produces, mirroring what the receipt path already does.

## Deliberately not touched

Two real defects on the shared HU-engine path (used by picking, shipping, inventory and distribution)
were found while investigating and are left alone on a hotfix branch: the unit-mixing subtraction in
the attribute redistribution strategy, and a new virtual HU taking its storage unit from the
allocation request rather than the product's stocking unit. Each needs its own issue.
