### PR TITLE
gh31399: replace the local-sequence IDs written by 5818170 with central ID-server IDs

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818170_sys_gh31399_FixProductWindowAndLabelsTab.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818170_sys_gh31399_FixProductWindowAndLabelsTab.sql
@@ -341,17 +341,17 @@ UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=21, Updated=now(), UpdatedBy=1
 
 -- UI Element: Produkt(140,D) -> Produkt(180,D) -> main -> 10 -> Divers.Tag
 -- 2026-08-11T06:50:36.516Z
-INSERT INTO AD_UI_Element (AD_Client_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,Labels_Selector_Field_ID,Labels_Tab_ID,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,0,180,1000039,1000528,'L',TO_TIMESTAMP('2026-08-11 06:50:36.096000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','N','N','Y','N','N','N',781900,549362,0,'Tag',20,0,0,TO_TIMESTAMP('2026-08-11 06:50:36.096000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,Labels_Selector_Field_ID,Labels_Tab_ID,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,0,180,1000039,654688,'L',TO_TIMESTAMP('2026-08-11 06:50:36.096000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','N','N','Y','N','N','N',781900,549362,0,'Tag',20,0,0,TO_TIMESTAMP('2026-08-11 06:50:36.096000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
 ;
 
 -- Field: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> Aktiv
 -- Column: M_Tag.IsActive
 -- 2026-08-11T08:34:00.488Z
-INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,FacetFilterSeqNo,Help,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,593114,1000008,0,549361,0,TO_TIMESTAMP('2026-08-11 08:33:59.789000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Der Eintrag ist im System aktiv',0,'D',0,'Es gibt zwei Möglichkeiten, einen Datensatz nicht mehr verfügbar zu machen: einer ist, ihn zu löschen; der andere, ihn zu deaktivieren. Ein deaktivierter Eintrag ist nicht mehr für eine Auswahl verfügbar, aber verfügbar für die Verwendung in Berichten. Es gibt zwei Gründe, Datensätze zu deaktivieren und nicht zu löschen: (1) Das System braucht den Datensatz für Revisionszwecke. (2) Der Datensatz wird von anderen Datensätzen referenziert. Z.B. können Sie keinen Geschäftspartner löschen, wenn es Rechnungen für diesen Geschäftspartner gibt. Sie deaktivieren den Geschäftspartner und verhindern, dass dieser Eintrag in zukünftigen Vorgängen verwendet wird.',0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Aktiv',0,0,10,0,1,1,TO_TIMESTAMP('2026-08-11 08:33:59.789000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,FacetFilterSeqNo,Help,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,593114,784918,0,549361,0,TO_TIMESTAMP('2026-08-11 08:33:59.789000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Der Eintrag ist im System aktiv',0,'D',0,'Es gibt zwei Möglichkeiten, einen Datensatz nicht mehr verfügbar zu machen: einer ist, ihn zu löschen; der andere, ihn zu deaktivieren. Ein deaktivierter Eintrag ist nicht mehr für eine Auswahl verfügbar, aber verfügbar für die Verwendung in Berichten. Es gibt zwei Gründe, Datensätze zu deaktivieren und nicht zu löschen: (1) Das System braucht den Datensatz für Revisionszwecke. (2) Der Datensatz wird von anderen Datensätzen referenziert. Z.B. können Sie keinen Geschäftspartner löschen, wenn es Rechnungen für diesen Geschäftspartner gibt. Sie deaktivieren den Geschäftspartner und verhindern, dass dieser Eintrag in zukünftigen Vorgängen verwendet wird.',0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Aktiv',0,0,10,0,1,1,TO_TIMESTAMP('2026-08-11 08:33:59.789000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
 ;
 
 -- 2026-08-11T08:34:00.531Z
-INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=1000008 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=784918 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
 ;
 
 -- 2026-08-11T08:34:00.604Z
@@ -359,21 +359,21 @@ INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTran
 ;
 
 -- 2026-08-11T08:34:00.717Z
-DELETE FROM AD_Element_Link WHERE AD_Field_ID=1000008
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=784918
 ;
 
 -- 2026-08-11T08:34:00.763Z
-/* DDL */ select AD_Element_Link_Create_Missing_Field(1000008)
+/* DDL */ select AD_Element_Link_Create_Missing_Field(784918)
 ;
 
 -- Field: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> Sektion
 -- Column: M_Tag.AD_Org_ID
 -- 2026-08-11T08:34:34.618Z
-INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,FacetFilterSeqNo,Help,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,593111,1000009,0,549361,0,TO_TIMESTAMP('2026-08-11 08:34:33.942000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Organisatorische Einheit des Mandanten',0,'D',0,'Eine Organisation ist ein Bereich ihres Mandanten - z.B. Laden oder Abteilung. Sie können Daten über Organisationen hinweg gemeinsam verwenden.',0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Sektion',0,0,20,0,1,1,TO_TIMESTAMP('2026-08-11 08:34:33.942000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,FacetFilterSeqNo,Help,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,593111,784919,0,549361,0,TO_TIMESTAMP('2026-08-11 08:34:33.942000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Organisatorische Einheit des Mandanten',0,'D',0,'Eine Organisation ist ein Bereich ihres Mandanten - z.B. Laden oder Abteilung. Sie können Daten über Organisationen hinweg gemeinsam verwenden.',0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Sektion',0,0,20,0,1,1,TO_TIMESTAMP('2026-08-11 08:34:33.942000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
 ;
 
 -- 2026-08-11T08:34:34.662Z
-INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=1000009 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=784919 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
 ;
 
 -- 2026-08-11T08:34:34.703Z
@@ -381,45 +381,45 @@ INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTran
 ;
 
 -- 2026-08-11T08:34:34.780Z
-DELETE FROM AD_Element_Link WHERE AD_Field_ID=1000009
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=784919
 ;
 
 -- 2026-08-11T08:34:34.824Z
-/* DDL */ select AD_Element_Link_Create_Missing_Field(1000009)
+/* DDL */ select AD_Element_Link_Create_Missing_Field(784919)
 ;
 
 -- UI Section: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main
 -- UI Column: 20
 -- 2026-08-11T08:34:59.708Z
-INSERT INTO AD_UI_Column (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy) VALUES (0,0,1000033,547866,TO_TIMESTAMP('2026-08-11 08:34:59.316000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y',20,TO_TIMESTAMP('2026-08-11 08:34:59.316000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+INSERT INTO AD_UI_Column (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy) VALUES (0,0,549754,547866,TO_TIMESTAMP('2026-08-11 08:34:59.316000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y',20,TO_TIMESTAMP('2026-08-11 08:34:59.316000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
 ;
 
 -- UI Column: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20
 -- UI Element Group: main
 -- 2026-08-11T08:35:10.444Z
-INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,Name,SeqNo,Updated,UpdatedBy) VALUES (0,0,1000033,1000047,TO_TIMESTAMP('2026-08-11 08:35:10.060000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','main',10,TO_TIMESTAMP('2026-08-11 08:35:10.060000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,Name,SeqNo,Updated,UpdatedBy) VALUES (0,0,549754,555763,TO_TIMESTAMP('2026-08-11 08:35:10.060000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','main',10,TO_TIMESTAMP('2026-08-11 08:35:10.060000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
 ;
 
 -- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20 -> main.Aktiv
 -- Column: M_Tag.IsActive
 -- 2026-08-11T08:35:39.193Z
-INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,1000008,0,549361,1000047,1000529,'F',TO_TIMESTAMP('2026-08-11 08:35:38.765000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Der Eintrag ist im System aktiv','Es gibt zwei Möglichkeiten, einen Datensatz nicht mehr verfügbar zu machen: einer ist, ihn zu löschen; der andere, ihn zu deaktivieren. Ein deaktivierter Eintrag ist nicht mehr für eine Auswahl verfügbar, aber verfügbar für die Verwendung in Berichten. Es gibt zwei Gründe, Datensätze zu deaktivieren und nicht zu löschen: (1) Das System braucht den Datensatz für Revisionszwecke. (2) Der Datensatz wird von anderen Datensätzen referenziert. Z.B. können Sie keinen Geschäftspartner löschen, wenn es Rechnungen für diesen Geschäftspartner gibt. Sie deaktivieren den Geschäftspartner und verhindern, dass dieser Eintrag in zukünftigen Vorgängen verwendet wird.','Y','N','N','Y','N','N','N',0,'Aktiv',10,0,0,TO_TIMESTAMP('2026-08-11 08:35:38.765000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,784918,0,549361,555763,654689,'F',TO_TIMESTAMP('2026-08-11 08:35:38.765000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Der Eintrag ist im System aktiv','Es gibt zwei Möglichkeiten, einen Datensatz nicht mehr verfügbar zu machen: einer ist, ihn zu löschen; der andere, ihn zu deaktivieren. Ein deaktivierter Eintrag ist nicht mehr für eine Auswahl verfügbar, aber verfügbar für die Verwendung in Berichten. Es gibt zwei Gründe, Datensätze zu deaktivieren und nicht zu löschen: (1) Das System braucht den Datensatz für Revisionszwecke. (2) Der Datensatz wird von anderen Datensätzen referenziert. Z.B. können Sie keinen Geschäftspartner löschen, wenn es Rechnungen für diesen Geschäftspartner gibt. Sie deaktivieren den Geschäftspartner und verhindern, dass dieser Eintrag in zukünftigen Vorgängen verwendet wird.','Y','N','N','Y','N','N','N',0,'Aktiv',10,0,0,TO_TIMESTAMP('2026-08-11 08:35:38.765000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
 ;
 
 -- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20 -> main.Sektion
 -- Column: M_Tag.AD_Org_ID
 -- 2026-08-11T08:35:57.039Z
-INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,1000009,0,549361,1000047,1000530,'F',TO_TIMESTAMP('2026-08-11 08:35:56.602000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Organisatorische Einheit des Mandanten','Eine Organisation ist ein Bereich ihres Mandanten - z.B. Laden oder Abteilung. Sie können Daten über Organisationen hinweg gemeinsam verwenden.','Y','N','N','Y','N','N','N',0,'Sektion',20,0,0,TO_TIMESTAMP('2026-08-11 08:35:56.602000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,784919,0,549361,555763,654690,'F',TO_TIMESTAMP('2026-08-11 08:35:56.602000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Organisatorische Einheit des Mandanten','Eine Organisation ist ein Bereich ihres Mandanten - z.B. Laden oder Abteilung. Sie können Daten über Organisationen hinweg gemeinsam verwenden.','Y','N','N','Y','N','N','N',0,'Sektion',20,0,0,TO_TIMESTAMP('2026-08-11 08:35:56.602000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
 ;
 
 -- Field: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> Mandant
 -- Column: M_Tag.AD_Client_ID
 -- 2026-08-11T08:36:24.226Z
-INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,FacetFilterSeqNo,Help,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,593110,1000010,0,549361,0,TO_TIMESTAMP('2026-08-11 08:36:23.679000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Mandant für diese Installation.',0,'D',0,'Ein Mandant ist eine Firma oder eine juristische Person. Sie können keine Daten über Mandanten hinweg verwenden. .',0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Mandant',0,0,30,0,1,1,TO_TIMESTAMP('2026-08-11 08:36:23.679000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,FacetFilterSeqNo,Help,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,593110,784920,0,549361,0,TO_TIMESTAMP('2026-08-11 08:36:23.679000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Mandant für diese Installation.',0,'D',0,'Ein Mandant ist eine Firma oder eine juristische Person. Sie können keine Daten über Mandanten hinweg verwenden. .',0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Mandant',0,0,30,0,1,1,TO_TIMESTAMP('2026-08-11 08:36:23.679000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
 ;
 
 -- 2026-08-11T08:36:24.267Z
-INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=1000010 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=784920 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
 ;
 
 -- 2026-08-11T08:36:24.309Z
@@ -427,17 +427,17 @@ INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTran
 ;
 
 -- 2026-08-11T08:36:24.399Z
-DELETE FROM AD_Element_Link WHERE AD_Field_ID=1000010
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=784920
 ;
 
 -- 2026-08-11T08:36:24.439Z
-/* DDL */ select AD_Element_Link_Create_Missing_Field(1000010)
+/* DDL */ select AD_Element_Link_Create_Missing_Field(784920)
 ;
 
 -- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20 -> main.Mandant
 -- Column: M_Tag.AD_Client_ID
 -- 2026-08-11T08:36:46.669Z
-INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,1000010,0,549361,1000047,1000531,'F',TO_TIMESTAMP('2026-08-11 08:36:46.160000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Mandant für diese Installation.','Ein Mandant ist eine Firma oder eine juristische Person. Sie können keine Daten über Mandanten hinweg verwenden. .','Y','N','N','Y','N','N','N',0,'Mandant',30,0,0,TO_TIMESTAMP('2026-08-11 08:36:46.160000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,784920,0,549361,555763,654691,'F',TO_TIMESTAMP('2026-08-11 08:36:46.160000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Mandant für diese Installation.','Ein Mandant ist eine Firma oder eine juristische Person. Sie können keine Daten über Mandanten hinweg verwenden. .','Y','N','N','Y','N','N','N',0,'Mandant',30,0,0,TO_TIMESTAMP('2026-08-11 08:36:46.160000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
 ;
 
 -- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 10 -> default.Beschreibung
@@ -461,19 +461,19 @@ UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=20,Updated=TO_TIMESTAMP(
 -- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20 -> main.Aktiv
 -- Column: M_Tag.IsActive
 -- 2026-08-11T08:37:02.524Z
-UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=30,Updated=TO_TIMESTAMP('2026-08-11 08:37:02.524000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=1000529
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=30,Updated=TO_TIMESTAMP('2026-08-11 08:37:02.524000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=654689
 ;
 
 -- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20 -> main.Sektion
 -- Column: M_Tag.AD_Org_ID
 -- 2026-08-11T08:37:02.779Z
-UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=40,Updated=TO_TIMESTAMP('2026-08-11 08:37:02.779000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=1000530
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=40,Updated=TO_TIMESTAMP('2026-08-11 08:37:02.779000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=654690
 ;
 
 -- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20 -> main.Mandant
 -- Column: M_Tag.AD_Client_ID
 -- 2026-08-11T08:37:03.032Z
-UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=50,Updated=TO_TIMESTAMP('2026-08-11 08:37:03.032000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=1000531
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=50,Updated=TO_TIMESTAMP('2026-08-11 08:37:03.032000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=654691
 ;
 
 -- Table: M_Tag

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818170_sys_gh31399_FixProductWindowAndLabelsTab.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818170_sys_gh31399_FixProductWindowAndLabelsTab.sql
@@ -1,5 +1,16 @@
 -- Run mode: SWING_CLIENT
 
+-- CORRECTED 2026-09-03: as recorded, this file INSERTed AD_Field / AD_UI_Column /
+-- AD_UI_ElementGroup / AD_UI_Element rows with the recording developer's LOCAL sequence ids
+-- (>= 1000000). Those are the ids an instance's own sequence hands out next, so the rows
+-- squatted on them -- 1000047 and 1000033 were literally max(id)+1 at the time. They are now
+-- central ID-server ids. Instances that already applied the original are corrected by
+-- 5822300_sys_gh31399_Renumber_LocalSequence_Ids_Of_5818170.sql, which renumbers by natural key.
+--
+-- The remaining 1000007-1000012 below are AD_TreeNodeMM MENU-SEED nodes (1000007=Menu,
+-- 1000008=CRM, ...), identical on every instance and shipped in the db seed. They are correct
+-- as they are -- do not 'fix' them.
+
 
 -- Reordering children of `webUI`
 -- Node name: `Product Tag`

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5822300_sys_gh31399_Renumber_LocalSequence_Ids_Of_5818170.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5822300_sys_gh31399_Renumber_LocalSequence_Ids_Of_5818170.sql
@@ -1,0 +1,268 @@
+-- Repairs the primary keys written by 5818170_sys_gh31399_FixProductWindowAndLabelsTab.sql.
+--
+-- 5818170 is a Swing-client recording. It inserted its new AD_Field / AD_UI_Column /
+-- AD_UI_ElementGroup / AD_UI_Element rows with IDs taken from the recording developer's
+-- LOCAL native sequence (>= 1000000) instead of IDs allocated from the central ID server.
+-- The native sequences ad_field_seq / ad_ui_column_seq / ad_ui_elementgroup_seq /
+-- ad_ui_element_seq all start at 1000000, so those IDs are exactly the numbers every
+-- instance's own sequence hands out to its own, unrelated rows: the recorded rows squat on
+-- that space and collide with locally created rows (observed on a customer instance that had
+-- independently allocated the same IDs).
+--
+-- 5818170 itself has been corrected to use the ID-server IDs below, so a fresh database gets
+-- them right. This script fixes the instances on which 5818170 already ran with the wrong IDs.
+--
+--   AD_Field            1000008 -> 784918   (AD_Tab_ID=549361, AD_Column_ID=593114)
+--   AD_Field            1000009 -> 784919   (AD_Tab_ID=549361, AD_Column_ID=593111)
+--   AD_Field            1000010 -> 784920   (AD_Tab_ID=549361, AD_Column_ID=593110)
+--   AD_UI_Column        1000033 -> 549754   (AD_UI_Section_ID=547866, SeqNo=20)
+--   AD_UI_ElementGroup  1000047 -> 555763   (that UI column, Name='main')
+--   AD_UI_Element       1000528 -> 654688   (AD_Tab_ID=180, group 1000039, Name='Tag')
+--   AD_UI_Element       1000529 -> 654689   (AD_Tab_ID=549361, the field that was 1000008)
+--   AD_UI_Element       1000530 -> 654690   (AD_Tab_ID=549361, the field that was 1000009)
+--   AD_UI_Element       1000531 -> 654691   (AD_Tab_ID=549361, the field that was 1000010)
+--
+-- All replacement IDs are /*From ID Server*/.
+--
+-- AD_UI_ElementGroup 1000039 and AD_UI_Column 1000004 are REFERENCED by 5818170 but not
+-- inserted by it: they are 2016-vintage rows that ship inside the shared seed dump, i.e. they
+-- are identical on every instance. They are NOT renumbered here.
+--
+-- Properties of this script:
+--   * every row is located by its NATURAL KEY, never by the wrong primary key (the primary key
+--     is the thing being corrected);
+--   * it is a no-op when the row already carries the correct ID, and a no-op on an instance
+--     where 5818170 never ran -- so it is fully idempotent and re-runnable;
+--   * it refuses (raises) rather than guesses if a row carries a third, unexpected ID, or if
+--     the target ID is already taken;
+--   * every foreign key onto the four parent tables is repointed in the same transaction. The
+--     reference list is the complete set of FK constraints on the four parents (pg_constraint
+--     where confrelid in (ad_field, ad_ui_column, ad_ui_elementgroup, ad_ui_element)); all of
+--     them are DEFERRABLE INITIALLY DEFERRED with ON UPDATE NO ACTION, so parent and children
+--     may be updated in any order inside the transaction and the check happens at COMMIT.
+--     None of ad_ui_column / ad_ui_elementgroup / ad_ui_element has a _Trl companion; only
+--     ad_field does (ad_field_trl).
+--
+-- Created / Updated / UpdatedBy are deliberately NOT stamped: this corrects a row's identity,
+-- not its content. Bumping AD_Field.Updated without bumping AD_Field_Trl.Updated would flip the
+-- `f_trl.updated <> e_trl.updated` guard inside update_FieldTranslation_From_AD_Name_Element and
+-- silently change translation-propagation behaviour, which is not what this fix is about.
+
+
+-- Defensive backup of the operator-configurable children, taken once and only when there is
+-- actually something to renumber. The AD_* structural metadata tables themselves are schema
+-- definitions and are exempt from the backup rule.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM AD_Field WHERE AD_Field_ID IN (1000008, 1000009, 1000010))
+    THEN
+        PERFORM backup_table('ad_userdef_field',      '_gh31399_renumber');
+        PERFORM backup_table('ad_user_sortpref_line', '_gh31399_renumber');
+        PERFORM backup_table('ad_field_contextmenu',  '_gh31399_renumber');
+    END IF;
+END $$;
+
+
+-- AD_Field: 1000008 -> 784918, 1000009 -> 784919, 1000010 -> 784920.
+-- Natural key: (AD_Tab_ID, AD_Column_ID) -- enforced unique by index ad_field_column.
+DO $$
+DECLARE
+    r        RECORD;
+    v_cur_id numeric(10,0);
+BEGIN
+    FOR r IN
+        SELECT *
+        FROM (VALUES
+                  (549361, 593114, 1000008, 784918 /*From ID Server*/),
+                  (549361, 593111, 1000009, 784919 /*From ID Server*/),
+                  (549361, 593110, 1000010, 784920 /*From ID Server*/)
+             ) AS t(ad_tab_id, ad_column_id, wrong_id, new_id)
+    LOOP
+        SELECT f.AD_Field_ID INTO v_cur_id
+        FROM AD_Field f
+        WHERE f.AD_Tab_ID = r.ad_tab_id AND f.AD_Column_ID = r.ad_column_id;
+
+        IF v_cur_id IS NULL THEN
+            RAISE NOTICE 'AD_Field (AD_Tab_ID=%, AD_Column_ID=%) does not exist - 5818170 never ran here; nothing to do', r.ad_tab_id, r.ad_column_id;
+            CONTINUE;
+        END IF;
+
+        IF v_cur_id = r.new_id THEN
+            RAISE NOTICE 'AD_Field (AD_Tab_ID=%, AD_Column_ID=%) already carries % - nothing to do', r.ad_tab_id, r.ad_column_id, r.new_id;
+            CONTINUE;
+        END IF;
+
+        IF v_cur_id <> r.wrong_id THEN
+            RAISE EXCEPTION 'AD_Field (AD_Tab_ID=%, AD_Column_ID=%) carries the unexpected AD_Field_ID % (expected % or %) - refusing to renumber', r.ad_tab_id, r.ad_column_id, v_cur_id, r.wrong_id, r.new_id;
+        END IF;
+
+        IF EXISTS (SELECT 1 FROM AD_Field WHERE AD_Field_ID = r.new_id) THEN
+            RAISE EXCEPTION 'AD_Field % is already taken - cannot renumber % to it', r.new_id, r.wrong_id;
+        END IF;
+
+        -- the eight foreign keys onto AD_Field; note AD_UI_Element references it TWICE
+        UPDATE AD_Field_Trl          SET AD_Field_ID              = r.new_id WHERE AD_Field_ID              = r.wrong_id;
+        UPDATE AD_Element_Link       SET AD_Field_ID              = r.new_id WHERE AD_Field_ID              = r.wrong_id;
+        UPDATE AD_Field_ContextMenu  SET AD_Field_ID              = r.new_id WHERE AD_Field_ID              = r.wrong_id;
+        UPDATE AD_UI_Element         SET AD_Field_ID              = r.new_id WHERE AD_Field_ID              = r.wrong_id;
+        UPDATE AD_UI_Element         SET Labels_Selector_Field_ID = r.new_id WHERE Labels_Selector_Field_ID = r.wrong_id;
+        UPDATE AD_UI_ElementField    SET AD_Field_ID              = r.new_id WHERE AD_Field_ID              = r.wrong_id;
+        UPDATE AD_User_SortPref_Line SET AD_Field_ID              = r.new_id WHERE AD_Field_ID              = r.wrong_id;
+        UPDATE AD_UserDef_Field      SET AD_Field_ID              = r.new_id WHERE AD_Field_ID              = r.wrong_id;
+
+        UPDATE AD_Field SET AD_Field_ID = r.new_id WHERE AD_Field_ID = r.wrong_id;
+
+        RAISE NOTICE 'AD_Field % renumbered to %', r.wrong_id, r.new_id;
+    END LOOP;
+END $$;
+
+
+-- AD_UI_Column: 1000033 -> 549754.
+-- Natural key: (AD_UI_Section_ID, SeqNo). AD_UI_Section_ID=547866 alone is NOT unique -- that
+-- section carries a second UI column at SeqNo=10 -- so SeqNo is part of the key.
+DO $$
+DECLARE
+    v_cur_id numeric(10,0);
+    v_wrong  numeric(10,0) := 1000033;
+    v_new    numeric(10,0) := 549754 /*From ID Server*/;
+BEGIN
+    SELECT c.AD_UI_Column_ID INTO v_cur_id
+    FROM AD_UI_Column c
+    WHERE c.AD_UI_Section_ID = 547866 AND c.SeqNo = 20;
+
+    IF v_cur_id IS NULL THEN
+        RAISE NOTICE 'AD_UI_Column (AD_UI_Section_ID=547866, SeqNo=20) does not exist - 5818170 never ran here; nothing to do';
+    ELSIF v_cur_id = v_new THEN
+        RAISE NOTICE 'AD_UI_Column (AD_UI_Section_ID=547866, SeqNo=20) already carries % - nothing to do', v_new;
+    ELSIF v_cur_id <> v_wrong THEN
+        RAISE EXCEPTION 'AD_UI_Column (AD_UI_Section_ID=547866, SeqNo=20) carries the unexpected AD_UI_Column_ID % (expected % or %) - refusing to renumber', v_cur_id, v_wrong, v_new;
+    ELSE
+        IF EXISTS (SELECT 1 FROM AD_UI_Column WHERE AD_UI_Column_ID = v_new) THEN
+            RAISE EXCEPTION 'AD_UI_Column % is already taken - cannot renumber % to it', v_new, v_wrong;
+        END IF;
+
+        -- the single foreign key onto AD_UI_Column
+        UPDATE AD_UI_ElementGroup SET AD_UI_Column_ID = v_new WHERE AD_UI_Column_ID = v_wrong;
+
+        UPDATE AD_UI_Column SET AD_UI_Column_ID = v_new WHERE AD_UI_Column_ID = v_wrong;
+
+        RAISE NOTICE 'AD_UI_Column % renumbered to %', v_wrong, v_new;
+    END IF;
+END $$;
+
+
+-- AD_UI_ElementGroup: 1000047 -> 555763.
+-- Natural key: (AD_UI_Column_ID, Name). The UI column is re-resolved from its own natural key
+-- so this block does not depend on whether the block above had anything to do.
+DO $$
+DECLARE
+    v_col_id numeric(10,0);
+    v_cur_id numeric(10,0);
+    v_wrong  numeric(10,0) := 1000047;
+    v_new    numeric(10,0) := 555763 /*From ID Server*/;
+BEGIN
+    SELECT c.AD_UI_Column_ID INTO v_col_id
+    FROM AD_UI_Column c
+    WHERE c.AD_UI_Section_ID = 547866 AND c.SeqNo = 20;
+
+    IF v_col_id IS NULL THEN
+        RAISE NOTICE 'AD_UI_Column (AD_UI_Section_ID=547866, SeqNo=20) does not exist - 5818170 never ran here; nothing to do';
+        RETURN;
+    END IF;
+
+    SELECT g.AD_UI_ElementGroup_ID INTO v_cur_id
+    FROM AD_UI_ElementGroup g
+    WHERE g.AD_UI_Column_ID = v_col_id AND g.Name = 'main';
+
+    IF v_cur_id IS NULL THEN
+        RAISE NOTICE 'AD_UI_ElementGroup (AD_UI_Column_ID=%, Name=main) does not exist - nothing to do', v_col_id;
+    ELSIF v_cur_id = v_new THEN
+        RAISE NOTICE 'AD_UI_ElementGroup (AD_UI_Column_ID=%, Name=main) already carries % - nothing to do', v_col_id, v_new;
+    ELSIF v_cur_id <> v_wrong THEN
+        RAISE EXCEPTION 'AD_UI_ElementGroup (AD_UI_Column_ID=%, Name=main) carries the unexpected AD_UI_ElementGroup_ID % (expected % or %) - refusing to renumber', v_col_id, v_cur_id, v_wrong, v_new;
+    ELSE
+        IF EXISTS (SELECT 1 FROM AD_UI_ElementGroup WHERE AD_UI_ElementGroup_ID = v_new) THEN
+            RAISE EXCEPTION 'AD_UI_ElementGroup % is already taken - cannot renumber % to it', v_new, v_wrong;
+        END IF;
+
+        -- the single foreign key onto AD_UI_ElementGroup
+        UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID = v_new WHERE AD_UI_ElementGroup_ID = v_wrong;
+
+        UPDATE AD_UI_ElementGroup SET AD_UI_ElementGroup_ID = v_new WHERE AD_UI_ElementGroup_ID = v_wrong;
+
+        RAISE NOTICE 'AD_UI_ElementGroup % renumbered to %', v_wrong, v_new;
+    END IF;
+END $$;
+
+
+-- AD_UI_Element: 1000528 -> 654688, 1000529 -> 654689, 1000530 -> 654690, 1000531 -> 654691.
+-- Natural keys:
+--   654688: (AD_Tab_ID=180, AD_UI_ElementGroup_ID=1000039, Name='Tag') -- group 1000039 is a
+--           pre-existing seed row and is NOT renumbered, so it is used as a literal here;
+--   654689..654691: (AD_Tab_ID=549361, AD_Field_ID), where the field is itself re-resolved from
+--           its own (AD_Tab_ID, AD_Column_ID) natural key -- so this block works whether or not
+--           the AD_Field block above renumbered anything.
+DO $$
+DECLARE
+    r          RECORD;
+    v_field_id numeric(10,0);
+    v_cur_id   numeric(10,0);
+BEGIN
+    FOR r IN
+        SELECT *
+        FROM (VALUES
+                  (180,    NULL::integer, 1000039::integer, 'Tag'::text, 1000528, 654688 /*From ID Server*/),
+                  (549361, 593114,        NULL,             NULL,        1000529, 654689 /*From ID Server*/),
+                  (549361, 593111,        NULL,             NULL,        1000530, 654690 /*From ID Server*/),
+                  (549361, 593110,        NULL,             NULL,        1000531, 654691 /*From ID Server*/)
+             ) AS t(ad_tab_id, ad_column_id, ad_ui_elementgroup_id, name, wrong_id, new_id)
+    LOOP
+        v_cur_id := NULL;
+
+        IF r.ad_column_id IS NULL THEN
+            SELECT e.AD_UI_Element_ID INTO v_cur_id
+            FROM AD_UI_Element e
+            WHERE e.AD_Tab_ID = r.ad_tab_id
+              AND e.AD_UI_ElementGroup_ID = r.ad_ui_elementgroup_id
+              AND e.Name = r.name;
+        ELSE
+            SELECT f.AD_Field_ID INTO v_field_id
+            FROM AD_Field f
+            WHERE f.AD_Tab_ID = r.ad_tab_id AND f.AD_Column_ID = r.ad_column_id;
+
+            IF v_field_id IS NULL THEN
+                RAISE NOTICE 'AD_Field (AD_Tab_ID=%, AD_Column_ID=%) does not exist - 5818170 never ran here; nothing to do', r.ad_tab_id, r.ad_column_id;
+                CONTINUE;
+            END IF;
+
+            SELECT e.AD_UI_Element_ID INTO v_cur_id
+            FROM AD_UI_Element e
+            WHERE e.AD_Tab_ID = r.ad_tab_id AND e.AD_Field_ID = v_field_id;
+        END IF;
+
+        IF v_cur_id IS NULL THEN
+            RAISE NOTICE 'AD_UI_Element for (AD_Tab_ID=%, AD_Column_ID=%, group=%, Name=%) does not exist - nothing to do', r.ad_tab_id, r.ad_column_id, r.ad_ui_elementgroup_id, r.name;
+            CONTINUE;
+        END IF;
+
+        IF v_cur_id = r.new_id THEN
+            RAISE NOTICE 'AD_UI_Element for (AD_Tab_ID=%, AD_Column_ID=%, group=%, Name=%) already carries % - nothing to do', r.ad_tab_id, r.ad_column_id, r.ad_ui_elementgroup_id, r.name, r.new_id;
+            CONTINUE;
+        END IF;
+
+        IF v_cur_id <> r.wrong_id THEN
+            RAISE EXCEPTION 'AD_UI_Element for (AD_Tab_ID=%, AD_Column_ID=%, group=%, Name=%) carries the unexpected AD_UI_Element_ID % (expected % or %) - refusing to renumber', r.ad_tab_id, r.ad_column_id, r.ad_ui_elementgroup_id, r.name, v_cur_id, r.wrong_id, r.new_id;
+        END IF;
+
+        IF EXISTS (SELECT 1 FROM AD_UI_Element WHERE AD_UI_Element_ID = r.new_id) THEN
+            RAISE EXCEPTION 'AD_UI_Element % is already taken - cannot renumber % to it', r.new_id, r.wrong_id;
+        END IF;
+
+        -- the single foreign key onto AD_UI_Element
+        UPDATE AD_UI_ElementField SET AD_UI_Element_ID = r.new_id WHERE AD_UI_Element_ID = r.wrong_id;
+
+        UPDATE AD_UI_Element SET AD_UI_Element_ID = r.new_id WHERE AD_UI_Element_ID = r.wrong_id;
+
+        RAISE NOTICE 'AD_UI_Element % renumbered to %', r.wrong_id, r.new_id;
+    END LOOP;
+END $$;


### PR DESCRIPTION
## What

`5818170_sys_gh31399_FixProductWindowAndLabelsTab.sql` is a Swing-client recording. As recorded it INSERTed nine new AD rows using the recording developer's **local sequence** ids (≥ 1000000) instead of ids from the central ID server.

Two parts, because the script is already rolled out:

1. **`5818170` corrected in place** — a fresh database now gets ID-server ids.
2. **New `5822300_sys_gh31399_Renumber_LocalSequence_Ids_Of_5818170.sql`** — renumbers the rows on instances that already applied the original, locating each **by natural key** (the primary key is the thing being corrected).

| table | was | now | natural key |
|---|---|---|---|
| `AD_Field` | 1000008 / 1000009 / 1000010 | 784918 / 784919 / 784920 | `AD_Tab_ID=549361` + `AD_Column_ID` 593114 / 593111 / 593110 |
| `AD_UI_Column` | 1000033 | 549754 | `AD_UI_Section_ID=547866` |
| `AD_UI_ElementGroup` | 1000047 | 555763 | its `AD_UI_Column_ID` |
| `AD_UI_Element` | 1000528–1000531 | 654688–654691 | tab + group + field |

## Why it matters

Ids ≥ 1000000 are what an instance's **own** sequence hands out. These rows did not merely land in that range — they landed on the very next number: before `5818170` ran, `max(ad_ui_elementgroup_id)` was 1000046 and `max(ad_ui_column_id)` was 1000032, and the script took 1000047 and 1000033. Any instance allocating locally would have collided. A customer repository independently squatted the same space, which is how this surfaced.

Renumbering also restores those maxima to 1000046 / 1000032, returning the sequences to their correct next-local values.

## What was deliberately NOT changed

The file also contains `AD_TreeNodeMM` rows referencing `1000007`–`1000012`. Those are **menu-seed nodes** — `1000007=Menu`, `1000008=CRM`, `1000009=Produktverwaltung`, … — shipped in the db seed dump and identical on every instance. They are correct as they are, and a naive find-and-replace of "ids ≥ 1000000" would have scrambled the menu tree on every instance.

The same number is a squatted primary key in one statement and a valid seed reference in another: **the table is decided by the statement the id sits in, not by its numeric value.** Every one of the 21 substitutions asserted its enclosing statement before applying. `git diff` shows zero changed lines containing `AD_TreeNodeMM`, and 67 such lines still carry 1000007–1000012 untouched.

`AD_UI_ElementGroup 1000039` and `AD_UI_Column 1000004` are referenced but not created here; they are seed rows below the seed high-water mark and are left alone.

## Verification

Against a stack carrying the full migration chain, all inside one transaction, rolled back:

- **Pre-state** — all nine rows present with the wrong ids; all nine target ids free.
- **FK coverage** — the reference set was enumerated from `pg_constraint`, not by hand: 11 constraints across the four parents. Before/after counts shown for **every** child including the empty ones, so "checked and empty" is distinguishable from "never checked": `ad_field_trl` 12→0 / 0→12, `ad_element_link` 3→0 / 0→3, `ad_ui_element.ad_field_id` 3→0 / 0→3, `ad_ui_elementgroup.ad_ui_column_id` 1→0 / 0→1, `ad_ui_element.ad_ui_elementgroup_id` 3→0 / 0→3; `ad_field_contextmenu`, `ad_ui_element.labels_selector_field_id`, `ad_ui_elementfield` (both columns), `ad_user_sortpref_line`, `ad_userdef_field` all 0 throughout.
- **Deferred FKs** — all 11 constraints are `DEFERRABLE INITIALLY DEFERRED` with `ON UPDATE NO ACTION`, verified per parent table rather than extrapolated, which is what makes a plain sequence of `UPDATE`s valid in one transaction. `SET CONSTRAINTS ALL IMMEDIATE` was fired in the harness afterwards to force every deferred check — no dangling reference.
- **Idempotency** — a second run in the same transaction reported "nothing to do" for all nine, and a full-row `EXCEPT` diff across all six affected tables showed 0 added / 0 removed.
- **Menu tree** — a full-table `EXCEPT` diff of `AD_TreeNodeMM` before vs after: 0 rows added, 0 removed.
- **Rollback** — database confirmed back to its original state, no leftover `backup.*` tables.

A no-op on an instance where the original never ran, and a no-op on a second application.

## Notes for review

- The renumber script deliberately does **not** stamp `Updated`/`UpdatedBy`. It corrects identity, not content, and bumping `AD_Field.Updated` without `AD_Field_Trl.Updated` would flip the `f_trl.updated <> e_trl.updated` guard inside `update_FieldTranslation_From_AD_Name_Element`, silently changing translation propagation. The rationale is in the script header so it does not read as an omission.
- `backup_table` is called for the three operator-data children only (`ad_userdef_field`, `ad_user_sortpref_line`, `ad_field_contextmenu`), guarded to run only when there is something to renumber. They are empty on the stacks checked, but "zero here" is not "zero everywhere". The structural `AD_*` tables are exempt per the backup rule.
- No layout, field set, placement or translation changes: the rendered window is identical before and after. Only the primary keys behind it change.
