### PR TITLE
HU Trace Report — pair direct-sale receipts and shipments along the HU trace graph, label lot-level guesses

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -147,7 +147,7 @@ public class M_HU_Trace_Report_StepDef
 	 *   <li>{@code INELIGIBLE_RECEIPT_DOC} — a shipment that descends from a receipt document this
 	 *       section may not report (an {@code MMR} whose doctype is {@code IsSOTrx='Y'}), plus a
 	 *       purchase receipt of the same lot with no VHU link. The graph link must not silence the
-	 *       lot-level candidate that the customer sees today.</li>
+	 *       lot-level candidate the report emits for such a group.</li>
 	 * </ul>
 	 */
 	@When("M_HU_Trace_Report test data is set up for scenario {string}:")
@@ -211,9 +211,9 @@ public class M_HU_Trace_Report_StepDef
 	 * selects via {@code HUTraceEventQuery.builder().productId(productId).types(typesToReport())}
 	 * — scoped by product and trace type, with no lot/InOut/scenario/time filter — so every prior
 	 * run's trace rows for that product would still be picked up: the MATERIAL_RECEIPT and
-	 * MATERIAL_SHIPMENT ones directly, being reported types, and their TRANSFORM_LOAD rows through
-	 * the recursion, which rebuilds its queries without the type filter. Both routes lead here, so
-	 * the cleanup is required either way. Left unhandled, {@link #assertDetailRows}'s
+	 * MATERIAL_SHIPMENT ones directly, being reported types, and whatever else the recursion
+	 * reaches over their VHU links — of any trace type, since it rebuilds its queries without the
+	 * type filter. Both routes lead here, so the cleanup is required either way. Left unhandled, {@link #assertDetailRows}'s
 	 * {@code containsExactlyInAnyOrderElementsOf} (deliberately exhaustive — it is what catches
 	 * a wrongly-emitted extra row, see its javadoc) would keep failing with leftover rows whose
 	 * {@code DocumentNo}s can never match the current run's freshly generated ones, independent
@@ -715,8 +715,9 @@ public class M_HU_Trace_Report_StepDef
 	 * balance correction, an empties return …), and the scenario does not depend on which.
 	 *
 	 * <p>The graph therefore says something about this shipment, but nothing the section may print.
-	 * The lot-level candidate resting on the purchase receipt is what the customer sees today and
-	 * must keep seeing: deciding "this group has a traced receipt, so drop its candidates" before
+	 * The lot-level candidate resting on the purchase receipt is what the report emits for such a
+	 * group, and must keep emitting: deciding "this group has a traced receipt, so drop its
+	 * candidates" before
 	 * the receipt document has been checked for eligibility would leave the group with no row at
 	 * all, silently deleting information.
 	 */

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -206,9 +206,12 @@ public class M_HU_Trace_Report_StepDef
 	 * <p>Test products are upserted by {@code Value} ({@code M_Product_StepDef#createM_Product}
 	 * resolves via {@code retrieveProductByValue} before creating), so a re-run against a
 	 * persistent stack resolves to the SAME {@code M_Product_ID}. {@link #invokeReport} then
-	 * selects via {@code HUTraceEventQuery.builder().productId(productId)...} — scoped by
-	 * product ALONE, no lot/InOut/scenario/time filter — so every prior run's trace rows for
-	 * that product would still be picked up. Left unhandled, {@link #assertDetailRows}'s
+	 * selects via {@code HUTraceEventQuery.builder().productId(productId).types(typesToReport())}
+	 * — scoped by product and trace type, with no lot/InOut/scenario/time filter — so every prior
+	 * run's trace rows for that product would still be picked up: the MATERIAL_RECEIPT and
+	 * MATERIAL_SHIPMENT ones directly, being reported types, and their TRANSFORM_LOAD rows through
+	 * the recursion, which rebuilds its queries without the type filter. Both routes lead here, so
+	 * the cleanup is required either way. Left unhandled, {@link #assertDetailRows}'s
 	 * {@code containsExactlyInAnyOrderElementsOf} (deliberately exhaustive — it is what catches
 	 * a wrongly-emitted extra row, see its javadoc) would keep failing with leftover rows whose
 	 * {@code DocumentNo}s can never match the current run's freshly generated ones, independent

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -75,12 +75,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Step definitions for testing the M_HU_Trace_Report SQL function.
  *
- * <p>Tests two specific SQL bugs that were fixed:
+ * <p>Covers two previously-fixed SQL bugs plus the receipt→shipment pairing behaviour of the
+ * DIRECT_SALE_DETAIL section:
  * <ul>
  *   <li>Bug A (Section 5 — PRODUCTION_RECEIPT_DETAL): INNER JOIN to m_hu_attribute mhd
  *       excluded products without best-before date. Fixed by LEFT JOIN.</li>
  *   <li>Bug B (Section 6 — DIRECT_SALE_DETAIL): {@code shipment_trace.lotnumber = t.lotnumber}
  *       evaluated to false for NULL lot numbers. Fixed by {@code IS NOT DISTINCT FROM}.</li>
+ *   <li>DIRECT_SALE_DETAIL pairing (Section 6): still matches a shipment to a receipt on
+ *       lot+product alone, producing a cartesian when several receipts share a lot — not yet
+ *       fixed. Test cases exercising this are added incrementally.</li>
  * </ul>
  */
 @RequiredArgsConstructor

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -84,7 +84,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       evaluated to false for NULL lot numbers. Fixed by {@code IS NOT DISTINCT FROM}.</li>
  *   <li>DIRECT_SALE_DETAIL pairing (Section 6): still matches a shipment to a receipt on
  *       lot+product alone, producing a cartesian when several receipts share a lot — not yet
- *       fixed. Test cases exercising this are added incrementally.</li>
+ *       fixed. Test cases exercising this are added incrementally, exercising the desired
+ *       graph-tracing rule: reachability along the {@code M_HU_Trace} graph (same VHU, or a
+ *       chain of {@code VHU_Source_ID} edges), guarded by lot agreement between the two ends.</li>
  * </ul>
  */
 @RequiredArgsConstructor
@@ -117,6 +119,16 @@ public class M_HU_Trace_Report_StepDef
 	 *       product/lot, with the shipped VHU descending from only the first receipt's VHU
 	 *       (a TRANSFORM_LOAD edge). Exposes the DIRECT_SALE_DETAIL cartesian: today's section 6
 	 *       pairs the shipment with BOTH receipts because it matches on lot+product alone.</li>
+	 *   <li>{@code LOT_DISAGREEMENT} — a receipt's VHU transforms (one TRANSFORM_LOAD edge) into
+	 *       the shipped VHU, but the shipment's own MATERIAL_SHIPMENT trace carries a different
+	 *       lot number than the receipt. Guards the lot-agreement half of the graph-tracing rule:
+	 *       a graph link alone must not be enough to call the pair traced.</li>
+	 *   <li>{@code SAME_VHU_NO_TRANSFORM} — one VHU carries both the MATERIAL_RECEIPT and the
+	 *       MATERIAL_SHIPMENT trace directly, with no TRANSFORM_LOAD edge at all (received and
+	 *       shipped without repacking). The depth-0 case a rule that only walks edges would miss.</li>
+	 *   <li>{@code TWO_STEP_TRANSFORM} — a receipt's VHU transforms into an intermediate VHU,
+	 *       which transforms again into the shipped VHU (two TRANSFORM_LOAD edges). The receipt
+	 *       document must still resolve to the original receipt, not the intermediate step.</li>
 	 * </ul>
 	 */
 	@When("M_HU_Trace_Report test data is set up for scenario {string}:")
@@ -141,6 +153,15 @@ public class M_HU_Trace_Report_StepDef
 				break;
 			case "TRACED_ONE_OF_TWO_RECEIPTS":
 				setupTracedOneOfTwoReceipts(scenarioName, productId);
+				break;
+			case "LOT_DISAGREEMENT":
+				setupLotDisagreement(scenarioName, productId);
+				break;
+			case "SAME_VHU_NO_TRANSFORM":
+				setupSameVhuNoTransform(scenarioName, productId);
+				break;
+			case "TWO_STEP_TRANSFORM":
+				setupTwoStepTransform(scenarioName, productId);
 				break;
 			default:
 				throw new AdempiereException("Unknown TestType: " + testType);
@@ -458,6 +479,91 @@ public class M_HU_Trace_Report_StepDef
 
 		scenarioDocNos.put(scenarioName + ".receipt1", receiptInOut1.getDocumentNo());
 		scenarioDocNos.put(scenarioName + ".receipt2", receiptInOut2.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".shipment", shipmentInOut.getDocumentNo());
+	}
+
+	/**
+	 * A receipt's VHU transforms (one TRANSFORM_LOAD edge) into the shipped VHU, but the
+	 * shipment's own MATERIAL_SHIPMENT trace carries a different lot number than the receipt.
+	 * Guards the lot-agreement half of the graph-tracing rule: a graph link alone must not be
+	 * enough to call the pair traced when the two ends disagree on lot.
+	 */
+	private void setupLotDisagreement(@NonNull final String scenarioName, @NonNull final ProductId productId)
+	{
+		scenarioProductIds.put(scenarioName, productId);
+		final I_C_DocType receiptDocType = loadDocType("MMR", false);
+		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
+
+		final I_M_HU receiptVhu = createVhu();
+		final I_M_InOut receiptInOut = createMinimalInOut(receiptDocType, "CO");
+		createHuTraceWithSource(receiptVhu, null, productId, HUTraceType.MATERIAL_RECEIPT,
+				"LOT-A", receiptInOut, new BigDecimal("100"));
+
+		// the shipped VHU genuinely descends from the receipt's VHU ...
+		final I_M_HU shippedVhu = createVhu();
+		createHuTraceWithSource(shippedVhu, receiptVhu, productId, HUTraceType.TRANSFORM_LOAD,
+				"LOT-A", null, new BigDecimal("24"));
+		// ... but its own MATERIAL_SHIPMENT trace was recorded under a different lot
+		final I_M_InOut shipmentInOut = createMinimalInOut(shipmentDocType, "CO");
+		createHuTraceWithSource(shippedVhu, null, productId, HUTraceType.MATERIAL_SHIPMENT,
+				"LOT-B", shipmentInOut, new BigDecimal("-24"));
+
+		scenarioDocNos.put(scenarioName + ".receipt1", receiptInOut.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".shipment", shipmentInOut.getDocumentNo());
+	}
+
+	/**
+	 * One VHU carries both the MATERIAL_RECEIPT and the MATERIAL_SHIPMENT trace directly, with
+	 * no TRANSFORM_LOAD edge at all — received and shipped without repacking. The depth-0 case a
+	 * rule that only walks {@code VHU_Source_ID} edges would forget.
+	 */
+	private void setupSameVhuNoTransform(@NonNull final String scenarioName, @NonNull final ProductId productId)
+	{
+		scenarioProductIds.put(scenarioName, productId);
+		final I_C_DocType receiptDocType = loadDocType("MMR", false);
+		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
+
+		final I_M_HU vhu = createVhu();
+		final I_M_InOut receiptInOut = createMinimalInOut(receiptDocType, "CO");
+		createHuTraceWithSource(vhu, null, productId, HUTraceType.MATERIAL_RECEIPT,
+				"LOT-SAME-VHU", receiptInOut, new BigDecimal("100"));
+
+		final I_M_InOut shipmentInOut = createMinimalInOut(shipmentDocType, "CO");
+		createHuTraceWithSource(vhu, null, productId, HUTraceType.MATERIAL_SHIPMENT,
+				"LOT-SAME-VHU", shipmentInOut, new BigDecimal("-24"));
+
+		scenarioDocNos.put(scenarioName + ".receipt1", receiptInOut.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".shipment", shipmentInOut.getDocumentNo());
+	}
+
+	/**
+	 * A receipt's VHU transforms into an intermediate VHU, which transforms again into the
+	 * shipped VHU — a two-edge TRANSFORM_LOAD chain. The receipt document must still resolve to
+	 * the original receipt, not the intermediate step.
+	 */
+	private void setupTwoStepTransform(@NonNull final String scenarioName, @NonNull final ProductId productId)
+	{
+		scenarioProductIds.put(scenarioName, productId);
+		final I_C_DocType receiptDocType = loadDocType("MMR", false);
+		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
+
+		final I_M_HU receiptVhu = createVhu();
+		final I_M_InOut receiptInOut = createMinimalInOut(receiptDocType, "CO");
+		createHuTraceWithSource(receiptVhu, null, productId, HUTraceType.MATERIAL_RECEIPT,
+				"LOT-TWO-STEP", receiptInOut, new BigDecimal("100"));
+
+		final I_M_HU intermediateVhu = createVhu();
+		createHuTraceWithSource(intermediateVhu, receiptVhu, productId, HUTraceType.TRANSFORM_LOAD,
+				"LOT-TWO-STEP", null, new BigDecimal("24"));
+
+		final I_M_HU shippedVhu = createVhu();
+		createHuTraceWithSource(shippedVhu, intermediateVhu, productId, HUTraceType.TRANSFORM_LOAD,
+				"LOT-TWO-STEP", null, new BigDecimal("24"));
+		final I_M_InOut shipmentInOut = createMinimalInOut(shipmentDocType, "CO");
+		createHuTraceWithSource(shippedVhu, null, productId, HUTraceType.MATERIAL_SHIPMENT,
+				"LOT-TWO-STEP", shipmentInOut, new BigDecimal("-24"));
+
+		scenarioDocNos.put(scenarioName + ".receipt1", receiptInOut.getDocumentNo());
 		scenarioDocNos.put(scenarioName + ".shipment", shipmentInOut.getDocumentNo());
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -129,6 +129,18 @@ public class M_HU_Trace_Report_StepDef
 	 *   <li>{@code TWO_STEP_TRANSFORM} — a receipt's VHU transforms into an intermediate VHU,
 	 *       which transforms again into the shipped VHU (two TRANSFORM_LOAD edges). The receipt
 	 *       document must still resolve to the original receipt, not the intermediate step.</li>
+	 *   <li>{@code MIXED_TRACED_AND_CANDIDATE} — two receipts and two shipments of one lot with no
+	 *       VHU link anywhere, plus a third shipment descending from the first receipt. Shows that
+	 *       candidate suppression is per (shipment, product, lot), not global across the lot: the
+	 *       graph-traced shipment is TRACED and never also a candidate, while the two unlinked
+	 *       shipments remain candidates for every receipt of the lot.</li>
+	 *   <li>{@code NO_LOT_NO_LINK} — a receipt and a shipment of one product, both with
+	 *       {@code lotnumber=NULL} and no VHU link. Labelled PRODUCT_CANDIDATE, distinct from
+	 *       {@code MIXED_TRACED_AND_CANDIDATE}'s LOT_CANDIDATE — there is no lot to agree on.</li>
+	 *   <li>{@code RECEIPT_QTY_AND_DEDUP} — one receipt document carrying two MATERIAL_RECEIPT
+	 *       traces of the same lot on different VHUs, with a shipment descending from the first of
+	 *       the two. The receipt document's total quantity across both VHUs must be reported once,
+	 *       not once per VHU.</li>
 	 * </ul>
 	 */
 	@When("M_HU_Trace_Report test data is set up for scenario {string}:")
@@ -162,6 +174,15 @@ public class M_HU_Trace_Report_StepDef
 				break;
 			case "TWO_STEP_TRANSFORM":
 				setupTwoStepTransform(scenarioName, productId);
+				break;
+			case "MIXED_TRACED_AND_CANDIDATE":
+				setupMixedTracedAndCandidate(scenarioName, productId);
+				break;
+			case "NO_LOT_NO_LINK":
+				setupNoLotNoLink(scenarioName, productId);
+				break;
+			case "RECEIPT_QTY_AND_DEDUP":
+				setupReceiptQtyAndDedup(scenarioName, productId);
 				break;
 			default:
 				throw new AdempiereException("Unknown TestType: " + testType);
@@ -562,6 +583,113 @@ public class M_HU_Trace_Report_StepDef
 		final I_M_InOut shipmentInOut = createMinimalInOut(shipmentDocType, "CO");
 		createHuTraceWithSource(shippedVhu, null, productId, HUTraceType.MATERIAL_SHIPMENT,
 				"LOT-TWO-STEP", shipmentInOut, new BigDecimal("-24"));
+
+		scenarioDocNos.put(scenarioName + ".receipt1", receiptInOut.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".shipment", shipmentInOut.getDocumentNo());
+	}
+
+	/**
+	 * Two receipts and two shipments of one lot with no VHU link anywhere, plus a third shipment
+	 * descending from the first receipt (one TRANSFORM_LOAD edge). Shows that candidate suppression
+	 * is per (shipment, product, lot), not global across the lot: the third shipment is graph-traced
+	 * to receipt1 and must never also appear as a candidate, while the two unlinked shipments remain
+	 * candidates for BOTH receipts of the lot.
+	 */
+	private void setupMixedTracedAndCandidate(@NonNull final String scenarioName, @NonNull final ProductId productId)
+	{
+		scenarioProductIds.put(scenarioName, productId);
+		final I_C_DocType receiptDocType = loadDocType("MMR", false);
+		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
+
+		final I_M_HU receiptVhu1 = createVhu();
+		final I_M_InOut receiptInOut1 = createMinimalInOut(receiptDocType, "CO");
+		createHuTraceWithSource(receiptVhu1, null, productId, HUTraceType.MATERIAL_RECEIPT,
+				"LOT-MIXED", receiptInOut1, new BigDecimal("100"));
+
+		final I_M_HU receiptVhu2 = createVhu();
+		final I_M_InOut receiptInOut2 = createMinimalInOut(receiptDocType, "CO");
+		createHuTraceWithSource(receiptVhu2, null, productId, HUTraceType.MATERIAL_RECEIPT,
+				"LOT-MIXED", receiptInOut2, new BigDecimal("50"));
+
+		// shipmentA: no VHU link anywhere — a candidate for BOTH receipts of this lot
+		final I_M_HU shipmentVhuA = createVhu();
+		final I_M_InOut shipmentInOutA = createMinimalInOut(shipmentDocType, "CO");
+		createHuTraceWithSource(shipmentVhuA, null, productId, HUTraceType.MATERIAL_SHIPMENT,
+				"LOT-MIXED", shipmentInOutA, new BigDecimal("-30"));
+
+		// shipmentB: same shape — also a candidate for BOTH receipts
+		final I_M_HU shipmentVhuB = createVhu();
+		final I_M_InOut shipmentInOutB = createMinimalInOut(shipmentDocType, "CO");
+		createHuTraceWithSource(shipmentVhuB, null, productId, HUTraceType.MATERIAL_SHIPMENT,
+				"LOT-MIXED", shipmentInOutB, new BigDecimal("-20"));
+
+		// shipment3: graph-traced to receipt1 — must be TRACED, and must never also show up as a candidate
+		final I_M_HU shippedVhu3 = createVhu();
+		createHuTraceWithSource(shippedVhu3, receiptVhu1, productId, HUTraceType.TRANSFORM_LOAD,
+				"LOT-MIXED", null, new BigDecimal("24"));
+		final I_M_InOut shipmentInOut3 = createMinimalInOut(shipmentDocType, "CO");
+		createHuTraceWithSource(shippedVhu3, null, productId, HUTraceType.MATERIAL_SHIPMENT,
+				"LOT-MIXED", shipmentInOut3, new BigDecimal("-24"));
+
+		scenarioDocNos.put(scenarioName + ".receipt1", receiptInOut1.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".receipt2", receiptInOut2.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".shipmentA", shipmentInOutA.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".shipmentB", shipmentInOutB.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".shipment3", shipmentInOut3.getDocumentNo());
+	}
+
+	/**
+	 * A receipt and a shipment of one product, both with {@code lotnumber=NULL} and no VHU link.
+	 * Labelled PRODUCT_CANDIDATE — distinct from the lot-sharing candidates of
+	 * {@link #setupMixedTracedAndCandidate} — because there is no lot for the two to agree on, only
+	 * the product. These are the semantics {@code @Id:S0000.1_HUTrace_BugB} depends on.
+	 */
+	private void setupNoLotNoLink(@NonNull final String scenarioName, @NonNull final ProductId productId)
+	{
+		scenarioProductIds.put(scenarioName, productId);
+		final I_C_DocType receiptDocType = loadDocType("MMR", false);
+		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
+
+		final I_M_HU receiptVhu = createVhu();
+		final I_M_InOut receiptInOut = createMinimalInOut(receiptDocType, "CO");
+		createHuTraceWithSource(receiptVhu, null, productId, HUTraceType.MATERIAL_RECEIPT,
+				null /*lotNumber*/, receiptInOut, new BigDecimal("100"));
+
+		final I_M_HU shipmentVhu = createVhu();
+		final I_M_InOut shipmentInOut = createMinimalInOut(shipmentDocType, "CO");
+		createHuTraceWithSource(shipmentVhu, null, productId, HUTraceType.MATERIAL_SHIPMENT,
+				null /*lotNumber*/, shipmentInOut, new BigDecimal("-24"));
+
+		scenarioDocNos.put(scenarioName + ".receipt1", receiptInOut.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".shipment", shipmentInOut.getDocumentNo());
+	}
+
+	/**
+	 * One receipt document carrying two MATERIAL_RECEIPT traces of the same lot on different VHUs
+	 * (e.g. two TUs unloaded together), with a shipment descending from the first of the two VHUs.
+	 * The receipt document's total quantity across both VHUs must be reported once, not once per VHU.
+	 */
+	private void setupReceiptQtyAndDedup(@NonNull final String scenarioName, @NonNull final ProductId productId)
+	{
+		scenarioProductIds.put(scenarioName, productId);
+		final I_C_DocType receiptDocType = loadDocType("MMR", false);
+		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
+
+		final I_M_InOut receiptInOut = createMinimalInOut(receiptDocType, "CO");
+		final I_M_HU receiptVhuA = createVhu();
+		createHuTraceWithSource(receiptVhuA, null, productId, HUTraceType.MATERIAL_RECEIPT,
+				"LOT-DEDUP", receiptInOut, new BigDecimal("60"));
+		final I_M_HU receiptVhuB = createVhu();
+		createHuTraceWithSource(receiptVhuB, null, productId, HUTraceType.MATERIAL_RECEIPT,
+				"LOT-DEDUP", receiptInOut, new BigDecimal("40"));
+
+		// the shipment descends from the FIRST of the two receipt VHUs
+		final I_M_HU shippedVhu = createVhu();
+		createHuTraceWithSource(shippedVhu, receiptVhuA, productId, HUTraceType.TRANSFORM_LOAD,
+				"LOT-DEDUP", null, new BigDecimal("24"));
+		final I_M_InOut shipmentInOut = createMinimalInOut(shipmentDocType, "CO");
+		createHuTraceWithSource(shippedVhu, null, productId, HUTraceType.MATERIAL_SHIPMENT,
+				"LOT-DEDUP", shipmentInOut, new BigDecimal("-24"));
 
 		scenarioDocNos.put(scenarioName + ".receipt1", receiptInOut.getDocumentNo());
 		scenarioDocNos.put(scenarioName + ".shipment", shipmentInOut.getDocumentNo());

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -142,6 +142,10 @@ public class M_HU_Trace_Report_StepDef
 	 *       traces of the same lot on different VHUs, with a shipment descending from the first of
 	 *       the two. The receipt document's total quantity across both VHUs must be reported once,
 	 *       not once per VHU.</li>
+	 *   <li>{@code INELIGIBLE_RECEIPT_DOC} — a shipment that descends from a receipt document this
+	 *       section may not report (a customer return, {@code IsSOTrx='Y'}), plus a genuine purchase
+	 *       receipt of the same lot with no VHU link. The graph link must not silence the lot-level
+	 *       candidate that the customer sees today.</li>
 	 * </ul>
 	 */
 	@When("M_HU_Trace_Report test data is set up for scenario {string}:")
@@ -184,6 +188,9 @@ public class M_HU_Trace_Report_StepDef
 				break;
 			case "RECEIPT_QTY_AND_DEDUP":
 				setupReceiptQtyAndDedup(scenarioName, productId);
+				break;
+			case "INELIGIBLE_RECEIPT_DOC":
+				setupIneligibleReceiptDoc(scenarioName, productId);
 				break;
 			default:
 				throw new AdempiereException("Unknown TestType: " + testType);
@@ -697,6 +704,49 @@ public class M_HU_Trace_Report_StepDef
 				"LOT-DEDUP", shipmentInOut, new BigDecimal("-24"));
 
 		scenarioDocNos.put(scenarioName + ".receipt1", receiptInOut.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".shipment", shipmentInOut.getDocumentNo());
+	}
+
+	/**
+	 * A shipment whose VHU descends from a receipt document that the DIRECT_SALE_DETAIL section is
+	 * not allowed to report — a customer return ({@code DocBaseType='MMR'}, {@code IsSOTrx='Y'}),
+	 * where the section only reports purchase receipts ({@code IsSOTrx='N'}) — plus a genuine
+	 * purchase receipt of the same product and lot that has no VHU link to anything.
+	 *
+	 * <p>The graph therefore says something about this shipment, but nothing the section may print.
+	 * The lot-level candidate resting on the purchase receipt is what the customer sees today and
+	 * must keep seeing: deciding "this group has a traced receipt, so drop its candidates" before
+	 * the receipt document has been checked for eligibility would leave the group with no row at
+	 * all, silently deleting information.
+	 */
+	private void setupIneligibleReceiptDoc(@NonNull final String scenarioName, @NonNull final ProductId productId)
+	{
+		scenarioProductIds.put(scenarioName, productId);
+		final I_C_DocType purchaseReceiptDocType = loadDocType("MMR", false);
+		final I_C_DocType customerReturnDocType = loadDocType("MMR", true);
+		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
+
+		// the receipt document this section may not report, and the shipment that descends from it
+		final I_M_HU returnVhu = createVhu();
+		final I_M_InOut returnInOut = createMinimalInOut(customerReturnDocType, "CO");
+		createHuTraceWithSource(returnVhu, null, productId, HUTraceType.MATERIAL_RECEIPT,
+				"LOT-INELIGIBLE", returnInOut, new BigDecimal("100"));
+
+		final I_M_HU shippedVhu = createVhu();
+		createHuTraceWithSource(shippedVhu, returnVhu, productId, HUTraceType.TRANSFORM_LOAD,
+				"LOT-INELIGIBLE", null, new BigDecimal("24"));
+		final I_M_InOut shipmentInOut = createMinimalInOut(shipmentDocType, "CO");
+		createHuTraceWithSource(shippedVhu, null, productId, HUTraceType.MATERIAL_SHIPMENT,
+				"LOT-INELIGIBLE", shipmentInOut, new BigDecimal("-24"));
+
+		// a reportable purchase receipt of the same lot, linked to nothing — the lot-level candidate
+		final I_M_HU purchaseVhu = createVhu();
+		final I_M_InOut purchaseInOut = createMinimalInOut(purchaseReceiptDocType, "CO");
+		createHuTraceWithSource(purchaseVhu, null, productId, HUTraceType.MATERIAL_RECEIPT,
+				"LOT-INELIGIBLE", purchaseInOut, new BigDecimal("80"));
+
+		scenarioDocNos.put(scenarioName + ".receipt1", purchaseInOut.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".returnReceipt", returnInOut.getDocumentNo());
 		scenarioDocNos.put(scenarioName + ".shipment", shipmentInOut.getDocumentNo());
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -82,11 +82,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       excluded products without best-before date. Fixed by LEFT JOIN.</li>
  *   <li>Bug B (Section 6 — DIRECT_SALE_DETAIL): {@code shipment_trace.lotnumber = t.lotnumber}
  *       evaluated to false for NULL lot numbers. Fixed by {@code IS NOT DISTINCT FROM}.</li>
- *   <li>DIRECT_SALE_DETAIL pairing (Section 6): still matches a shipment to a receipt on
- *       lot+product alone, producing a cartesian when several receipts share a lot — not yet
- *       fixed. Test cases exercising this are added incrementally, exercising the desired
- *       graph-tracing rule: reachability along the {@code M_HU_Trace} graph (same VHU, or a
- *       chain of {@code VHU_Source_ID} edges), guarded by lot agreement between the two ends.</li>
+ *   <li>DIRECT_SALE_DETAIL pairing (Section 6): a shipment is paired with the receipt it is
+ *       traceable to along the {@code M_HU_Trace} graph — the same VHU, or a chain of
+ *       {@code VHU_Source_ID} edges — guarded by lot agreement between the two ends. Where the
+ *       graph is silent for a (shipment document, product, lot) group, lot-level or product-level
+ *       candidates are emitted for that group and labelled as such in {@code link_basis}.</li>
  * </ul>
  */
 @RequiredArgsConstructor
@@ -95,6 +95,8 @@ public class M_HU_Trace_Report_StepDef
 	private final M_Product_StepDefData productTable;
 
 	private final HUTraceRepository huTraceRepository = SpringContextHolder.instance.getBean(HUTraceRepository.class);
+
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	/** Maps scenario name → list of HUTraceType (section name) values returned by the report */
 	private final Map<String, List<String>> reportResultsByScenario = new HashMap<>();
@@ -117,8 +119,8 @@ public class M_HU_Trace_Report_StepDef
 	 *       without MHD (best-before) attribute on the HU. Tests Bug A fix (LEFT JOIN).</li>
 	 *   <li>{@code TRACED_ONE_OF_TWO_RECEIPTS} — creates two MATERIAL_RECEIPT traces of the same
 	 *       product/lot, with the shipped VHU descending from only the first receipt's VHU
-	 *       (a TRANSFORM_LOAD edge). Exposes the DIRECT_SALE_DETAIL cartesian: today's section 6
-	 *       pairs the shipment with BOTH receipts because it matches on lot+product alone.</li>
+	 *       (a TRANSFORM_LOAD edge). Only that receipt is paired with the shipment; the other
+	 *       receipt of the lot is suppressed because the group already has a traced receipt.</li>
 	 *   <li>{@code LOT_DISAGREEMENT} — a receipt's VHU transforms (one TRANSFORM_LOAD edge) into
 	 *       the shipped VHU, but the shipment's own MATERIAL_SHIPMENT trace carries a different
 	 *       lot number than the receipt. Guards the lot-agreement half of the graph-tracing rule:
@@ -210,15 +212,14 @@ public class M_HU_Trace_Report_StepDef
 	 * {@code containsExactlyInAnyOrderElementsOf} (deliberately exhaustive — it is what catches
 	 * a wrongly-emitted extra row, see its javadoc) would keep failing with leftover rows whose
 	 * {@code DocumentNo}s can never match the current run's freshly generated ones, independent
-	 * of whether the still-open section 6 pairing rewrite is correct. Deleting the row instead of
+	 * of whether the section 6 pairing itself is correct. Deleting the row instead of
 	 * deleting-and-recreating the product itself avoids the FK from {@code M_HU_Trace.M_Product_ID}
 	 * (constraint {@code mproduct_mhutrace}, {@code ON DELETE NO ACTION}) blocking product deletion
 	 * while old trace rows still reference it.
 	 */
 	private void deleteExistingHuTraceRows(@NonNull final ProductId productId)
 	{
-		Services.get(IQueryBL.class)
-				.createQueryBuilder(I_M_HU_Trace.class)
+		queryBL.createQueryBuilder(I_M_HU_Trace.class)
 				.addEqualsFilter(I_M_HU_Trace.COLUMNNAME_M_Product_ID, productId.getRepoId())
 				.create()
 				.delete();
@@ -477,9 +478,8 @@ public class M_HU_Trace_Report_StepDef
 	/**
 	 * Two receipts of the same product and lot, one of them graph-traced to the shipment: the
 	 * shipment's VHU descends from the FIRST receipt's VHU through one TRANSFORM_LOAD edge. The
-	 * second receipt is connected to nothing — today's DIRECT_SALE_DETAIL section pairs it with
-	 * the shipment anyway (lot+product match alone), producing a two-row cartesian where exactly
-	 * one row (linked to receipt1) is correct.
+	 * second receipt is connected to nothing, and sharing the lot is not enough to be paired once
+	 * the graph has answered — so the shipment yields exactly one row, linked to receipt1.
 	 */
 	private void setupTracedOneOfTwoReceipts(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{
@@ -490,21 +490,21 @@ public class M_HU_Trace_Report_StepDef
 		final I_M_HU receiptVhu1 = createVhu();
 		final I_M_InOut receiptInOut1 = createMinimalInOut(receiptDocType, "CO");
 		createHuTraceWithSource(receiptVhu1, null, productId, HUTraceType.MATERIAL_RECEIPT,
-				"LOT-TC1", receiptInOut1, new BigDecimal("100"));
+				"LOT-ONE-OF-TWO", receiptInOut1, new BigDecimal("100"));
 
-		// a second receipt of the SAME lot, connected to nothing — today's function pairs it anyway
+		// a second receipt of the SAME lot, connected to nothing — must not be paired with the shipment
 		final I_M_HU receiptVhu2 = createVhu();
 		final I_M_InOut receiptInOut2 = createMinimalInOut(receiptDocType, "CO");
 		createHuTraceWithSource(receiptVhu2, null, productId, HUTraceType.MATERIAL_RECEIPT,
-				"LOT-TC1", receiptInOut2, new BigDecimal("100"));
+				"LOT-ONE-OF-TWO", receiptInOut2, new BigDecimal("100"));
 
 		// the shipped VHU descends from receipt 1
 		final I_M_HU shippedVhu = createVhu();
 		createHuTraceWithSource(shippedVhu, receiptVhu1, productId, HUTraceType.TRANSFORM_LOAD,
-				"LOT-TC1", null, new BigDecimal("24"));
+				"LOT-ONE-OF-TWO", null, new BigDecimal("24"));
 		final I_M_InOut shipmentInOut = createMinimalInOut(shipmentDocType, "CO");
 		createHuTraceWithSource(shippedVhu, null, productId, HUTraceType.MATERIAL_SHIPMENT,
-				"LOT-TC1", shipmentInOut, new BigDecimal("-24"));
+				"LOT-ONE-OF-TWO", shipmentInOut, new BigDecimal("-24"));
 
 		scenarioDocNos.put(scenarioName + ".receipt1", receiptInOut1.getDocumentNo());
 		scenarioDocNos.put(scenarioName + ".receipt2", receiptInOut2.getDocumentNo());
@@ -519,7 +519,7 @@ public class M_HU_Trace_Report_StepDef
 	 *
 	 * <p>The rejected pair is dropped, not demoted: the candidate branch also requires lot
 	 * agreement, so nothing at all is emitted. A product-only fallback would pair every receipt of
-	 * the product with every shipment of it — the cartesian this whole section is being fixed for.
+	 * the product with every shipment of it — a cartesian at product granularity.
 	 */
 	private void setupLotDisagreement(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{
@@ -762,18 +762,18 @@ public class M_HU_Trace_Report_StepDef
 	/**
 	 * Loads the first active C_DocType with the given DocBaseType and IsSOTrx flag.
 	 *
-	 * <p>Filtering by IsSOTrx is critical because metasfresh has multiple doctypes per
-	 * DocBaseType (e.g. MMR has both standard material receipt with isSOTrx='N' and
-	 * customer return receipt with isSOTrx='Y'). Section 6 of M_HU_Trace_Report
-	 * checks {@code receipt_dt.isSOTrx = 'N'} and {@code shipment_dt.isSOTrx = 'Y'}.
+	 * <p>Filtering by IsSOTrx is critical because metasfresh has several doctypes per
+	 * DocBaseType — MMR alone has both inbound ones ({@code isSOTrx='N'}) and outbound ones
+	 * ({@code isSOTrx='Y'}), and which of the latter this returns depends on the seed data, since
+	 * it takes the lowest {@code C_DocType_ID}. Section 6 of M_HU_Trace_Report checks
+	 * {@code receipt_dt.isSOTrx = 'N'} and {@code shipment_dt.isSOTrx = 'Y'}.
 	 *
 	 * @param docBaseType e.g. "MMR" (Material Receipt) or "MMS" (Material Shipment)
 	 * @param isSOTrx     true for sales transactions, false for purchase transactions
 	 */
 	private I_C_DocType loadDocType(@NonNull final String docBaseType, final boolean isSOTrx)
 	{
-		final I_C_DocType docType = Services.get(IQueryBL.class)
-				.createQueryBuilder(I_C_DocType.class)
+		final I_C_DocType docType = queryBL.createQueryBuilder(I_C_DocType.class)
 				.addEqualsFilter(I_C_DocType.COLUMNNAME_DocBaseType, docBaseType)
 				.addEqualsFilter(I_C_DocType.COLUMNNAME_IsSOTrx, isSOTrx)
 				.addEqualsFilter(I_C_DocType.COLUMNNAME_IsActive, true)
@@ -794,8 +794,7 @@ public class M_HU_Trace_Report_StepDef
 	private I_M_HU createVhu()
 	{
 		// Load the Virtual PI (M_HU_PI_ID = 101 is the well-known Virtual PI in metasfresh)
-		final I_M_HU_PI_Version virtualPiVersion = Services.get(IQueryBL.class)
-				.createQueryBuilder(I_M_HU_PI_Version.class)
+		final I_M_HU_PI_Version virtualPiVersion = queryBL.createQueryBuilder(I_M_HU_PI_Version.class)
 				.addEqualsFilter(I_M_HU_PI_Version.COLUMNNAME_M_HU_PI_ID, 101)
 				.addEqualsFilter(I_M_HU_PI_Version.COLUMNNAME_IsCurrent, true)
 				.orderBy(I_M_HU_PI_Version.COLUMNNAME_M_HU_PI_Version_ID)
@@ -947,9 +946,9 @@ public class M_HU_Trace_Report_StepDef
 			@NonNull final I_M_HU vhu,
 			@NonNull final ProductId productId,
 			@NonNull final HUTraceType traceType,
-			final String lotNumber,
-			final I_M_InOut inOut,
-			final I_PP_Order ppOrder)
+			@Nullable final String lotNumber,
+			@Nullable final I_M_InOut inOut,
+			@Nullable final I_PP_Order ppOrder)
 	{
 		return buildAndSaveHuTrace(vhu, null, productId, traceType, lotNumber, inOut, ppOrder, BigDecimal.ONE);
 	}
@@ -977,9 +976,9 @@ public class M_HU_Trace_Report_StepDef
 			@Nullable final I_M_HU sourceVhu,
 			@NonNull final ProductId productId,
 			@NonNull final HUTraceType traceType,
-			final String lotNumber,
-			final I_M_InOut inOut,
-			final I_PP_Order ppOrder,
+			@Nullable final String lotNumber,
+			@Nullable final I_M_InOut inOut,
+			@Nullable final I_PP_Order ppOrder,
 			@NonNull final BigDecimal qty)
 	{
 		final I_M_HU_Trace trace = newInstance(I_M_HU_Trace.class);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -160,7 +160,7 @@ public class M_HU_Trace_Report_StepDef
 	 * {@code containsExactlyInAnyOrderElementsOf} (deliberately exhaustive — it is what catches
 	 * a wrongly-emitted extra row, see its javadoc) would keep failing with leftover rows whose
 	 * {@code DocumentNo}s can never match the current run's freshly generated ones, independent
-	 * of whether the section 6 pairing fix (Task 4) is correct. Deleting the row instead of
+	 * of whether the still-open section 6 pairing rewrite is correct. Deleting the row instead of
 	 * deleting-and-recreating the product itself avoids the FK from {@code M_HU_Trace.M_Product_ID}
 	 * (constraint {@code mproduct_mhutrace}, {@code ON DELETE NO ACTION}) blocking product deletion
 	 * while old trace rows still reference it.
@@ -425,11 +425,11 @@ public class M_HU_Trace_Report_StepDef
 	}
 
 	/**
-	 * TC1 test setup: two receipts of the same product and lot; the shipment's VHU descends from
-	 * the FIRST receipt's VHU through one TRANSFORM_LOAD edge. The second receipt is connected to
-	 * nothing — today's DIRECT_SALE_DETAIL section pairs it with the shipment anyway (lot+product
-	 * match alone), producing a two-row cartesian where exactly one row (linked to receipt1) is
-	 * correct.
+	 * Two receipts of the same product and lot, one of them graph-traced to the shipment: the
+	 * shipment's VHU descends from the FIRST receipt's VHU through one TRANSFORM_LOAD edge. The
+	 * second receipt is connected to nothing — today's DIRECT_SALE_DETAIL section pairs it with
+	 * the shipment anyway (lot+product match alone), producing a two-row cartesian where exactly
+	 * one row (linked to receipt1) is correct.
 	 */
 	private void setupTracedOneOfTwoReceipts(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{
@@ -649,7 +649,7 @@ public class M_HU_Trace_Report_StepDef
 	 * @param inOut     the linked M_InOut (may be null)
 	 * @param ppOrder   the linked PP_Order (may be null)
 	 */
-	private void createHuTrace(
+	private I_M_HU_Trace createHuTrace(
 			@NonNull final I_M_HU vhu,
 			@NonNull final ProductId productId,
 			@NonNull final HUTraceType traceType,
@@ -657,12 +657,47 @@ public class M_HU_Trace_Report_StepDef
 			final I_M_InOut inOut,
 			final I_PP_Order ppOrder)
 	{
+		return buildAndSaveHuTrace(vhu, null, productId, traceType, lotNumber, inOut, ppOrder, BigDecimal.ONE);
+	}
+
+	/** Creates an M_HU_Trace row that also records where its VHU came from (a TRANSFORM_LOAD edge). */
+	private I_M_HU_Trace createHuTraceWithSource(
+			@NonNull final I_M_HU vhu,
+			@Nullable final I_M_HU sourceVhu,
+			@NonNull final ProductId productId,
+			@NonNull final HUTraceType type,
+			@Nullable final String lotNumber,
+			@Nullable final I_M_InOut inOut,
+			@NonNull final BigDecimal qty)
+	{
+		return buildAndSaveHuTrace(vhu, sourceVhu, productId, type, lotNumber, inOut, null, qty);
+	}
+
+	/**
+	 * Shared M_HU_Trace record builder behind {@link #createHuTrace} and
+	 * {@link #createHuTraceWithSource} — the two differ only in whether a source VHU / PP_Order
+	 * is set and in the qty, so both delegate here instead of duplicating the field-setting.
+	 */
+	private I_M_HU_Trace buildAndSaveHuTrace(
+			@NonNull final I_M_HU vhu,
+			@Nullable final I_M_HU sourceVhu,
+			@NonNull final ProductId productId,
+			@NonNull final HUTraceType traceType,
+			final String lotNumber,
+			final I_M_InOut inOut,
+			final I_PP_Order ppOrder,
+			@NonNull final BigDecimal qty)
+	{
 		final I_M_HU_Trace trace = newInstance(I_M_HU_Trace.class);
 		trace.setVHU_ID(vhu.getM_HU_ID());
 		trace.setM_HU_ID(vhu.getM_HU_ID());
+		if (sourceVhu != null)
+		{
+			trace.setVHU_Source_ID(sourceVhu.getM_HU_ID());
+		}
 		trace.setM_Product_ID(productId.getRepoId());
 		trace.setC_UOM_ID(StepDefConstants.PCE_UOM_ID.getRepoId());
-		trace.setQty(BigDecimal.ONE);
+		trace.setQty(qty);
 		trace.setHUTraceType(traceType.getCode());
 		trace.setEventTime(Timestamp.from(Instant.now()));
 		trace.setVHUStatus("A");
@@ -677,37 +712,6 @@ public class M_HU_Trace_Report_StepDef
 		if (ppOrder != null)
 		{
 			trace.setPP_Order_ID(ppOrder.getPP_Order_ID());
-		}
-		saveRecord(trace);
-	}
-
-	/** Creates an M_HU_Trace row that also records where its VHU came from (a TRANSFORM_LOAD edge). */
-	private I_M_HU_Trace createHuTraceWithSource(
-			@NonNull final I_M_HU vhu,
-			@Nullable final I_M_HU sourceVhu,
-			@NonNull final ProductId productId,
-			@NonNull final HUTraceType type,
-			@Nullable final String lotNumber,
-			@Nullable final I_M_InOut inOut,
-			@NonNull final BigDecimal qty)
-	{
-		final I_M_HU_Trace trace = newInstance(I_M_HU_Trace.class);
-		trace.setVHU_ID(vhu.getM_HU_ID());
-		trace.setM_HU_ID(vhu.getM_HU_ID());
-		if (sourceVhu != null)
-		{
-			trace.setVHU_Source_ID(sourceVhu.getM_HU_ID());
-		}
-		trace.setM_Product_ID(productId.getRepoId());
-		trace.setHUTraceType(type.getCode());
-		trace.setLotNumber(lotNumber);
-		trace.setQty(qty);
-		trace.setC_UOM_ID(StepDefConstants.PCE_UOM_ID.getRepoId());
-		trace.setEventTime(Timestamp.from(Instant.now()));
-		trace.setVHUStatus("A");
-		if (inOut != null)
-		{
-			trace.setM_InOut_ID(inOut.getM_InOut_ID());
 		}
 		saveRecord(trace);
 		return trace;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -94,7 +94,7 @@ public class M_HU_Trace_Report_StepDef
 {
 	private final M_Product_StepDefData productTable;
 
-	private final HUTraceRepository huTraceRepository = SpringContextHolder.instance.getBean(HUTraceRepository.class);
+	@NonNull private final HUTraceRepository huTraceRepository = SpringContextHolder.instance.getBean(HUTraceRepository.class);
 
 	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
@@ -220,7 +220,7 @@ public class M_HU_Trace_Report_StepDef
 	private void deleteExistingHuTraceRows(@NonNull final ProductId productId)
 	{
 		queryBL.createQueryBuilder(I_M_HU_Trace.class)
-				.addEqualsFilter(I_M_HU_Trace.COLUMNNAME_M_Product_ID, productId.getRepoId())
+				.addEqualsFilter(I_M_HU_Trace.COLUMNNAME_M_Product_ID, productId)
 				.create()
 				.delete();
 	}
@@ -376,16 +376,19 @@ public class M_HU_Trace_Report_StepDef
 	/**
 	 * Bug B test setup: creates MATERIAL_RECEIPT + MATERIAL_SHIPMENT traces with lotnumber=NULL.
 	 *
-	 * <p>The DIRECT_SALE_DETAIL section of M_HU_Trace_Report uses:
+	 * <p>What keeps this pair reportable is the lot condition of the DIRECT_SALE_DETAIL section's
+	 * candidate branch:
 	 * <pre>
-	 * LEFT JOIN M_HU_Trace shipment_trace ON
-	 *     shipment_trace.lotnumber IS NOT DISTINCT FROM t.lotnumber   -- Bug B fix
-	 *     AND shipment_trace.m_product_id = t.m_product_id
-	 *     AND shipment_trace.hutracetype = 'MATERIAL_SHIPMENT'
+	 * FROM receipt_trace r
+	 * JOIN shipment_trace_sel st
+	 *        ON st.M_Product_ID = r.M_Product_ID
+	 *       AND st.LotNumber IS NOT DISTINCT FROM r.LotNumber
 	 * </pre>
-	 * Before the fix ({@code =} instead of {@code IS NOT DISTINCT FROM}), NULL=NULL evaluated
-	 * to false, so the shipment_trace was never found, and the INNER JOIN on M_Product
-	 * eliminated the row entirely.
+	 * {@code IS NOT DISTINCT FROM} makes two NULL lots agree, so the pair reaches
+	 * {@code candidate_pair} and is emitted with {@code link_basis = 'PRODUCT_CANDIDATE'}.
+	 *
+	 * <p>Historically this was a plain {@code =}: NULL=NULL evaluated to false, the shipment side
+	 * was never found, and the INNER JOIN on M_Product eliminated the row entirely.
 	 */
 	private void setupDirectSaleNullLot(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -111,43 +111,19 @@ public class M_HU_Trace_Report_StepDef
 	/**
 	 * Sets up all DB records required for a specific trace report test scenario.
 	 *
-	 * <p>Supported TestType values:
+	 * <p>Supported TestType values (see each {@code setupXxx} method's Javadoc for the full
+	 * behaviour):
 	 * <ul>
-	 *   <li>{@code DIRECT_SALE_NULL_LOT} — creates MATERIAL_RECEIPT + MATERIAL_SHIPMENT traces
-	 *       with {@code lotnumber=NULL}. Tests Bug B fix (IS NOT DISTINCT FROM).</li>
-	 *   <li>{@code PRODUCTION_RECEIPT_NO_MHD} — creates PRODUCTION_RECEIPT + PRODUCTION_ISSUE traces
-	 *       without MHD (best-before) attribute on the HU. Tests Bug A fix (LEFT JOIN).</li>
-	 *   <li>{@code TRACED_ONE_OF_TWO_RECEIPTS} — creates two MATERIAL_RECEIPT traces of the same
-	 *       product/lot, with the shipped VHU descending from only the first receipt's VHU
-	 *       (a TRANSFORM_LOAD edge). Only that receipt is paired with the shipment; the other
-	 *       receipt of the lot is suppressed because the group already has a traced receipt.</li>
-	 *   <li>{@code LOT_DISAGREEMENT} — a receipt's VHU transforms (one TRANSFORM_LOAD edge) into
-	 *       the shipped VHU, but the shipment's own MATERIAL_SHIPMENT trace carries a different
-	 *       lot number than the receipt. Guards the lot-agreement half of the graph-tracing rule:
-	 *       a graph link alone must not be enough to call the pair traced, and such a pair is
-	 *       dropped outright rather than demoted to a product-level candidate.</li>
-	 *   <li>{@code SAME_VHU_NO_TRANSFORM} — one VHU carries both the MATERIAL_RECEIPT and the
-	 *       MATERIAL_SHIPMENT trace directly, with no TRANSFORM_LOAD edge at all (received and
-	 *       shipped without repacking). The depth-0 case a rule that only walks edges would miss.</li>
-	 *   <li>{@code TWO_STEP_TRANSFORM} — a receipt's VHU transforms into an intermediate VHU,
-	 *       which transforms again into the shipped VHU (two TRANSFORM_LOAD edges). The receipt
-	 *       document must still resolve to the original receipt, not the intermediate step.</li>
-	 *   <li>{@code MIXED_TRACED_AND_CANDIDATE} — two receipts and two shipments of one lot with no
-	 *       VHU link anywhere, plus a third shipment descending from the first receipt. Shows that
-	 *       candidate suppression is per (shipment, product, lot), not global across the lot: the
-	 *       graph-traced shipment is TRACED and never also a candidate, while the two unlinked
-	 *       shipments remain candidates for every receipt of the lot.</li>
-	 *   <li>{@code NO_LOT_NO_LINK} — a receipt and a shipment of one product, both with
-	 *       {@code lotnumber=NULL} and no VHU link. Labelled PRODUCT_CANDIDATE, distinct from
-	 *       {@code MIXED_TRACED_AND_CANDIDATE}'s LOT_CANDIDATE — there is no lot to agree on.</li>
-	 *   <li>{@code RECEIPT_QTY_AND_DEDUP} — one receipt document carrying two MATERIAL_RECEIPT
-	 *       traces of the same lot on different VHUs, with a shipment descending from the first of
-	 *       the two. The receipt document's total quantity across both VHUs must be reported once,
-	 *       not once per VHU.</li>
-	 *   <li>{@code INELIGIBLE_RECEIPT_DOC} — a shipment that descends from a receipt document this
-	 *       section may not report (an {@code MMR} whose doctype is {@code IsSOTrx='Y'}), plus a
-	 *       purchase receipt of the same lot with no VHU link. The graph link must not silence the
-	 *       lot-level candidate the report emits for such a group.</li>
+	 *   <li>{@code DIRECT_SALE_NULL_LOT} — NULL lots on both sides; Bug B fix (IS NOT DISTINCT FROM).</li>
+	 *   <li>{@code PRODUCTION_RECEIPT_NO_MHD} — no best-before attribute; Bug A fix (LEFT JOIN).</li>
+	 *   <li>{@code TRACED_ONE_OF_TWO_RECEIPTS} — one of two same-lot receipts is graph-traced.</li>
+	 *   <li>{@code LOT_DISAGREEMENT} — a graph-linked pair whose lots disagree; must be dropped.</li>
+	 *   <li>{@code SAME_VHU_NO_TRANSFORM} — receipt and shipment on the same VHU (depth 0).</li>
+	 *   <li>{@code TWO_STEP_TRANSFORM} — a two-edge TRANSFORM_LOAD chain.</li>
+	 *   <li>{@code MIXED_TRACED_AND_CANDIDATE} — candidate suppression is per group, not per lot.</li>
+	 *   <li>{@code NO_LOT_NO_LINK} — PRODUCT_CANDIDATE when neither side has a lot.</li>
+	 *   <li>{@code RECEIPT_QTY_AND_DEDUP} — one receipt document, two VHUs, reported once.</li>
+	 *   <li>{@code INELIGIBLE_RECEIPT_DOC} — graph-traced but an unreportable receipt doctype.</li>
 	 * </ul>
 	 */
 	@When("M_HU_Trace_Report test data is set up for scenario {string}:")
@@ -205,22 +181,12 @@ public class M_HU_Trace_Report_StepDef
 	 * Deletes any {@code M_HU_Trace} rows left over from a PREVIOUS run of this feature against
 	 * the same (persistent, not reset-between-runs) local stack.
 	 *
-	 * <p>Test products are upserted by {@code Value} ({@code M_Product_StepDef#createM_Product}
-	 * resolves via {@code retrieveProductByValue} before creating), so a re-run against a
-	 * persistent stack resolves to the SAME {@code M_Product_ID}. {@link #invokeReport} then
-	 * selects via {@code HUTraceEventQuery.builder().productId(productId).types(typesToReport())}
-	 * — scoped by product and trace type, with no lot/InOut/scenario/time filter — so every prior
-	 * run's trace rows for that product would still be picked up: the MATERIAL_RECEIPT and
-	 * MATERIAL_SHIPMENT ones directly, being reported types, and whatever else the recursion
-	 * reaches over their VHU links — of any trace type, since it rebuilds its queries without the
-	 * type filter. Both routes lead here, so the cleanup is required either way. Left unhandled, {@link #assertDetailRows}'s
-	 * {@code containsExactlyInAnyOrderElementsOf} (deliberately exhaustive — it is what catches
-	 * a wrongly-emitted extra row, see its javadoc) would keep failing with leftover rows whose
-	 * {@code DocumentNo}s can never match the current run's freshly generated ones, independent
-	 * of whether the section 6 pairing itself is correct. Deleting the row instead of
-	 * deleting-and-recreating the product itself avoids the FK from {@code M_HU_Trace.M_Product_ID}
-	 * (constraint {@code mproduct_mhutrace}, {@code ON DELETE NO ACTION}) blocking product deletion
-	 * while old trace rows still reference it.
+	 * <p>Products are upserted by {@code Value}, so a re-run resolves to the SAME
+	 * {@code M_Product_ID}, and {@link #invokeReport}'s query is scoped by product and trace type
+	 * only (no lot/InOut/scenario/time filter) — so leftover rows from a prior run would still be
+	 * picked up and break {@link #assertDetailRows}'s exhaustive comparison against freshly
+	 * generated {@code DocumentNo}s. Deletes the trace rows rather than the product itself because
+	 * {@code M_HU_Trace.M_Product_ID} has an {@code ON DELETE NO ACTION} FK that would block it.
 	 */
 	private void deleteExistingHuTraceRows(@NonNull final ProductId productId)
 	{
@@ -236,12 +202,10 @@ public class M_HU_Trace_Report_StepDef
 
 	/**
 	 * Invokes the {@code M_HU_Trace_Report(?)} SQL function for the product associated with the given
-	 * scenario and stores the returned {@code HUTraceType} section names (e.g. {@code PRODUCTION_RECEIPT_DETAL},
-	 * {@code DIRECT_SALE_DETAIL}) for later assertion.
+	 * scenario and stores the returned {@code HUTraceType} section names for later assertion.
 	 *
-	 * <p>Note: the SQL function has two different columns — {@code HUTraceType} (the section name)
-	 * and {@code detail_type} (the sub-record's trace type). We read {@code HUTraceType} because
-	 * the feature file assertions reference section names.
+	 * <p>Reads {@code HUTraceType} (the section name), not {@code detail_type} (the sub-record's
+	 * trace type) — the feature file assertions reference section names.
 	 */
 	@And("M_HU_Trace_Report is invoked for scenario {string}")
 	public void invokeReport(@NonNull final String scenarioName)
@@ -514,14 +478,13 @@ public class M_HU_Trace_Report_StepDef
 	}
 
 	/**
-	 * A receipt's VHU transforms (one TRANSFORM_LOAD edge) into the shipped VHU, but the
-	 * shipment's own MATERIAL_SHIPMENT trace carries a different lot number than the receipt.
-	 * Guards the lot-agreement half of the graph-tracing rule: a graph link alone must not be
-	 * enough to call the pair traced when the two ends disagree on lot.
+	 * A receipt's VHU transforms (one TRANSFORM_LOAD edge) into the shipped VHU, but the shipment's
+	 * own trace carries a different lot number. Guards the lot-agreement half of the graph-tracing
+	 * rule: a graph link alone must not be enough to call the pair traced when the ends disagree.
 	 *
-	 * <p>The rejected pair is dropped, not demoted: the candidate branch also requires lot
-	 * agreement, so nothing at all is emitted. A product-only fallback would pair every receipt of
-	 * the product with every shipment of it — a cartesian at product granularity.
+	 * <p>The rejected pair is dropped, not demoted — the candidate branch also requires lot
+	 * agreement, so nothing is emitted. A product-only fallback would cartesian every receipt of
+	 * the product against every shipment of it.
 	 */
 	private void setupLotDisagreement(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{
@@ -704,22 +667,17 @@ public class M_HU_Trace_Report_StepDef
 	}
 
 	/**
-	 * A shipment whose VHU descends from a receipt document that the DIRECT_SALE_DETAIL section is
-	 * not allowed to report, plus a purchase receipt of the same product and lot that has no VHU
-	 * link to anything.
+	 * A shipment whose VHU descends from a receipt document the DIRECT_SALE_DETAIL section may not
+	 * report, plus a purchase receipt of the same product and lot with no VHU link to anything.
 	 *
-	 * <p>What makes the first document ineligible is exactly one thing: its doctype is
-	 * {@code IsSOTrx='Y'}, while the section reports only {@code IsSOTrx='N'} receipts. It is
-	 * loaded as the first active {@code DocBaseType='MMR'} doctype with {@code IsSOTrx='Y'} by
-	 * {@code C_DocType_ID} — which document that is depends on the seed data (a customer return, a
-	 * balance correction, an empties return …), and the scenario does not depend on which.
+	 * <p>The first document is ineligible only because its doctype is {@code IsSOTrx='Y'} (the
+	 * section reports only {@code IsSOTrx='N'}); it is loaded as the first active
+	 * {@code DocBaseType='MMR'}/{@code IsSOTrx='Y'} doctype by {@code C_DocType_ID} — which one
+	 * that is depends on seed data, and the scenario doesn't depend on which.
 	 *
-	 * <p>The graph therefore says something about this shipment, but nothing the section may print.
-	 * The lot-level candidate resting on the purchase receipt is what the report emits for such a
-	 * group, and must keep emitting: deciding "this group has a traced receipt, so drop its
-	 * candidates" before
-	 * the receipt document has been checked for eligibility would leave the group with no row at
-	 * all, silently deleting information.
+	 * <p>The graph links the shipment to this ineligible receipt, but the section may not print it.
+	 * The lot-level candidate on the purchase receipt must still be emitted: checking "group already
+	 * has a traced receipt" before the receipt's eligibility would silently drop the group entirely.
 	 */
 	private void setupIneligibleReceiptDoc(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{
@@ -758,11 +716,9 @@ public class M_HU_Trace_Report_StepDef
 	/**
 	 * Loads the first active C_DocType with the given DocBaseType and IsSOTrx flag.
 	 *
-	 * <p>Filtering by IsSOTrx is critical because metasfresh has several doctypes per
-	 * DocBaseType — MMR alone has both inbound ones ({@code isSOTrx='N'}) and outbound ones
-	 * ({@code isSOTrx='Y'}), and which of the latter this returns depends on the seed data, since
-	 * it takes the lowest {@code C_DocType_ID}. Section 6 of M_HU_Trace_Report checks
-	 * {@code receipt_dt.isSOTrx = 'N'} and {@code shipment_dt.isSOTrx = 'Y'}.
+	 * <p>IsSOTrx filtering matters because metasfresh has several doctypes per DocBaseType — MMR
+	 * has both inbound ({@code isSOTrx='N'}) and outbound ({@code isSOTrx='Y'}) ones — and section 6
+	 * of M_HU_Trace_Report checks {@code receipt_dt.isSOTrx = 'N'} / {@code shipment_dt.isSOTrx = 'Y'}.
 	 *
 	 * @param docBaseType e.g. "MMR" (Material Receipt) or "MMS" (Material Shipment)
 	 * @param isSOTrx     true for sales transactions, false for purchase transactions
@@ -825,13 +781,8 @@ public class M_HU_Trace_Report_StepDef
 	/**
 	 * Creates a minimal M_InOut record with the given doctype and docstatus.
 	 *
-	 * <p>Only the fields required by the M_HU_Trace_Report SQL function are set.
-	 * Non-critical FK columns (C_BPartner_ID, etc.) use test defaults where possible.
-	 *
-	 * <p>Uses direct SQL to force DocStatus after saving because M_InOut model interceptors
-	 * enforce the DocAction workflow — setting DocStatus='CO' on the model object gets
-	 * overridden during save. Our test only needs the M_InOut as a FK reference for the
-	 * SQL function's JOIN conditions.
+	 * <p>Forces DocStatus via direct SQL after saving because M_InOut model interceptors enforce
+	 * the DocAction workflow and override a plain {@code DocStatus='CO'} set on the model during save.
 	 */
 	private I_M_InOut createMinimalInOut(
 			@NonNull final I_C_DocType docType,
@@ -849,10 +800,8 @@ public class M_HU_Trace_Report_StepDef
 		inOut.setMovementType(docType.isSOTrx() ? "C-" : "V+");
 		saveRecord(inOut);
 
-		// Force DocStatus, Processed, and C_DocType_ID via SQL — model validators enforce
-		// the DocAction workflow and may reset DocStatus and C_DocType_ID during save.
-		// Section 6 of M_HU_Trace_Report JOINs C_DocType and checks isSOTrx, so
-		// C_DocType_ID must match the intended document type.
+		// Model validators may reset DocStatus/C_DocType_ID during save; force them (and Processed)
+		// via SQL. Section 6 checks isSOTrx, so C_DocType_ID must match the intended doctype.
 		DB.executeUpdateAndThrowExceptionOnFail(
 				"UPDATE M_InOut SET DocStatus = ?, Processed = 'Y', C_DocType_ID = ? WHERE M_InOut_ID = ?",
 				new Object[] { docStatus, docType.getC_DocType_ID(), inOut.getM_InOut_ID() },
@@ -862,16 +811,12 @@ public class M_HU_Trace_Report_StepDef
 	}
 
 	/**
-	 * Creates a minimal PP_Order record in docstatus='CO' for use in PRODUCTION_RECEIPT traces.
+	 * Creates a minimal PP_Order record in docstatus='CO' for use in PRODUCTION_RECEIPT traces
+	 * (M_HU_Trace_Report requires {@code po.docstatus IN ('CO', 'CL')}).
 	 *
-	 * <p>The M_HU_Trace_Report SQL function requires:
-	 * <ul>
-	 *   <li>{@code po.docstatus IN ('CO', 'CL')}</li>
-	 * </ul>
-	 *
-	 * <p>Uses direct SQL because the PP_Order model validator requires PP_Product_BOM_ID &gt; 0,
-	 * but the SQL report function only needs PP_Order_ID for its JOIN condition.
-	 * Creating a full BOM hierarchy would be disproportionate to the test's purpose.
+	 * <p>Uses direct SQL because the PP_Order model validator requires {@code PP_Product_BOM_ID > 0},
+	 * while the report function only needs {@code PP_Order_ID} for its JOIN — a full BOM hierarchy
+	 * would be disproportionate to the test's purpose.
 	 */
 	private I_PP_Order createMinimalPpOrder(@NonNull final ProductId productId)
 	{
@@ -931,12 +876,7 @@ public class M_HU_Trace_Report_StepDef
 	/**
 	 * Creates a single M_HU_Trace record.
 	 *
-	 * @param vhu       the Virtual HU being traced (used for both VHU_ID and M_HU_ID)
-	 * @param productId the product
-	 * @param traceType the trace event type
-	 * @param lotNumber the lot number (may be null)
-	 * @param inOut     the linked M_InOut (may be null)
-	 * @param ppOrder   the linked PP_Order (may be null)
+	 * @param vhu the Virtual HU being traced (used for both VHU_ID and M_HU_ID)
 	 */
 	private I_M_HU_Trace createHuTrace(
 			@NonNull final I_M_HU vhu,

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -126,6 +126,9 @@ public class M_HU_Trace_Report_StepDef
 		final String testType = row.getAsString("TestType");
 		final ProductId productId = productTable.getId(row.getAsIdentifier("M_Product_ID"));
 
+		// see #deleteExistingHuTraceRows javadoc: makes the report selection see only THIS run's data
+		deleteExistingHuTraceRows(productId);
+
 		switch (testType)
 		{
 			case "DIRECT_SALE_NULL_LOT":
@@ -133,6 +136,7 @@ public class M_HU_Trace_Report_StepDef
 				break;
 			case "PRODUCTION_RECEIPT_NO_MHD":
 				final ProductId rawMaterialProductId = productTable.getId(row.getAsIdentifier("RawMaterial_ID"));
+				deleteExistingHuTraceRows(rawMaterialProductId);
 				setupProductionReceiptNoMhd(scenarioName, productId, rawMaterialProductId);
 				break;
 			case "TRACED_ONE_OF_TWO_RECEIPTS":
@@ -141,6 +145,33 @@ public class M_HU_Trace_Report_StepDef
 			default:
 				throw new AdempiereException("Unknown TestType: " + testType);
 		}
+	}
+
+	/**
+	 * Deletes any {@code M_HU_Trace} rows left over from a PREVIOUS run of this feature against
+	 * the same (persistent, not reset-between-runs) local stack.
+	 *
+	 * <p>Test products are upserted by {@code Value} ({@code M_Product_StepDef#createM_Product}
+	 * resolves via {@code retrieveProductByValue} before creating), so a re-run against a
+	 * persistent stack resolves to the SAME {@code M_Product_ID}. {@link #invokeReport} then
+	 * selects via {@code HUTraceEventQuery.builder().productId(productId)...} — scoped by
+	 * product ALONE, no lot/InOut/scenario/time filter — so every prior run's trace rows for
+	 * that product would still be picked up. Left unhandled, {@link #assertDetailRows}'s
+	 * {@code containsExactlyInAnyOrderElementsOf} (deliberately exhaustive — it is what catches
+	 * a wrongly-emitted extra row, see its javadoc) would keep failing with leftover rows whose
+	 * {@code DocumentNo}s can never match the current run's freshly generated ones, independent
+	 * of whether the section 6 pairing fix (Task 4) is correct. Deleting the row instead of
+	 * deleting-and-recreating the product itself avoids the FK from {@code M_HU_Trace.M_Product_ID}
+	 * (constraint {@code mproduct_mhutrace}, {@code ON DELETE NO ACTION}) blocking product deletion
+	 * while old trace rows still reference it.
+	 */
+	private void deleteExistingHuTraceRows(@NonNull final ProductId productId)
+	{
+		Services.get(IQueryBL.class)
+				.createQueryBuilder(I_M_HU_Trace.class)
+				.addEqualsFilter(I_M_HU_Trace.COLUMNNAME_M_Product_ID, productId.getRepoId())
+				.create()
+				.delete();
 	}
 
 	// =====================================================================================

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -122,7 +122,8 @@ public class M_HU_Trace_Report_StepDef
 	 *   <li>{@code LOT_DISAGREEMENT} — a receipt's VHU transforms (one TRANSFORM_LOAD edge) into
 	 *       the shipped VHU, but the shipment's own MATERIAL_SHIPMENT trace carries a different
 	 *       lot number than the receipt. Guards the lot-agreement half of the graph-tracing rule:
-	 *       a graph link alone must not be enough to call the pair traced.</li>
+	 *       a graph link alone must not be enough to call the pair traced, and such a pair is
+	 *       dropped outright rather than demoted to a product-level candidate.</li>
 	 *   <li>{@code SAME_VHU_NO_TRANSFORM} — one VHU carries both the MATERIAL_RECEIPT and the
 	 *       MATERIAL_SHIPMENT trace directly, with no TRANSFORM_LOAD edge at all (received and
 	 *       shipped without repacking). The depth-0 case a rule that only walks edges would miss.</li>
@@ -508,6 +509,10 @@ public class M_HU_Trace_Report_StepDef
 	 * shipment's own MATERIAL_SHIPMENT trace carries a different lot number than the receipt.
 	 * Guards the lot-agreement half of the graph-tracing rule: a graph link alone must not be
 	 * enough to call the pair traced when the two ends disagree on lot.
+	 *
+	 * <p>The rejected pair is dropped, not demoted: the candidate branch also requires lot
+	 * agreement, so nothing at all is emitted. A product-only fallback would pair every receipt of
+	 * the product with every shipment of it — the cartesian this whole section is being fixed for.
 	 */
 	private void setupLotDisagreement(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -143,9 +143,9 @@ public class M_HU_Trace_Report_StepDef
 	 *       the two. The receipt document's total quantity across both VHUs must be reported once,
 	 *       not once per VHU.</li>
 	 *   <li>{@code INELIGIBLE_RECEIPT_DOC} — a shipment that descends from a receipt document this
-	 *       section may not report (a customer return, {@code IsSOTrx='Y'}), plus a genuine purchase
-	 *       receipt of the same lot with no VHU link. The graph link must not silence the lot-level
-	 *       candidate that the customer sees today.</li>
+	 *       section may not report (an {@code MMR} whose doctype is {@code IsSOTrx='Y'}), plus a
+	 *       purchase receipt of the same lot with no VHU link. The graph link must not silence the
+	 *       lot-level candidate that the customer sees today.</li>
 	 * </ul>
 	 */
 	@When("M_HU_Trace_Report test data is set up for scenario {string}:")
@@ -709,9 +709,14 @@ public class M_HU_Trace_Report_StepDef
 
 	/**
 	 * A shipment whose VHU descends from a receipt document that the DIRECT_SALE_DETAIL section is
-	 * not allowed to report — a customer return ({@code DocBaseType='MMR'}, {@code IsSOTrx='Y'}),
-	 * where the section only reports purchase receipts ({@code IsSOTrx='N'}) — plus a genuine
-	 * purchase receipt of the same product and lot that has no VHU link to anything.
+	 * not allowed to report, plus a purchase receipt of the same product and lot that has no VHU
+	 * link to anything.
+	 *
+	 * <p>What makes the first document ineligible is exactly one thing: its doctype is
+	 * {@code IsSOTrx='Y'}, while the section reports only {@code IsSOTrx='N'} receipts. It is
+	 * loaded as the first active {@code DocBaseType='MMR'} doctype with {@code IsSOTrx='Y'} by
+	 * {@code C_DocType_ID} — which document that is depends on the seed data (a customer return, a
+	 * balance correction, an empties return …), and the scenario does not depend on which.
 	 *
 	 * <p>The graph therefore says something about this shipment, but nothing the section may print.
 	 * The lot-level candidate resting on the purchase receipt is what the customer sees today and
@@ -723,17 +728,17 @@ public class M_HU_Trace_Report_StepDef
 	{
 		scenarioProductIds.put(scenarioName, productId);
 		final I_C_DocType purchaseReceiptDocType = loadDocType("MMR", false);
-		final I_C_DocType customerReturnDocType = loadDocType("MMR", true);
+		final I_C_DocType outboundReceiptDocType = loadDocType("MMR", true);
 		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
 
 		// the receipt document this section may not report, and the shipment that descends from it
-		final I_M_HU returnVhu = createVhu();
-		final I_M_InOut returnInOut = createMinimalInOut(customerReturnDocType, "CO");
-		createHuTraceWithSource(returnVhu, null, productId, HUTraceType.MATERIAL_RECEIPT,
-				"LOT-INELIGIBLE", returnInOut, new BigDecimal("100"));
+		final I_M_HU ineligibleVhu = createVhu();
+		final I_M_InOut ineligibleInOut = createMinimalInOut(outboundReceiptDocType, "CO");
+		createHuTraceWithSource(ineligibleVhu, null, productId, HUTraceType.MATERIAL_RECEIPT,
+				"LOT-INELIGIBLE", ineligibleInOut, new BigDecimal("100"));
 
 		final I_M_HU shippedVhu = createVhu();
-		createHuTraceWithSource(shippedVhu, returnVhu, productId, HUTraceType.TRANSFORM_LOAD,
+		createHuTraceWithSource(shippedVhu, ineligibleVhu, productId, HUTraceType.TRANSFORM_LOAD,
 				"LOT-INELIGIBLE", null, new BigDecimal("24"));
 		final I_M_InOut shipmentInOut = createMinimalInOut(shipmentDocType, "CO");
 		createHuTraceWithSource(shippedVhu, null, productId, HUTraceType.MATERIAL_SHIPMENT,
@@ -746,7 +751,7 @@ public class M_HU_Trace_Report_StepDef
 				"LOT-INELIGIBLE", purchaseInOut, new BigDecimal("80"));
 
 		scenarioDocNos.put(scenarioName + ".receipt1", purchaseInOut.getDocumentNo());
-		scenarioDocNos.put(scenarioName + ".returnReceipt", returnInOut.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".ineligibleReceipt", ineligibleInOut.getDocumentNo());
 		scenarioDocNos.put(scenarioName + ".shipment", shipmentInOut.getDocumentNo());
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -159,16 +159,18 @@ public class M_HU_Trace_Report_StepDef
 
 		// see #deleteExistingHuTraceRows javadoc: makes the report selection see only THIS run's data
 		deleteExistingHuTraceRows(productId);
+		// the product all ten setups below build their traces for; #invokeReport reads it back
+		scenarioProductIds.put(scenarioName, productId);
 
 		switch (testType)
 		{
 			case "DIRECT_SALE_NULL_LOT":
-				setupDirectSaleNullLot(scenarioName, productId);
+				setupDirectSaleNullLot(productId);
 				break;
 			case "PRODUCTION_RECEIPT_NO_MHD":
 				final ProductId rawMaterialProductId = productTable.getId(row.getAsIdentifier("RawMaterial_ID"));
 				deleteExistingHuTraceRows(rawMaterialProductId);
-				setupProductionReceiptNoMhd(scenarioName, productId, rawMaterialProductId);
+				setupProductionReceiptNoMhd(productId, rawMaterialProductId);
 				break;
 			case "TRACED_ONE_OF_TWO_RECEIPTS":
 				setupTracedOneOfTwoReceipts(scenarioName, productId);
@@ -393,10 +395,8 @@ public class M_HU_Trace_Report_StepDef
 	 * <p>Historically this was a plain {@code =}: NULL=NULL evaluated to false, the shipment side
 	 * was never found, and the INNER JOIN on M_Product eliminated the row entirely.
 	 */
-	private void setupDirectSaleNullLot(@NonNull final String scenarioName, @NonNull final ProductId productId)
+	private void setupDirectSaleNullLot(@NonNull final ProductId productId)
 	{
-		scenarioProductIds.put(scenarioName, productId);
-
 		// Load standard C_DocTypes (receipt = isSOTrx='N', shipment = isSOTrx='Y')
 		final I_C_DocType receiptDocType = loadDocType("MMR", false);
 		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
@@ -446,12 +446,9 @@ public class M_HU_Trace_Report_StepDef
 	 * After the fix (LEFT JOIN), they appear with {@code finished_product_mhd=NULL}.
 	 */
 	private void setupProductionReceiptNoMhd(
-			@NonNull final String scenarioName,
 			@NonNull final ProductId finishedProductId,
 			@NonNull final ProductId rawMaterialProductId)
 	{
-		scenarioProductIds.put(scenarioName, finishedProductId);
-
 		// Create a PP_Order (docstatus='CO') — links receipt and issue traces
 		final I_PP_Order ppOrder = createMinimalPpOrder(finishedProductId);
 
@@ -489,7 +486,6 @@ public class M_HU_Trace_Report_StepDef
 	 */
 	private void setupTracedOneOfTwoReceipts(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{
-		scenarioProductIds.put(scenarioName, productId);
 		final I_C_DocType receiptDocType = loadDocType("MMR", false);
 		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
 
@@ -529,7 +525,6 @@ public class M_HU_Trace_Report_StepDef
 	 */
 	private void setupLotDisagreement(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{
-		scenarioProductIds.put(scenarioName, productId);
 		final I_C_DocType receiptDocType = loadDocType("MMR", false);
 		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
 
@@ -558,7 +553,6 @@ public class M_HU_Trace_Report_StepDef
 	 */
 	private void setupSameVhuNoTransform(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{
-		scenarioProductIds.put(scenarioName, productId);
 		final I_C_DocType receiptDocType = loadDocType("MMR", false);
 		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
 
@@ -582,7 +576,6 @@ public class M_HU_Trace_Report_StepDef
 	 */
 	private void setupTwoStepTransform(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{
-		scenarioProductIds.put(scenarioName, productId);
 		final I_C_DocType receiptDocType = loadDocType("MMR", false);
 		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
 
@@ -615,7 +608,6 @@ public class M_HU_Trace_Report_StepDef
 	 */
 	private void setupMixedTracedAndCandidate(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{
-		scenarioProductIds.put(scenarioName, productId);
 		final I_C_DocType receiptDocType = loadDocType("MMR", false);
 		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
 
@@ -664,7 +656,6 @@ public class M_HU_Trace_Report_StepDef
 	 */
 	private void setupNoLotNoLink(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{
-		scenarioProductIds.put(scenarioName, productId);
 		final I_C_DocType receiptDocType = loadDocType("MMR", false);
 		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
 
@@ -689,7 +680,6 @@ public class M_HU_Trace_Report_StepDef
 	 */
 	private void setupReceiptQtyAndDedup(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{
-		scenarioProductIds.put(scenarioName, productId);
 		final I_C_DocType receiptDocType = loadDocType("MMR", false);
 		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
 
@@ -732,7 +722,6 @@ public class M_HU_Trace_Report_StepDef
 	 */
 	private void setupIneligibleReceiptDoc(@NonNull final String scenarioName, @NonNull final ProductId productId)
 	{
-		scenarioProductIds.put(scenarioName, productId);
 		final I_C_DocType purchaseReceiptDocType = loadDocType("MMR", false);
 		final I_C_DocType outboundReceiptDocType = loadDocType("MMR", true);
 		final I_C_DocType shipmentDocType = loadDocType("MMS", true);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Trace_Report_StepDef.java
@@ -43,6 +43,7 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
@@ -55,6 +56,7 @@ import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.eevolution.model.I_PP_Order;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -91,6 +93,9 @@ public class M_HU_Trace_Report_StepDef
 	/** Maps scenario name → list of HUTraceType (section name) values returned by the report */
 	private final Map<String, List<String>> reportResultsByScenario = new HashMap<>();
 
+	/** Maps scenario name → list of DIRECT_SALE_DETAIL rows returned by the report */
+	private final Map<String, List<DetailRow>> detailRowsByScenario = new HashMap<>();
+
 	// =====================================================================================
 	// Setup steps
 	// =====================================================================================
@@ -104,6 +109,10 @@ public class M_HU_Trace_Report_StepDef
 	 *       with {@code lotnumber=NULL}. Tests Bug B fix (IS NOT DISTINCT FROM).</li>
 	 *   <li>{@code PRODUCTION_RECEIPT_NO_MHD} — creates PRODUCTION_RECEIPT + PRODUCTION_ISSUE traces
 	 *       without MHD (best-before) attribute on the HU. Tests Bug A fix (LEFT JOIN).</li>
+	 *   <li>{@code TRACED_ONE_OF_TWO_RECEIPTS} — creates two MATERIAL_RECEIPT traces of the same
+	 *       product/lot, with the shipped VHU descending from only the first receipt's VHU
+	 *       (a TRANSFORM_LOAD edge). Exposes the DIRECT_SALE_DETAIL cartesian: today's section 6
+	 *       pairs the shipment with BOTH receipts because it matches on lot+product alone.</li>
 	 * </ul>
 	 */
 	@When("M_HU_Trace_Report test data is set up for scenario {string}:")
@@ -121,6 +130,9 @@ public class M_HU_Trace_Report_StepDef
 			case "PRODUCTION_RECEIPT_NO_MHD":
 				final ProductId rawMaterialProductId = productTable.getId(row.getAsIdentifier("RawMaterial_ID"));
 				setupProductionReceiptNoMhd(scenarioName, productId, rawMaterialProductId);
+				break;
+			case "TRACED_ONE_OF_TWO_RECEIPTS":
+				setupTracedOneOfTwoReceipts(scenarioName, productId);
 				break;
 			default:
 				throw new AdempiereException("Unknown TestType: " + testType);
@@ -178,6 +190,34 @@ public class M_HU_Trace_Report_StepDef
 		}
 
 		reportResultsByScenario.put(scenarioName, ImmutableList.copyOf(detailTypes));
+
+		final List<DetailRow> detailRows = new ArrayList<>();
+		final String detailSql = "SELECT \"InOut\" AS receipt_docno, shipment_note AS shipment_docno,"
+				+ " link_basis, qty AS menge, shipmentqty AS liefermenge"
+				+ " FROM M_HU_Trace_Report(?)"
+				+ " WHERE hutracetype = 'DIRECT_SALE_DETAIL'";
+		try (final PreparedStatement pstmt = DB.prepareStatement(detailSql, ITrx.TRXNAME_None))
+		{
+			pstmt.setInt(1, pInstanceId.getRepoId());
+			try (final ResultSet rs = pstmt.executeQuery())
+			{
+				while (rs.next())
+				{
+					detailRows.add(new DetailRow(
+							rs.getString("receipt_docno"),
+							rs.getString("shipment_docno"),
+							rs.getString("link_basis"),
+							rs.getBigDecimal("menge"),
+							rs.getBigDecimal("liefermenge")));
+				}
+			}
+		}
+		catch (final SQLException e)
+		{
+			throw AdempiereException.wrapIfNeeded(e);
+		}
+
+		detailRowsByScenario.put(scenarioName, ImmutableList.copyOf(detailRows));
 	}
 
 	/**
@@ -194,12 +234,54 @@ public class M_HU_Trace_Report_StepDef
 				.contains(expectedDetailType);
 	}
 
+	/**
+	 * Asserts the exact set of {@code DIRECT_SALE_DETAIL} rows returned for the given scenario —
+	 * row-level, unlike {@link #assertDetailTypePresent}. {@code containsExactlyInAnyOrderElementsOf}
+	 * is deliberate: it fails on a missing row AND on an extra one, which is what catches a cartesian
+	 * (e.g. a shipment paired with more than one receipt of the same lot).
+	 *
+	 * <p>DataTable columns: {@code ReceiptDocNo | ShipmentDocNo | LinkBasis | Menge | Liefermenge}.
+	 * {@code ReceiptDocNo}/{@code ShipmentDocNo} are identifiers (e.g. {@code receipt1}, {@code shipment})
+	 * registered by the scenario's setup step in {@link #scenarioDocNos} — resolved to the DB-generated
+	 * DocumentNo here.
+	 */
+	@Then("M_HU_Trace_Report detail rows for scenario {string} are:")
+	public void assertDetailRows(@NonNull final String scenarioName, @NonNull final DataTable dataTable)
+	{
+		final List<DetailRow> actual = detailRowsByScenario.get(scenarioName);
+		assertThat(actual).as("no report result stored for scenario '%s'", scenarioName).isNotNull();
+
+		final List<DetailRow> expected = DataTableRows.of(dataTable).stream()
+				.map(row -> new DetailRow(
+						resolveDocNo(scenarioName, row.getAsString("ReceiptDocNo")),
+						resolveDocNo(scenarioName, row.getAsString("ShipmentDocNo")),
+						row.getAsString("LinkBasis"),
+						row.getAsBigDecimal("Menge"),
+						row.getAsBigDecimal("Liefermenge")))
+				.collect(ImmutableList.toImmutableList());
+
+		assertThat(actual)
+				.as("DIRECT_SALE_DETAIL rows for scenario '%s'", scenarioName)
+				.containsExactlyInAnyOrderElementsOf(expected);
+	}
+
+	/** Feature files name documents by identifier; the DB generates the numbers. */
+	private String resolveDocNo(@NonNull final String scenarioName, @NonNull final String identifier)
+	{
+		final String docNo = scenarioDocNos.get(scenarioName + "." + identifier);
+		assertThat(docNo).as("unknown document identifier '%s' in scenario '%s'", identifier, scenarioName).isNotNull();
+		return docNo;
+	}
+
 	// =====================================================================================
 	// Private state: scenario → product mapping
 	// =====================================================================================
 
 	/** Maps scenario name → product ID (for invoking the report) */
 	private final Map<String, ProductId> scenarioProductIds = new HashMap<>();
+
+	/** Maps {@code scenarioName + "." + identifier} (e.g. {@code "traced_one_of_two.receipt1"}) → generated DocumentNo */
+	private final Map<String, String> scenarioDocNos = new HashMap<>();
 
 	// =====================================================================================
 	// Private setup helpers
@@ -305,6 +387,43 @@ public class M_HU_Trace_Report_StepDef
 				"LOT-BUG-A",
 				null /*inOut*/,
 				ppOrder);
+	}
+
+	/**
+	 * TC1 test setup: two receipts of the same product and lot; the shipment's VHU descends from
+	 * the FIRST receipt's VHU through one TRANSFORM_LOAD edge. The second receipt is connected to
+	 * nothing — today's DIRECT_SALE_DETAIL section pairs it with the shipment anyway (lot+product
+	 * match alone), producing a two-row cartesian where exactly one row (linked to receipt1) is
+	 * correct.
+	 */
+	private void setupTracedOneOfTwoReceipts(@NonNull final String scenarioName, @NonNull final ProductId productId)
+	{
+		scenarioProductIds.put(scenarioName, productId);
+		final I_C_DocType receiptDocType = loadDocType("MMR", false);
+		final I_C_DocType shipmentDocType = loadDocType("MMS", true);
+
+		final I_M_HU receiptVhu1 = createVhu();
+		final I_M_InOut receiptInOut1 = createMinimalInOut(receiptDocType, "CO");
+		createHuTraceWithSource(receiptVhu1, null, productId, HUTraceType.MATERIAL_RECEIPT,
+				"LOT-TC1", receiptInOut1, new BigDecimal("100"));
+
+		// a second receipt of the SAME lot, connected to nothing — today's function pairs it anyway
+		final I_M_HU receiptVhu2 = createVhu();
+		final I_M_InOut receiptInOut2 = createMinimalInOut(receiptDocType, "CO");
+		createHuTraceWithSource(receiptVhu2, null, productId, HUTraceType.MATERIAL_RECEIPT,
+				"LOT-TC1", receiptInOut2, new BigDecimal("100"));
+
+		// the shipped VHU descends from receipt 1
+		final I_M_HU shippedVhu = createVhu();
+		createHuTraceWithSource(shippedVhu, receiptVhu1, productId, HUTraceType.TRANSFORM_LOAD,
+				"LOT-TC1", null, new BigDecimal("24"));
+		final I_M_InOut shipmentInOut = createMinimalInOut(shipmentDocType, "CO");
+		createHuTraceWithSource(shippedVhu, null, productId, HUTraceType.MATERIAL_SHIPMENT,
+				"LOT-TC1", shipmentInOut, new BigDecimal("-24"));
+
+		scenarioDocNos.put(scenarioName + ".receipt1", receiptInOut1.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".receipt2", receiptInOut2.getDocumentNo());
+		scenarioDocNos.put(scenarioName + ".shipment", shipmentInOut.getDocumentNo());
 	}
 
 	// =====================================================================================
@@ -525,5 +644,48 @@ public class M_HU_Trace_Report_StepDef
 			trace.setPP_Order_ID(ppOrder.getPP_Order_ID());
 		}
 		saveRecord(trace);
+	}
+
+	/** Creates an M_HU_Trace row that also records where its VHU came from (a TRANSFORM_LOAD edge). */
+	private I_M_HU_Trace createHuTraceWithSource(
+			@NonNull final I_M_HU vhu,
+			@Nullable final I_M_HU sourceVhu,
+			@NonNull final ProductId productId,
+			@NonNull final HUTraceType type,
+			@Nullable final String lotNumber,
+			@Nullable final I_M_InOut inOut,
+			@NonNull final BigDecimal qty)
+	{
+		final I_M_HU_Trace trace = newInstance(I_M_HU_Trace.class);
+		trace.setVHU_ID(vhu.getM_HU_ID());
+		trace.setM_HU_ID(vhu.getM_HU_ID());
+		if (sourceVhu != null)
+		{
+			trace.setVHU_Source_ID(sourceVhu.getM_HU_ID());
+		}
+		trace.setM_Product_ID(productId.getRepoId());
+		trace.setHUTraceType(type.getCode());
+		trace.setLotNumber(lotNumber);
+		trace.setQty(qty);
+		trace.setC_UOM_ID(StepDefConstants.PCE_UOM_ID.getRepoId());
+		trace.setEventTime(Timestamp.from(Instant.now()));
+		trace.setVHUStatus("A");
+		if (inOut != null)
+		{
+			trace.setM_InOut_ID(inOut.getM_InOut_ID());
+		}
+		saveRecord(trace);
+		return trace;
+	}
+
+	/** One DIRECT_SALE_DETAIL row, reduced to the fields the scenarios assert. */
+	@Value
+	private static class DetailRow
+	{
+		String receiptDocNo;
+		String shipmentDocNo;
+		String linkBasis;
+		BigDecimal menge;
+		BigDecimal liefermenge;
 	}
 }

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
@@ -97,3 +97,46 @@ Feature: HU Traceability Report — SQL correctness tests
     Then M_HU_Trace_Report detail rows for scenario "two_step_transform" are:
       | ReceiptDocNo | ShipmentDocNo | LinkBasis | Menge | Liefermenge |
       | receipt1     | shipment      | TRACED    | 100   | 24          |
+
+  @Id:S0000.1_HUTrace_TC4
+  Scenario: Candidate suppression applies per shipment, not globally across the lot
+    Given metasfresh contains M_Products:
+      | Identifier          | Value                  | Name                 |
+      | traceProduct_mixed  | traceProductVal_mixed  | Trace Product Mixed  |
+    When M_HU_Trace_Report test data is set up for scenario "mixed_traced_and_candidate":
+      | TestType                    | M_Product_ID.Identifier |
+      | MIXED_TRACED_AND_CANDIDATE  | traceProduct_mixed      |
+    And M_HU_Trace_Report is invoked for scenario "mixed_traced_and_candidate"
+    Then M_HU_Trace_Report detail rows for scenario "mixed_traced_and_candidate" are:
+      | ReceiptDocNo | ShipmentDocNo | LinkBasis     | Menge | Liefermenge |
+      | receipt1     | shipmentA     | LOT_CANDIDATE | 100   | 30          |
+      | receipt2     | shipmentA     | LOT_CANDIDATE | 50    | 30          |
+      | receipt1     | shipmentB     | LOT_CANDIDATE | 100   | 20          |
+      | receipt2     | shipmentB     | LOT_CANDIDATE | 50    | 20          |
+      | receipt1     | shipment3     | TRACED        | 100   | 24          |
+
+  @Id:S0000.1_HUTrace_TC5
+  Scenario: A receipt and shipment with neither a lot number nor a VHU link are a product-level candidate
+    Given metasfresh contains M_Products:
+      | Identifier              | Value                       | Name                       |
+      | traceProduct_noLotLink  | traceProductVal_noLotLink   | Trace Product No Lot Link  |
+    When M_HU_Trace_Report test data is set up for scenario "no_lot_no_link":
+      | TestType        | M_Product_ID.Identifier |
+      | NO_LOT_NO_LINK  | traceProduct_noLotLink  |
+    And M_HU_Trace_Report is invoked for scenario "no_lot_no_link"
+    Then M_HU_Trace_Report detail rows for scenario "no_lot_no_link" are:
+      | ReceiptDocNo | ShipmentDocNo | LinkBasis          | Menge | Liefermenge |
+      | receipt1     | shipment      | PRODUCT_CANDIDATE  | 100   | 24          |
+
+  @Id:S0000.1_HUTrace_TC6
+  Scenario: A receipt document's quantity across several VHUs is reported once, not once per VHU
+    Given metasfresh contains M_Products:
+      | Identifier             | Value                      | Name                     |
+      | traceProduct_qtyDedup  | traceProductVal_qtyDedup   | Trace Product Qty Dedup  |
+    When M_HU_Trace_Report test data is set up for scenario "receipt_qty_and_dedup":
+      | TestType               | M_Product_ID.Identifier |
+      | RECEIPT_QTY_AND_DEDUP  | traceProduct_qtyDedup   |
+    And M_HU_Trace_Report is invoked for scenario "receipt_qty_and_dedup"
+    Then M_HU_Trace_Report detail rows for scenario "receipt_qty_and_dedup" are:
+      | ReceiptDocNo | ShipmentDocNo | LinkBasis | Menge | Liefermenge |
+      | receipt1     | shipment      | TRACED    | 100   | 24          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
@@ -4,10 +4,13 @@
 @F5000
 @ghActions:run_on_executor5
 Feature: HU Traceability Report — SQL correctness tests
-  Verifies that the M_HU_Trace_Report SQL function returns the correct rows
-  for the two bug fixes:
+  Verifies that the M_HU_Trace_Report SQL function returns the correct rows,
+  covering two previously-fixed SQL bugs plus the receipt-to-shipment pairing
+  behaviour of the DIRECT_SALE_DETAIL section:
   - Bug A (Section 5): PRODUCTION_RECEIPT_DETAL appears even when the PRODUCTION_ISSUE HU has no MHD attribute
   - Bug B (Section 6): DIRECT_SALE_DETAIL appears for products with NULL lot number
+  - DIRECT_SALE_DETAIL pairing (Section 6): a shipment must be paired with the receipt(s) it is
+    actually traceable to, not with every receipt that merely shares the same lot and product
 
   Background:
     Given infrastructure and metasfresh are running

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
@@ -65,8 +65,8 @@ Feature: HU Traceability Report — SQL correctness tests
     # Decided semantics: a pair the lot-agreement guard rejects is DROPPED, not demoted to a
     # product-level candidate. PRODUCT_CANDIDATE means "neither side carries a lot number";
     # falling back to product equality whenever two lots disagree would re-open the cartesian at
-    # product granularity, which is the defect being fixed. The empty table below asserts the
-    # outcome exhaustively — no traced row and no candidate row.
+    # product granularity — the very failure these pairing rules exist to prevent. The empty table
+    # below asserts the outcome exhaustively — no traced row and no candidate row.
     Given metasfresh contains M_Products:
       | Identifier                | Value                        | Name                         |
       | traceProduct_lotMismatch  | traceProductVal_lotMismatch  | Trace Product Lot Mismatch   |
@@ -133,7 +133,7 @@ Feature: HU Traceability Report — SQL correctness tests
       | ReceiptDocNo | ShipmentDocNo | LinkBasis          | Menge | Liefermenge |
       | receipt1     | shipment      | PRODUCT_CANDIDATE  | 100   | 24          |
 
-  @Id:S0000.1_HUTrace_IneligibleReceiptDoc
+  @Id:S0000.1_HUTrace_TC7
   Scenario: A graph link to a receipt document this section may not report does not silence the lot candidate
     # The shipment descends from a receipt document whose doctype is IsSOTrx='Y', which this section
     # may not report — it reports only IsSOTrx='N' purchase receipts. Deciding "this group is traced,

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
@@ -61,7 +61,12 @@ Feature: HU Traceability Report — SQL correctness tests
       | receipt1     | shipment      | TRACED    | 100   | 24          |
 
   @Id:S0000.1_HUTrace_TC0
-  Scenario: A graph-traced receipt whose lot disagrees with the shipment's is not reported as traced
+  Scenario: A graph-connected pair whose lot numbers disagree yields no detail row at all
+    # Decided semantics: a pair the lot-agreement guard rejects is DROPPED, not demoted to a
+    # product-level candidate. PRODUCT_CANDIDATE means "neither side carries a lot number";
+    # falling back to product equality whenever two lots disagree would re-open the cartesian at
+    # product granularity, which is the defect being fixed. The empty table below asserts the
+    # outcome exhaustively — no traced row and no candidate row.
     Given metasfresh contains M_Products:
       | Identifier                | Value                        | Name                         |
       | traceProduct_lotMismatch  | traceProductVal_lotMismatch  | Trace Product Lot Mismatch   |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
@@ -10,7 +10,9 @@ Feature: HU Traceability Report — SQL correctness tests
   - Bug A (Section 5): PRODUCTION_RECEIPT_DETAL appears even when the PRODUCTION_ISSUE HU has no MHD attribute
   - Bug B (Section 6): DIRECT_SALE_DETAIL appears for products with NULL lot number
   - DIRECT_SALE_DETAIL pairing (Section 6): a shipment must be paired with the receipt(s) it is
-    actually traceable to, not with every receipt that merely shares the same lot and product
+    actually traceable to, not with every receipt that merely shares the same lot and product.
+    Tracing follows the M_HU_Trace graph — same VHU, or a chain of VHU_Source_ID edges — and is
+    guarded by lot agreement between the receipt and the shipment.
 
   Background:
     Given infrastructure and metasfresh are running
@@ -55,5 +57,43 @@ Feature: HU Traceability Report — SQL correctness tests
       | TRACED_ONE_OF_TWO_RECEIPTS | traceProduct_1          |
     And M_HU_Trace_Report is invoked for scenario "traced_one_of_two"
     Then M_HU_Trace_Report detail rows for scenario "traced_one_of_two" are:
+      | ReceiptDocNo | ShipmentDocNo | LinkBasis | Menge | Liefermenge |
+      | receipt1     | shipment      | TRACED    | 100   | 24          |
+
+  @Id:S0000.1_HUTrace_TC0
+  Scenario: A graph-traced receipt whose lot disagrees with the shipment's is not reported as traced
+    Given metasfresh contains M_Products:
+      | Identifier                | Value                        | Name                         |
+      | traceProduct_lotMismatch  | traceProductVal_lotMismatch  | Trace Product Lot Mismatch   |
+    When M_HU_Trace_Report test data is set up for scenario "lot_disagreement":
+      | TestType         | M_Product_ID.Identifier  |
+      | LOT_DISAGREEMENT | traceProduct_lotMismatch |
+    And M_HU_Trace_Report is invoked for scenario "lot_disagreement"
+    Then M_HU_Trace_Report detail rows for scenario "lot_disagreement" are:
+      | ReceiptDocNo | ShipmentDocNo | LinkBasis | Menge | Liefermenge |
+
+  @Id:S0000.1_HUTrace_TC2
+  Scenario: A receipt and shipment sharing the same VHU are traced without any transform edge
+    Given metasfresh contains M_Products:
+      | Identifier            | Value                    | Name                     |
+      | traceProduct_sameVhu  | traceProductVal_sameVhu  | Trace Product Same VHU   |
+    When M_HU_Trace_Report test data is set up for scenario "same_vhu_no_transform":
+      | TestType               | M_Product_ID.Identifier |
+      | SAME_VHU_NO_TRANSFORM  | traceProduct_sameVhu    |
+    And M_HU_Trace_Report is invoked for scenario "same_vhu_no_transform"
+    Then M_HU_Trace_Report detail rows for scenario "same_vhu_no_transform" are:
+      | ReceiptDocNo | ShipmentDocNo | LinkBasis | Menge | Liefermenge |
+      | receipt1     | shipment      | TRACED    | 100   | 24          |
+
+  @Id:S0000.1_HUTrace_TC3
+  Scenario: A multi-step VHU transformation chain still traces to the original receipt
+    Given metasfresh contains M_Products:
+      | Identifier                | Value                     | Name                          |
+      | traceProduct_twoStepChain | traceProductVal_twoStep   | Trace Product Two Step Chain  |
+    When M_HU_Trace_Report test data is set up for scenario "two_step_transform":
+      | TestType            | M_Product_ID.Identifier   |
+      | TWO_STEP_TRANSFORM  | traceProduct_twoStepChain |
+    And M_HU_Trace_Report is invoked for scenario "two_step_transform"
+    Then M_HU_Trace_Report detail rows for scenario "two_step_transform" are:
       | ReceiptDocNo | ShipmentDocNo | LinkBasis | Menge | Liefermenge |
       | receipt1     | shipment      | TRACED    | 100   | 24          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
@@ -41,3 +41,16 @@ Feature: HU Traceability Report — SQL correctness tests
       | PRODUCTION_RECEIPT_NO_MHD     | finishedProduct_BugA    | rawMaterial_BugA          |
     And M_HU_Trace_Report is invoked for scenario "production_receipt_no_mhd"
     Then M_HU_Trace_Report result for scenario "production_receipt_no_mhd" contains detail_type row "PRODUCTION_RECEIPT_DETAL"
+
+  @Id:S0000.1_HUTrace_TC1
+  Scenario: A graph-traced receipt suppresses the other receipts of the same lot (TC1)
+    Given metasfresh contains M_Products:
+      | Identifier     | Value             | Name            |
+      | traceProduct_1 | traceProductVal_1 | Trace Product 1 |
+    When M_HU_Trace_Report test data is set up for scenario "traced_one_of_two":
+      | TestType                   | M_Product_ID.Identifier |
+      | TRACED_ONE_OF_TWO_RECEIPTS | traceProduct_1          |
+    And M_HU_Trace_Report is invoked for scenario "traced_one_of_two"
+    Then M_HU_Trace_Report detail rows for scenario "traced_one_of_two" are:
+      | ReceiptDocNo | ShipmentDocNo | LinkBasis | Menge | Liefermenge |
+      | receipt1     | shipment      | TRACED    | 100   | 24          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
@@ -138,7 +138,7 @@ Feature: HU Traceability Report — SQL correctness tests
     # The shipment descends from a receipt document whose doctype is IsSOTrx='Y', which this section
     # may not report — it reports only IsSOTrx='N' purchase receipts. Deciding "this group is traced,
     # so drop its candidates" before the receipt document's eligibility has been checked would leave
-    # the group with no row at all — deleting the lot-level candidate the customer sees today.
+    # the group with no row at all — deleting the lot-level candidate the report emits for such a group.
     Given metasfresh contains M_Products:
       | Identifier                 | Value                          | Name                            |
       | traceProduct_ineligibleDoc | traceProductVal_ineligibleDoc  | Trace Product Ineligible Doc    |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
@@ -46,7 +46,7 @@ Feature: HU Traceability Report — SQL correctness tests
     Then M_HU_Trace_Report result for scenario "production_receipt_no_mhd" contains detail_type row "PRODUCTION_RECEIPT_DETAL"
 
   @Id:S0000.1_HUTrace_TC1
-  Scenario: A graph-traced receipt suppresses the other receipts of the same lot (TC1)
+  Scenario: A graph-traced receipt suppresses the other receipts of the same lot
     Given metasfresh contains M_Products:
       | Identifier     | Value             | Name            |
       | traceProduct_1 | traceProductVal_1 | Trace Product 1 |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
@@ -133,6 +133,23 @@ Feature: HU Traceability Report — SQL correctness tests
       | ReceiptDocNo | ShipmentDocNo | LinkBasis          | Menge | Liefermenge |
       | receipt1     | shipment      | PRODUCT_CANDIDATE  | 100   | 24          |
 
+  @Id:S0000.1_HUTrace_IneligibleReceiptDoc
+  Scenario: A graph link to a receipt document this section may not report does not silence the lot candidate
+    # The shipment descends from a customer-return receipt (IsSOTrx='Y'), which the DIRECT_SALE_DETAIL
+    # section only reports for purchase receipts (IsSOTrx='N'). Deciding "this group is traced, so drop
+    # its candidates" before the receipt document's eligibility has been checked would leave the group
+    # with no row at all — deleting the lot-level candidate the customer sees today.
+    Given metasfresh contains M_Products:
+      | Identifier                 | Value                          | Name                            |
+      | traceProduct_ineligibleDoc | traceProductVal_ineligibleDoc  | Trace Product Ineligible Doc    |
+    When M_HU_Trace_Report test data is set up for scenario "ineligible_receipt_doc":
+      | TestType               | M_Product_ID.Identifier    |
+      | INELIGIBLE_RECEIPT_DOC | traceProduct_ineligibleDoc |
+    And M_HU_Trace_Report is invoked for scenario "ineligible_receipt_doc"
+    Then M_HU_Trace_Report detail rows for scenario "ineligible_receipt_doc" are:
+      | ReceiptDocNo | ShipmentDocNo | LinkBasis     | Menge | Liefermenge |
+      | receipt1     | shipment      | LOT_CANDIDATE | 80    | 24          |
+
   @Id:S0000.1_HUTrace_TC6
   Scenario: A receipt document's quantity across several VHUs is reported once, not once per VHU
     Given metasfresh contains M_Products:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huTraceability.feature
@@ -135,10 +135,10 @@ Feature: HU Traceability Report — SQL correctness tests
 
   @Id:S0000.1_HUTrace_IneligibleReceiptDoc
   Scenario: A graph link to a receipt document this section may not report does not silence the lot candidate
-    # The shipment descends from a customer-return receipt (IsSOTrx='Y'), which the DIRECT_SALE_DETAIL
-    # section only reports for purchase receipts (IsSOTrx='N'). Deciding "this group is traced, so drop
-    # its candidates" before the receipt document's eligibility has been checked would leave the group
-    # with no row at all — deleting the lot-level candidate the customer sees today.
+    # The shipment descends from a receipt document whose doctype is IsSOTrx='Y', which this section
+    # may not report — it reports only IsSOTrx='N' purchase receipts. Deciding "this group is traced,
+    # so drop its candidates" before the receipt document's eligibility has been checked would leave
+    # the group with no row at all — deleting the lot-level candidate the customer sees today.
     Given metasfresh contains M_Products:
       | Identifier                 | Value                          | Name                            |
       | traceProduct_ineligibleDoc | traceProductVal_ineligibleDoc  | Trace Product Ineligible Doc    |

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5821850_sys_HU_Trace_Report_LinkBasis_Element.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5821850_sys_HU_Trace_Report_LinkBasis_Element.sql
@@ -1,0 +1,58 @@
+-- IDs allocated from idserver.metas.de on 2026-09-02:
+--   AD_Element 585414 (label for the m_hu_trace_report(numeric) link_basis column)
+
+-- AD_Element for the Excel column header of m_hu_trace_report(numeric).link_basis, which tells
+-- the reader whether a receipt-to-shipment pairing was proven from the HU trace graph or is a
+-- lot- or product-level guess. Resolved directly by ColumnName, not attached to any AD_Column,
+-- AD_Field, or window.
+INSERT INTO AD_Element (
+    AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy,
+    ColumnName, EntityType,
+    Name, PrintName, Description, Help
+) VALUES (
+    585414 /*From ID Server*/, 0, 0, 'Y',
+    TO_TIMESTAMP('2026-09-02 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+    TO_TIMESTAMP('2026-09-02 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+    'Link_Basis', 'de.metas.handlingunits',
+    'Verknüpfung', 'Verknüpfung',
+    'Gibt an, ob die Zuordnung von Wareneingang zu Warenausgang im Rückverfolgungsbericht nachgewiesen oder nur aus Los- bzw. Produktangaben geschätzt wurde.', NULL
+);
+
+-- Seed skeleton AD_Element_Trl rows for every active system language, copying the base (German) text.
+INSERT INTO AD_Element_Trl (
+    AD_Language, AD_Element_ID,
+    CommitWarning, Description, Help, Name, PO_Description, PO_Help,
+    PO_Name, PO_PrintName, PrintName,
+    WEBUI_NameBrowse, WEBUI_NameNew, WEBUI_NameNewBreadcrumb,
+    IsTranslated, AD_Client_ID, AD_Org_ID,
+    Created, CreatedBy, Updated, UpdatedBy
+)
+SELECT l.AD_Language, t.AD_Element_ID,
+       t.CommitWarning, t.Description, t.Help, t.Name, t.PO_Description, t.PO_Help,
+       t.PO_Name, t.PO_PrintName, t.PrintName,
+       t.WEBUI_NameBrowse, t.WEBUI_NameNew, t.WEBUI_NameNewBreadcrumb,
+       'N', t.AD_Client_ID, t.AD_Org_ID,
+       t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Element_ID = 585414
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID);
+
+-- de_DE / de_CH already carry the correct German text from the seed above; just mark them translated.
+UPDATE AD_Element_Trl
+SET IsTranslated = 'Y',
+    Updated = TO_TIMESTAMP('2026-09-02 10:00:12', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+WHERE AD_Element_ID = 585414 AND AD_Language IN ('de_DE', 'de_CH');
+
+-- en_US gets the English override.
+UPDATE AD_Element_Trl
+SET Name = 'Link basis', PrintName = 'Link basis',
+    Description = 'States whether the receipt-to-shipment pairing in the traceability report was proven from the trace graph or is only a lot- or product-level estimate.',
+    IsTranslated = 'Y',
+    Updated = TO_TIMESTAMP('2026-09-02 10:00:18', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+WHERE AD_Element_ID = 585414 AND AD_Language = 'en_US';
+
+-- No AD_Column/AD_Field/AD_Window/AD_Tab/AD_Menu references this element (it is looked up
+-- directly by ColumnName as an Excel header label), so no further propagation call is needed.

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5821850_sys_HU_Trace_Report_LinkBasis_Element.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5821850_sys_HU_Trace_Report_LinkBasis_Element.sql
@@ -15,7 +15,7 @@ INSERT INTO AD_Element (
     TO_TIMESTAMP('2026-09-02 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
     TO_TIMESTAMP('2026-09-02 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
     'Link_Basis', 'de.metas.handlingunits',
-    'Verknüpfung', 'Verknüpfung',
+    'Zuordnung', 'Zuordnung',
     'Gibt an, ob die Zuordnung von Wareneingang zu Warenausgang im Rückverfolgungsbericht nachgewiesen oder nur aus Los- bzw. Produktangaben geschätzt wurde.', NULL
 );
 

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5821870_sys_HU_Trace_Report_Description_LinkBasis.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5821870_sys_HU_Trace_Report_Description_LinkBasis.sql
@@ -1,0 +1,132 @@
+-- English translation edited alongside the German (base-language) text below, per the
+-- established base-language sync pattern for AD_Process 585253 (see 5775190).
+-- Documents: the new link-basis column (proven vs. guessed pairing) and the corrected
+-- meaning of 2_Menge / 2_Liefermenge (document totals, not per-row values -- do not sum).
+-- Also restores 5775190's "only filled for Production Issue or Production Receipt" qualifier
+-- on the German heading and adds the matching qualifier to the English heading, which never had it.
+
+-- Process: M_HU_Trace_Report_Excel(de.metas.handlingunits.trace.process.M_HU_Trace_Report_Excel)
+UPDATE AD_Process_Trl SET Description='Purpose:
+Creates a complete traceability overview for the product and batch (lot number).
+The report tracks handling units (HUs) throughout their entire lifecycle – from receipt of goods by the supplier through production and storage to shipment to the customer.
+This makes it possible to understand where materials come from, how they were used, and where they were delivered.
+
+Process Parameters:
+• Product: The product for which the traceability analysis is to be performed.
+• Lot Number (Batch): The specific lot or batch to be traced across all related transactions.
+
+What it shows:
+• Current Stock per Lot: Displays the current on-hand quantity of the selected lot in the warehouse.
+• Goods Receipts from Suppliers: Lists incoming deliveries of the lot, showing supplier, document, and date information.
+• Shipments to Customers: Shows outgoing deliveries of the lot, including customer details, document numbers, and shipped quantities.
+• Production Movements: Details components issued to production and finished or semi-finished goods received from production orders.
+• Inventory Adjustments and Clearances: Includes manual stock corrections, inventory counts, and clearance or quality status changes.
+• Material Trace Links: Connects raw material lots with the finished goods they were used in (and vice versa), ensuring full upstream and downstream traceability.
+
+Report 2_ Columns (only filled for Production Issue or Production Receipt):
+• 2_Typ: The type of transaction (e.g., Goods Receipt, Production Issue, Shipment).
+• 2_Produkt Nr.: The internal product number of the finished good or component.
+• 2_Produktname: The product name or description.
+• 2_Menge: The related shipment document''s total quantity for this product and lot.
+• 2_Maßeinheit: Unit of measure (UOM) used for the quantity.
+• 2_Leer: Supplier’s lot number, if available (blank if not applicable).
+• 2_Belegdatum: Document date or best-before date, depending on context.
+• 2_Freigabestatus: Clearance or quality status of the lot.
+• 2_Kunde/Lieferant Nr.: Customer or vendor number involved in the transaction.
+• 2_Kunde/Lieferant: Customer or vendor name.
+• 2_Liefermenge: Same as 2_Menge – the related shipment document''s total quantity for this product and lot.
+• 2_Belegnummer: Reference document number (e.g., shipment or receipt document).
+• 2_Bestand: Current stock quantity of the lot.
+• 2_Trace_ID: Internal traceability identifier linking related transactions
+
+Additional columns:
+• Menge: The related receipt document''s total quantity for this product and lot.
+• Verknüpfung: States whether the receipt-to-shipment pairing is proven or only estimated. TRACED: proven from the handling units'' packaging/transformation history. LOT_CANDIDATE: not proven, only guessed from a matching lot number. PRODUCT_CANDIDATE: like LOT_CANDIDATE but without a lot number, guessed from the product alone.
+
+Important note: Menge, 2_Menge and 2_Liefermenge are document totals and repeat on every row assigned to that document. If, for example, one receipt has several rows assigned to it (one per shipment it is paired with), its full quantity appears on each of those rows – so these columns must NOT be summed, or the quantity gets multiplied. To get the actual received or shipped quantity, de-duplicate by document first.',Updated=TO_TIMESTAMP('2026-09-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Process_ID=585253
+;
+
+UPDATE AD_Process base SET Description=trl.Description, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy FROM AD_Process_Trl trl WHERE trl.AD_Process_ID=base.AD_Process_ID AND trl.AD_Language='en_US' AND trl.AD_Language=getBaseLanguage() AND base.AD_Process_ID=585253
+;
+
+-- Value: M_HU_Trace_Report_Excel
+-- Classname: de.metas.handlingunits.trace.process.M_HU_Trace_Report_Excel
+UPDATE AD_Process SET Description='Zweck:
+Erstellt eine vollständige Rückverfolgbarkeitsübersicht für Produkt und Charge (Losnummer).
+Der Bericht verfolgt die Handling Units (HUs) über ihren gesamten Lebenszyklus hinweg – von der Warenanlieferung durch den Lieferanten über die Produktion und Lagerung bis hin zum Versand an den Kunden.
+So lässt sich nachvollziehen, woher Materialien stammen, wie sie verwendet wurden und wohin sie geliefert wurden.
+
+Prozessparameter:
+• Produkt: Das Produkt, für das die Rückverfolgung durchgeführt werden soll.
+• Losnummer (Charge): Die spezifische Charge oder Losnummer, deren Materialfluss nachvollzogen werden soll.
+
+Inhalt des Berichts:
+• Aktueller Lagerbestand pro Charge: Zeigt die derzeit verfügbare Menge der ausgewählten Charge im Lager.
+• Wareneingänge von Lieferanten: Listet alle eingegangenen Lieferungen dieser Charge auf, inklusive Lieferant, Beleg und Datum.
+• Warenausgänge zu Kunden: Zeigt alle Auslieferungen der Charge an Kunden mit Kundendaten, Belegnummer und Menge.
+• Produktionsbewegungen: Beinhaltet Materialentnahmen für die Produktion und Wareneingänge fertiger oder halbfertiger Produkte.
+• Bestandskorrekturen und Freigaben: Enthält manuelle Bestandsanpassungen, Inventurzählungen und Freigabe- oder Qualitätsstatusänderungen.
+• Materialverknüpfungen: Verknüpft Rohstoffchargen mit den daraus hergestellten Endprodukten (und umgekehrt) für eine vollständige Rückverfolgbarkeit in beide Richtungen.
+
+Berichtsspalten (2_, nur ausgefüllt bei Produktionsentnahme oder Produktionswareneingang):
+• 2_Typ: Art der Bewegung (z. B. Wareneingang, Produktionsentnahme, Lieferung).
+• 2_Produkt Nr.: Interne Produktnummer des Fertigprodukts oder der Komponente.
+• 2_Produktname: Produktbezeichnung oder Beschreibung.
+• 2_Menge: Gesamtmenge des zugehörigen Warenausgangs-Belegs (Lieferung) für dieses Produkt und diese Charge.
+• 2_Maßeinheit: Einheit, in der die Menge gemessen wird (Maßeinheit).
+• 2_Leer: Lieferantenchargennummer, falls vorhanden (leer, wenn nicht zutreffend).
+• 2_Belegdatum: Belegdatum oder Mindesthaltbarkeitsdatum, je nach Kontext.
+• 2_Freigabestatus: Freigabe- oder Qualitätsstatus der Charge.
+• 2_Kunde/Lieferant Nr.: Kunden- oder Lieferantennummer, die an der Bewegung beteiligt ist.
+• 2_Kunde/Lieferant: Name des Kunden oder Lieferanten.
+• 2_Liefermenge: Wie 2_Menge – Gesamtmenge des zugehörigen Warenausgangs-Belegs für dieses Produkt und diese Charge.
+• 2_Belegnummer: Referenzbelegnummer (z. B. Liefer- oder Wareneingangsbeleg).
+• 2_Bestand: Aktueller Bestand der Charge.
+• 2_Trace_ID: Interne Rückverfolgungs-ID, die zusammengehörige Bewegungen verbindet.
+
+Weitere Spalten:
+• Menge: Gesamtmenge des zugehörigen Wareneingangs-Belegs für dieses Produkt und diese Charge.
+• Verknüpfung: Gibt an, ob die Zuordnung von Wareneingang zu Warenausgang nachgewiesen oder nur geschätzt ist. TRACED: über die Verpackungs-/Umwandlungshistorie der Handling Units nachgewiesen. LOT_CANDIDATE: nicht nachgewiesen, sondern anhand einer übereinstimmenden Losnummer vermutet. PRODUCT_CANDIDATE: wie LOT_CANDIDATE, aber ohne Losnummer, nur anhand des Produkts vermutet.
+
+Wichtiger Hinweis: Menge, 2_Menge und 2_Liefermenge sind Belegsummen und wiederholen sich auf jeder Zeile, die diesem Beleg zugeordnet ist. Ist z. B. ein Wareneingang mehreren Zeilen zugeordnet (je einer pro Warenausgang, dem er zugeordnet wurde), erscheint seine volle Menge auf jeder dieser Zeilen – die Spalten dürfen daher NICHT aufsummiert werden, sonst wird die Menge vervielfacht. Für die tatsächlich empfangene bzw. gelieferte Menge zuerst je Beleg deduplizieren.',Updated=TO_TIMESTAMP('2026-09-02 12:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=585253
+;
+
+UPDATE AD_Process_Trl trl SET Description='Zweck:
+Erstellt eine vollständige Rückverfolgbarkeitsübersicht für Produkt und Charge (Losnummer).
+Der Bericht verfolgt die Handling Units (HUs) über ihren gesamten Lebenszyklus hinweg – von der Warenanlieferung durch den Lieferanten über die Produktion und Lagerung bis hin zum Versand an den Kunden.
+So lässt sich nachvollziehen, woher Materialien stammen, wie sie verwendet wurden und wohin sie geliefert wurden.
+
+Prozessparameter:
+• Produkt: Das Produkt, für das die Rückverfolgung durchgeführt werden soll.
+• Losnummer (Charge): Die spezifische Charge oder Losnummer, deren Materialfluss nachvollzogen werden soll.
+
+Inhalt des Berichts:
+• Aktueller Lagerbestand pro Charge: Zeigt die derzeit verfügbare Menge der ausgewählten Charge im Lager.
+• Wareneingänge von Lieferanten: Listet alle eingegangenen Lieferungen dieser Charge auf, inklusive Lieferant, Beleg und Datum.
+• Warenausgänge zu Kunden: Zeigt alle Auslieferungen der Charge an Kunden mit Kundendaten, Belegnummer und Menge.
+• Produktionsbewegungen: Beinhaltet Materialentnahmen für die Produktion und Wareneingänge fertiger oder halbfertiger Produkte.
+• Bestandskorrekturen und Freigaben: Enthält manuelle Bestandsanpassungen, Inventurzählungen und Freigabe- oder Qualitätsstatusänderungen.
+• Materialverknüpfungen: Verknüpft Rohstoffchargen mit den daraus hergestellten Endprodukten (und umgekehrt) für eine vollständige Rückverfolgbarkeit in beide Richtungen.
+
+Berichtsspalten (2_, nur ausgefüllt bei Produktionsentnahme oder Produktionswareneingang):
+• 2_Typ: Art der Bewegung (z. B. Wareneingang, Produktionsentnahme, Lieferung).
+• 2_Produkt Nr.: Interne Produktnummer des Fertigprodukts oder der Komponente.
+• 2_Produktname: Produktbezeichnung oder Beschreibung.
+• 2_Menge: Gesamtmenge des zugehörigen Warenausgangs-Belegs (Lieferung) für dieses Produkt und diese Charge.
+• 2_Maßeinheit: Einheit, in der die Menge gemessen wird (Maßeinheit).
+• 2_Leer: Lieferantenchargennummer, falls vorhanden (leer, wenn nicht zutreffend).
+• 2_Belegdatum: Belegdatum oder Mindesthaltbarkeitsdatum, je nach Kontext.
+• 2_Freigabestatus: Freigabe- oder Qualitätsstatus der Charge.
+• 2_Kunde/Lieferant Nr.: Kunden- oder Lieferantennummer, die an der Bewegung beteiligt ist.
+• 2_Kunde/Lieferant: Name des Kunden oder Lieferanten.
+• 2_Liefermenge: Wie 2_Menge – Gesamtmenge des zugehörigen Warenausgangs-Belegs für dieses Produkt und diese Charge.
+• 2_Belegnummer: Referenzbelegnummer (z. B. Liefer- oder Wareneingangsbeleg).
+• 2_Bestand: Aktueller Bestand der Charge.
+• 2_Trace_ID: Interne Rückverfolgungs-ID, die zusammengehörige Bewegungen verbindet.
+
+Weitere Spalten:
+• Menge: Gesamtmenge des zugehörigen Wareneingangs-Belegs für dieses Produkt und diese Charge.
+• Verknüpfung: Gibt an, ob die Zuordnung von Wareneingang zu Warenausgang nachgewiesen oder nur geschätzt ist. TRACED: über die Verpackungs-/Umwandlungshistorie der Handling Units nachgewiesen. LOT_CANDIDATE: nicht nachgewiesen, sondern anhand einer übereinstimmenden Losnummer vermutet. PRODUCT_CANDIDATE: wie LOT_CANDIDATE, aber ohne Losnummer, nur anhand des Produkts vermutet.
+
+Wichtiger Hinweis: Menge, 2_Menge und 2_Liefermenge sind Belegsummen und wiederholen sich auf jeder Zeile, die diesem Beleg zugeordnet ist. Ist z. B. ein Wareneingang mehreren Zeilen zugeordnet (je einer pro Warenausgang, dem er zugeordnet wurde), erscheint seine volle Menge auf jeder dieser Zeilen – die Spalten dürfen daher NICHT aufsummiert werden, sonst wird die Menge vervielfacht. Für die tatsächlich empfangene bzw. gelieferte Menge zuerst je Beleg deduplizieren.',Updated=TO_TIMESTAMP('2026-09-02 12:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=585253 AND AD_Language='de_DE'
+;

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5821870_sys_HU_Trace_Report_Description_LinkBasis.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5821870_sys_HU_Trace_Report_Description_LinkBasis.sql
@@ -41,7 +41,7 @@ Report 2_ Columns (only filled for Production Issue or Production Receipt):
 
 Additional columns:
 • Menge: The related receipt document''s total quantity for this product and lot.
-• Verknüpfung: States whether the receipt-to-shipment pairing is proven or only estimated. TRACED: proven from the handling units'' packaging/transformation history. LOT_CANDIDATE: not proven, only guessed from a matching lot number. PRODUCT_CANDIDATE: like LOT_CANDIDATE but without a lot number, guessed from the product alone.
+• Link basis: States whether the receipt-to-shipment pairing is proven or only estimated. TRACED: proven from the handling units'' packaging/transformation history. LOT_CANDIDATE: not proven, only guessed from a matching lot number. PRODUCT_CANDIDATE: like LOT_CANDIDATE but without a lot number, guessed from the product alone.
 
 Important note: Menge, 2_Menge and 2_Liefermenge are document totals and repeat on every row assigned to that document. If, for example, one receipt has several rows assigned to it (one per shipment it is paired with), its full quantity appears on each of those rows – so these columns must NOT be summed, or the quantity gets multiplied. To get the actual received or shipped quantity, de-duplicate by document first.',Updated=TO_TIMESTAMP('2026-09-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Process_ID=585253
 ;
@@ -86,7 +86,7 @@ Berichtsspalten (2_, nur ausgefüllt bei Produktionsentnahme oder Produktionswar
 
 Weitere Spalten:
 • Menge: Gesamtmenge des zugehörigen Wareneingangs-Belegs für dieses Produkt und diese Charge.
-• Verknüpfung: Gibt an, ob die Zuordnung von Wareneingang zu Warenausgang nachgewiesen oder nur geschätzt ist. TRACED: über die Verpackungs-/Umwandlungshistorie der Handling Units nachgewiesen. LOT_CANDIDATE: nicht nachgewiesen, sondern anhand einer übereinstimmenden Losnummer vermutet. PRODUCT_CANDIDATE: wie LOT_CANDIDATE, aber ohne Losnummer, nur anhand des Produkts vermutet.
+• Zuordnung: Gibt an, ob die Verbindung zwischen Wareneingang und Warenausgang nachgewiesen oder nur geschätzt ist. TRACED: über die Verpackungs-/Umwandlungshistorie der Handling Units nachgewiesen. LOT_CANDIDATE: nicht nachgewiesen, sondern anhand einer übereinstimmenden Losnummer vermutet. PRODUCT_CANDIDATE: wie LOT_CANDIDATE, aber ohne Losnummer, nur anhand des Produkts vermutet.
 
 Wichtiger Hinweis: Menge, 2_Menge und 2_Liefermenge sind Belegsummen und wiederholen sich auf jeder Zeile, die diesem Beleg zugeordnet ist. Ist z. B. ein Wareneingang mehreren Zeilen zugeordnet (je einer pro Warenausgang, dem er zugeordnet wurde), erscheint seine volle Menge auf jeder dieser Zeilen – die Spalten dürfen daher NICHT aufsummiert werden, sonst wird die Menge vervielfacht. Für die tatsächlich empfangene bzw. gelieferte Menge zuerst je Beleg deduplizieren.',Updated=TO_TIMESTAMP('2026-09-02 12:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=585253
 ;
@@ -126,7 +126,7 @@ Berichtsspalten (2_, nur ausgefüllt bei Produktionsentnahme oder Produktionswar
 
 Weitere Spalten:
 • Menge: Gesamtmenge des zugehörigen Wareneingangs-Belegs für dieses Produkt und diese Charge.
-• Verknüpfung: Gibt an, ob die Zuordnung von Wareneingang zu Warenausgang nachgewiesen oder nur geschätzt ist. TRACED: über die Verpackungs-/Umwandlungshistorie der Handling Units nachgewiesen. LOT_CANDIDATE: nicht nachgewiesen, sondern anhand einer übereinstimmenden Losnummer vermutet. PRODUCT_CANDIDATE: wie LOT_CANDIDATE, aber ohne Losnummer, nur anhand des Produkts vermutet.
+• Zuordnung: Gibt an, ob die Verbindung zwischen Wareneingang und Warenausgang nachgewiesen oder nur geschätzt ist. TRACED: über die Verpackungs-/Umwandlungshistorie der Handling Units nachgewiesen. LOT_CANDIDATE: nicht nachgewiesen, sondern anhand einer übereinstimmenden Losnummer vermutet. PRODUCT_CANDIDATE: wie LOT_CANDIDATE, aber ohne Losnummer, nur anhand des Produkts vermutet.
 
 Wichtiger Hinweis: Menge, 2_Menge und 2_Liefermenge sind Belegsummen und wiederholen sich auf jeder Zeile, die diesem Beleg zugeordnet ist. Ist z. B. ein Wareneingang mehreren Zeilen zugeordnet (je einer pro Warenausgang, dem er zugeordnet wurde), erscheint seine volle Menge auf jeder dieser Zeilen – die Spalten dürfen daher NICHT aufsummiert werden, sonst wird die Menge vervielfacht. Für die tatsächlich empfangene bzw. gelieferte Menge zuerst je Beleg deduplizieren.',Updated=TO_TIMESTAMP('2026-09-02 12:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=585253 AND AD_Language='de_DE'
 ;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/trace/process/M_HU_Trace_Report_Excel.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/trace/process/M_HU_Trace_Report_Excel.java
@@ -142,7 +142,8 @@ public class M_HU_Trace_Report_Excel extends JavaProcess
 				"Shipment_Date",
 				"Prod_Stock",
 				"TraceId",
-				"ReportDate"
+				"ReportDate",
+				"Link_Basis"
 				);
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
@@ -85,7 +85,7 @@ SELECT distinct
     null::numeric AS prod_stock,
     null::numeric AS traceid,
     to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
-    null as link_basis
+    null::varchar as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
@@ -139,7 +139,7 @@ SELECT DISTINCT ON (t.m_inout_ID)
     null::numeric AS prod_stock,
     null::numeric AS traceid,
     to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
-    null as link_basis
+    null::varchar as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
@@ -185,7 +185,7 @@ SELECT
     null::numeric AS prod_stock,
     null::numeric AS traceid,
     to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
-    null as link_basis
+    null::varchar as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
@@ -228,7 +228,7 @@ SELECT DISTINCT ON (t.pp_cost_collector_id)
     null::numeric AS prod_stock,
     null::numeric AS traceid,
     to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
-    null as link_basis
+    null::varchar as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
@@ -274,7 +274,7 @@ SELECT DISTINCT
     getcurrentstoragestock(t.m_product_id, t.c_uom_id, 1000017, prod_trace.lotnumber, t.ad_client_id, t.ad_org_id) AS prod_stock,
     prod_trace.m_hu_trace_id,
     to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
-    null as link_basis
+    null::varchar as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
@@ -329,7 +329,7 @@ SELECT DISTINCT
     getcurrentstoragestock(t.m_product_id, t.c_uom_id, 1000017, shipment_trace.lotnumber, t.ad_client_id, t.ad_org_id) AS prod_stock,
     shipment_trace.m_hu_trace_id,
     to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
-    null as link_basis
+    null::varchar as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
@@ -401,7 +401,7 @@ SELECT
     null::numeric AS prod_stock,
     null::numeric AS traceid,
     to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
-    null as link_basis
+    null::varchar as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
@@ -74,7 +74,6 @@ vhu_edge AS (
     SELECT DISTINCT t.VHU_Source_ID AS src, t.VHU_ID AS dst
     FROM M_HU_Trace t
     WHERE t.VHU_Source_ID IS NOT NULL
-      AND t.VHU_ID IS NOT NULL
       AND t.VHU_Source_ID <> t.VHU_ID
 ),
 -- The MATERIAL_RECEIPT rows this report run is about, already narrowed to rows whose document
@@ -82,12 +81,12 @@ vhu_edge AS (
 -- traced and the candidate branch working off exactly the same set of eligible receipts, so a
 -- pair that the final projection would discard can never suppress the candidates of its group.
 receipt_trace AS (
-    SELECT t.M_HU_Trace_ID, t.VHU_ID, t.M_HU_ID, t.M_Product_ID, t.LotNumber, t.M_InOut_ID, t.C_UOM_ID
+    SELECT t.M_HU_Trace_ID, t.VHU_ID, t.M_HU_ID, t.M_Product_ID, t.LotNumber, t.M_InOut_ID, t.C_UOM_ID,
+           t.AD_Client_ID, t.AD_Org_ID
     FROM M_HU_Trace t
     JOIN M_InOut receipt_io ON receipt_io.M_InOut_ID = t.M_InOut_ID
     JOIN C_DocType receipt_dt ON receipt_dt.C_DocType_ID = receipt_io.C_DocType_ID
     WHERE t.HUTraceType = 'MATERIAL_RECEIPT'
-      AND t.VHU_ID IS NOT NULL
       AND receipt_dt.IsSOTrx = 'N'
       AND receipt_io.DocStatus IN ('CO', 'CL')
       AND EXISTS (SELECT 1 FROM T_Selection s
@@ -104,9 +103,9 @@ receipt_reach (M_HU_Trace_ID, VHU_ID, depth) AS (
     FROM receipt_reach rr
     JOIN vhu_edge e ON e.src = rr.VHU_ID
     -- Termination guard against a runaway or cyclic transformation chain: UNION alone cannot stop
-    -- a cycle here because the depth column makes every revisit a distinct row. Measured on the
-    -- customer instance the chains are one hop long (see round2-results.md), so 15 is far above
-    -- anything real while still bounding a corrupt graph.
+    -- a cycle here because the depth column makes every revisit a distinct row. The longest chain
+    -- measured on a production dataset (25 816 trace rows, 12 908 transformation edges) was 2 hops,
+    -- so 15 is far above anything real while still bounding a corrupt graph.
     WHERE rr.depth < 15
 ),
 -- The MATERIAL_SHIPMENT rows this run is about, narrowed to rows whose document qualifies as a
@@ -118,7 +117,6 @@ shipment_trace_sel AS (
     JOIN M_InOut shipment_io ON shipment_io.M_InOut_ID = t.M_InOut_ID
     JOIN C_DocType shipment_dt ON shipment_dt.C_DocType_ID = shipment_io.C_DocType_ID
     WHERE t.HUTraceType = 'MATERIAL_SHIPMENT'
-      AND t.VHU_ID IS NOT NULL
       AND shipment_dt.IsSOTrx = 'Y'
       AND shipment_io.DocStatus IN ('CO', 'CL')
       AND EXISTS (SELECT 1 FROM T_Selection s
@@ -138,8 +136,15 @@ traced_pair AS (
            min(st.M_HU_Trace_ID) AS shipment_trace_id,
            min(r.M_HU_ID)        AS receipt_hu_id,
            min(st.M_HU_ID)       AS shipment_hu_id,
+           -- assumes every trace row of one document/product/lot shares a UOM, which is how the
+           -- pre-rewrite body could take qty and UOM from one and the same trace row. The
+           -- quantities beside these are document-level sums, so a document that genuinely mixed
+           -- UOMs would print the sum under only one of them.
            min(st.C_UOM_ID)      AS shipment_uom_id,
-           min(r.C_UOM_ID)       AS receipt_uom_id
+           min(r.C_UOM_ID)       AS receipt_uom_id,
+           -- client/org of the receipt TRACE ROW, the source the pre-rewrite prod_stock used
+           min(r.AD_Client_ID)   AS receipt_client_id,
+           min(r.AD_Org_ID)      AS receipt_org_id
     FROM receipt_trace r
     JOIN receipt_reach rr ON rr.M_HU_Trace_ID = r.M_HU_Trace_ID
     JOIN shipment_trace_sel st
@@ -164,8 +169,11 @@ candidate_pair AS (
            min(st.M_HU_Trace_ID) AS shipment_trace_id,
            min(r.M_HU_ID)        AS receipt_hu_id,
            min(st.M_HU_ID)       AS shipment_hu_id,
+           -- same UOM and client/org assumptions as traced_pair above
            min(st.C_UOM_ID)      AS shipment_uom_id,
-           min(r.C_UOM_ID)       AS receipt_uom_id
+           min(r.C_UOM_ID)       AS receipt_uom_id,
+           min(r.AD_Client_ID)   AS receipt_client_id,
+           min(r.AD_Org_ID)      AS receipt_org_id
     FROM receipt_trace r
     JOIN shipment_trace_sel st
            ON st.M_Product_ID = r.M_Product_ID
@@ -191,20 +199,25 @@ detail_pair AS (
 -- lots in one group, which is what the IS NOT DISTINCT FROM join below matches; a combination
 -- with no rows produces no join partner and therefore a NULL quantity, exactly as a correlated
 -- SUM over no rows would.
+-- The IN restricts the set of DOCUMENTS grouped here, never the rows summed for one of them, so
+-- the quantity stays the document's full total. It is not a filter but a bound: the only document
+-- ids this CTE is ever probed with come from receipt_trace, and without it every invocation of the
+-- function would aggregate the whole of M_HU_Trace even when this section emits nothing.
 receipt_doc_qty AS (
     SELECT rt.M_InOut_ID, rt.M_Product_ID, rt.LotNumber, SUM(rt.Qty) AS qty_sum
     FROM M_HU_Trace rt
     WHERE rt.HUTraceType = 'MATERIAL_RECEIPT'
-      AND rt.M_InOut_ID IS NOT NULL
+      AND rt.M_InOut_ID IN (SELECT M_InOut_ID FROM receipt_trace)
     GROUP BY rt.M_InOut_ID, rt.M_Product_ID, rt.LotNumber
 ),
 -- Document-level shipped quantity per (shipment document, product, lot). finished_product_qty
 -- and shipmentqty are the same figure under two column names, so both read this one CTE.
+-- Bounded to the shipment documents in scope for the same reason as receipt_doc_qty above.
 shipment_doc_qty AS (
     SELECT stq.M_InOut_ID, stq.M_Product_ID, stq.LotNumber, SUM(stq.Qty) AS qty_sum
     FROM M_HU_Trace stq
     WHERE stq.HUTraceType = 'MATERIAL_SHIPMENT'
-      AND stq.M_InOut_ID IS NOT NULL
+      AND stq.M_InOut_ID IN (SELECT M_InOut_ID FROM shipment_trace_sel)
     GROUP BY stq.M_InOut_ID, stq.M_Product_ID, stq.LotNumber
 )
 -- =====================================================================================
@@ -480,7 +493,8 @@ SELECT
     ABS(ROUND(sq.qty_sum, COALESCE(su.stdprecision, 0))) as finished_product_qty,
     su.uomsymbol as finished_product_uom,
     dp.LotNumber as finished_product_lot,
-    -- 1000029: the vendor-lot M_HU_Attribute, carried over verbatim from the previous body
+    -- 1000029: M_Attribute (vendor lot) -- the FK m_hu_attribute.m_attribute_id, not the
+    -- m_hu_attribute PK. Carried over verbatim from the previous body.
     (select value from m_hu_attribute vendorlot
       where vendorlot.m_hu_id = dp.receipt_hu_id and vendorlot.m_attribute_id = 1000029::numeric) as vendorlot,
     -- 540020: M_Attribute HU_BestBeforeDate (Mindesthaltbarkeit), carried over verbatim
@@ -494,10 +508,11 @@ SELECT
     ABS(ROUND(sq.qty_sum, COALESCE(su.stdprecision, 0))) as shipmentqty,
     shipment_io.documentno as shipment_note,
     to_char(shipment_io.movementdate, 'DD.MM.YYYY') as shipment_date,
-    -- 1000017: M_Attribute Lot-Nummer. UOM and client/org are taken from the receipt side, which
-    -- is what the pre-rewrite expression used (t.c_uom_id / t.ad_client_id / t.ad_org_id).
+    -- 1000017: M_Attribute Lot-Nummer. UOM and client/org come from the receipt TRACE ROW, the
+    -- same source the pre-rewrite expression used (t.c_uom_id / t.ad_client_id / t.ad_org_id).
+    -- All three are equality filters inside getcurrentstoragestock, so the source matters.
     getcurrentstoragestock(dp.M_Product_ID, dp.receipt_uom_id, 1000017, dp.LotNumber,
-                           receipt_io.ad_client_id, receipt_io.ad_org_id) AS prod_stock,
+                           dp.receipt_client_id, dp.receipt_org_id) AS prod_stock,
     dp.shipment_trace_id AS traceid,
     to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
     dp.link_basis

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
@@ -57,32 +57,25 @@ as
 $$
 -- =====================================================================================
 -- SHARED CTE BLOCK
--- Used by SECTION 6 (DIRECT SALE DETAILS) only; the other sections do not reference it.
--- It derives the receipt-to-shipment pairing from the M_HU_Trace transformation graph
--- (VHU_Source_ID -> VHU_ID edges), and labels every emitted pair with the basis on which it was
--- paired (link_basis) so a proven link is distinguishable from a guess.
+-- Used by SECTION 6 (DIRECT SALE DETAILS) only. Derives the receipt-to-shipment pairing from the
+-- M_HU_Trace transformation graph (VHU_Source_ID -> VHU_ID edges) and labels each pair with the
+-- basis it was paired on (link_basis), so a proven link is distinguishable from a guess.
 -- =====================================================================================
 WITH RECURSIVE
--- Every descent edge: any trace row that records a source VHU, whatever its trace type -- the
--- transformation splits, and customer returns, which record the originally-shipped VHU as the
--- source and so still run forward along physical descent. The COLUMN defines the edge set, not
--- the type: adding a trace-type predicate here would silently drop return-chain traceability,
--- and no test would go red. On a production dataset every target VHU has exactly one source, so
--- the graph is a forest and attributing a shipped VHU back to one received VHU is unambiguous.
--- The walk below runs the other way -- forward, from a receipt to everything it became -- and may
--- legitimately fan out, one received pallet split into many shipped pieces. Deliberately not
--- restricted by trace type or by T_Selection: whether such a row is in the selection depends on
--- how the caller's recursion happened to reach it, so the walk must not depend on it.
+-- Every descent edge: any trace row with a source VHU, whatever its trace type -- transformation
+-- splits AND customer returns (which record the originally-shipped VHU as source) both belong
+-- here. The COLUMN defines the edge set, not the type: adding a trace-type predicate here would
+-- silently drop return-chain traceability, and no test would go red. Not restricted by
+-- T_Selection: the walk must not depend on how the caller's recursion reached a row.
 vhu_edge AS (
     SELECT DISTINCT t.VHU_Source_ID AS src, t.VHU_ID AS dst
     FROM M_HU_Trace t
     WHERE t.VHU_Source_ID IS NOT NULL
       AND t.VHU_Source_ID <> t.VHU_ID
 ),
--- The MATERIAL_RECEIPT rows this report run is about, already narrowed to rows whose document
--- qualifies as a purchase receipt. Filtering here rather than in the final WHERE keeps the
--- traced and the candidate branch working off exactly the same set of eligible receipts, so a
--- pair that the final projection would discard can never suppress the candidates of its group.
+-- The MATERIAL_RECEIPT rows this run is about, narrowed to purchase-receipt documents. Filtered
+-- here rather than in the final WHERE so the traced and candidate branches share exactly the same
+-- eligible-receipts set -- a pair the final projection discards can't suppress its group's candidates.
 receipt_trace AS (
     SELECT t.M_HU_Trace_ID, t.VHU_ID, t.M_HU_ID, t.M_Product_ID, t.LotNumber, t.M_InOut_ID, t.C_UOM_ID,
            t.AD_Client_ID, t.AD_Org_ID
@@ -105,16 +98,13 @@ receipt_reach (M_HU_Trace_ID, VHU_ID, depth) AS (
     SELECT rr.M_HU_Trace_ID, e.dst, rr.depth + 1
     FROM receipt_reach rr
     JOIN vhu_edge e ON e.src = rr.VHU_ID
-    -- Termination guard against a runaway or cyclic transformation chain: UNION alone cannot stop
-    -- a cycle here because the depth column makes every revisit a distinct row. On a production
-    -- dataset of 25 816 trace rows, of which 12 908 carry a source VHU (the distinct edge count is
-    -- at most that, since vhu_edge de-duplicates and drops self-edges), the longest chain measured
-    -- was 2 hops -- so 15 is far above anything real while still bounding a corrupt graph.
+    -- Termination guard against a runaway or cyclic chain (UNION alone can't stop a cycle since
+    -- depth makes every revisit distinct). On production data (25 816 trace rows, longest chain
+    -- measured 2 hops) 15 is far above anything real while still bounding a corrupt graph.
     WHERE rr.depth < 15
 ),
--- The MATERIAL_SHIPMENT rows this run is about, narrowed to rows whose document qualifies as a
--- customer shipment. Both sides are restricted to the report's selection, so a shipment outside
--- the run's scope can never be paired.
+-- The MATERIAL_SHIPMENT rows this run is about, narrowed to customer-shipment documents. Both
+-- sides are restricted to the report's selection, so a shipment outside scope can never be paired.
 shipment_trace_sel AS (
     SELECT t.M_HU_Trace_ID, t.VHU_ID, t.M_HU_ID, t.M_Product_ID, t.LotNumber, t.M_InOut_ID, t.C_UOM_ID
     FROM M_HU_Trace t
@@ -128,31 +118,26 @@ shipment_trace_sel AS (
                      AND s.T_Selection_ID = t.M_HU_Trace_ID)
 ),
 -- A pair is TRACED when the shipped VHU is reachable from the receipt VHU AND the two trace rows
--- agree on lot. Lot agreement is a consistency guard, not the pairing criterion: transformation
--- edges do connect trace rows carrying different lot numbers, and the report must not assert a
--- link across a relabelling it cannot explain.
--- The GROUP BY is the report row's identity: one row per (receipt document, shipment document,
--- product, lot), however many VHUs and trace rows the two documents carry for that product and
--- lot. This is de-duplication by construction, not by a DISTINCT over the projected columns.
+-- agree on lot -- lot agreement is a consistency guard, not the pairing criterion: transformation
+-- edges do connect rows with different lot numbers, and a relabelling must not be asserted as a link.
+-- The GROUP BY is the row's identity (receipt doc, shipment doc, product, lot); this is
+-- de-duplication by construction, not a DISTINCT over the projected columns.
 traced_pair AS (
     SELECT r.M_InOut_ID AS receipt_inout_id, r.M_Product_ID, r.LotNumber,
            st.M_InOut_ID AS shipment_inout_id,
            min(st.M_HU_Trace_ID) AS shipment_trace_id,
            min(r.M_HU_ID)        AS receipt_hu_id,
            min(st.M_HU_ID)       AS shipment_hu_id,
-           -- assumes every trace row of one document/product/lot shares a UOM. The quantities
-           -- beside these are document-level sums, so a document that genuinely mixed UOMs would
-           -- print the sum under only one of them.
+           -- assumes one document/product/lot shares a UOM; a document that genuinely mixed UOMs
+           -- would print the document-level sum under only one of them.
            min(st.C_UOM_ID)      AS shipment_uom_id,
            min(r.C_UOM_ID)       AS receipt_uom_id,
-           -- client/org of the receipt TRACE ROW, which is what prod_stock below filters on.
-           -- Reducing them with min() is safe because the rows of one group agree: the writer of a
-           -- MATERIAL_RECEIPT trace takes its org from the document's own M_HU_Assignment rows
-           -- (HUTraceEventsService.createAndAddEvents), and never sets the client at all, so the
-           -- row carries the installation's default. Were that ever violated, min() would pick the
-           -- numerically smallest -- org '*' = 0 being the likely one -- and all three of product,
-           -- client and org are equality filters inside getcurrentstoragestock, so prod_stock
-           -- would silently read 0 instead of the real stock.
+           -- client/org of the receipt TRACE ROW, which is what prod_stock below filters on. Reducing
+           -- with min() is safe because the group's rows agree: MATERIAL_RECEIPT traces take their org
+           -- from the document's own M_HU_Assignment rows (HUTraceEventsService.createAndAddEvents)
+           -- and never set the client, so every row carries the installation default. Were that ever
+           -- violated, min() would pick org '*' = 0, and prod_stock (which equality-filters on all
+           -- three) would silently read 0.
            min(r.AD_Client_ID)   AS receipt_client_id,
            min(r.AD_Org_ID)      AS receipt_org_id
     FROM receipt_trace r
@@ -164,15 +149,10 @@ traced_pair AS (
     GROUP BY r.M_InOut_ID, r.M_Product_ID, r.LotNumber, st.M_InOut_ID
 ),
 -- Lot-level guesses, emitted ONLY for the (shipment document, product, lot) groups the graph
--- leaves empty. A group with a traced receipt never also shows candidates.
--- The lot condition below is also what decides the fate of a graph-connected pair that the lot
--- guard above rejected: such a pair does not match here either, so it is DROPPED rather than
--- demoted to a candidate. Deliberate. A relabelling the data does not explain is not evidence of
--- a product-level link, and admitting one would re-open the cartesian at product granularity --
--- every receipt of the product against every shipment of it -- the very failure these pairing
--- rules exist to prevent.
--- Silence is the honest answer; PRODUCT_CANDIDATE keeps its single meaning of "neither side
--- carries a lot number".
+-- leaves empty; a group with a traced receipt never also shows candidates. A graph-connected pair
+-- that the lot guard rejected is DROPPED here too, not demoted to a candidate -- a relabelling the
+-- data doesn't explain is not evidence of a product-level link, and admitting one would reopen the
+-- product-level cartesian these pairing rules exist to prevent.
 -- The GROUP BY carries the same row identity as traced_pair above.
 candidate_pair AS (
     SELECT r.M_InOut_ID AS receipt_inout_id, r.M_Product_ID, r.LotNumber,
@@ -206,14 +186,12 @@ detail_pair AS (
            (CASE WHEN cp.LotNumber IS NULL THEN 'PRODUCT_CANDIDATE' ELSE 'LOT_CANDIDATE' END)::varchar
       FROM candidate_pair cp
 ),
--- Document-level received quantity per (receipt document, product, lot). GROUP BY puts all NULL
--- lots in one group, which is what the IS NOT DISTINCT FROM join below matches; a combination
--- with no rows produces no join partner and therefore a NULL quantity, exactly as a correlated
--- SUM over no rows would.
--- The IN restricts the set of DOCUMENTS grouped here, never the rows summed for one of them, so
--- the quantity stays the document's full total. It is not a filter but a bound: the only document
--- ids this CTE is ever probed with come from receipt_trace, and without it every invocation of the
--- function would aggregate the whole of M_HU_Trace even when this section emits nothing.
+-- Document-level received quantity per (receipt document, product, lot); GROUP BY puts all NULL
+-- lots in one group, matching the IS NOT DISTINCT FROM join below (a combination with no rows
+-- yields no join partner, hence NULL, as a correlated SUM over no rows would).
+-- The IN is a bound, not a filter: it restricts which DOCUMENTS are grouped, never the rows summed
+-- for one of them, so the total stays the document's full sum -- it only keeps this CTE from
+-- aggregating the whole of M_HU_Trace on every invocation, even when section 6 emits nothing.
 receipt_doc_qty AS (
     SELECT rt.M_InOut_ID, rt.M_Product_ID, rt.LotNumber, SUM(rt.Qty) AS qty_sum
     FROM M_HU_Trace rt
@@ -475,15 +453,10 @@ UNION ALL
 
 -- =====================================================================================
 -- SECTION 6: DIRECT SALE DETAILS (Non-Manufactured Products)
--- Handles the direct purchase-to-sale flow: material receipts from vendors (issotrx=N) paired
--- with material shipments to customers (issotrx=Y).
--- The pairing is derived in the CTE block at the top of this function: a pair is TRACED when the
--- shipped VHU is reachable from the received VHU along the transformation graph and both ends
--- agree on lot; where the graph is silent for a (shipment document, product, lot) group, the
--- lot-level or product-level guesses are emitted for that group instead, and say so in link_basis.
--- One row per (receipt document, shipment document, product, lot) -- the aggregation that produces
--- that identity lives in traced_pair / candidate_pair, so no DISTINCT is needed or wanted here:
--- a duplicate would be a defect in the pairing and must stay visible rather than be swallowed.
+-- The purchase-to-sale flow for non-manufactured products: material receipts (issotrx=N) paired
+-- with material shipments (issotrx=Y) via the pairing CTEs above. One row per (receipt document,
+-- shipment document, product, lot) -- already deduplicated by traced_pair / candidate_pair, so no
+-- DISTINCT is needed here; a duplicate would be a pairing defect that must stay visible.
 -- =====================================================================================
 SELECT
     dp.LotNumber AS LotNumber,
@@ -493,8 +466,7 @@ SELECT
     NULL AS PPOrder,
     NULL AS Inventory,
     receipt_io.movementdate AS DocumentDate,
-    -- the receipt document's own quantity for this product and lot, summed over the document's
-    -- VHUs -- so the received-versus-shipped proportion is readable from the row itself.
+    -- document-level received quantity for this product/lot, so received-vs-shipped is readable from the row.
     ABS(ROUND(rq.qty_sum, COALESCE(ru.stdprecision, 0))) AS Qty,
     ru.uomsymbol AS UOM,
     'MATERIAL_SHIPMENT' as detail_type,
@@ -513,8 +485,7 @@ SELECT
     shipment_hulu_clearancestatus.name as finished_product_clearance,
     shipment_bp.value as customer_no,
     shipment_bp.name as customer,
-    -- same figure as finished_product_qty above, under the column name the report prints as
-    -- "2_Liefermenge"; both read the one shipment_doc_qty CTE
+    -- same figure as finished_product_qty above (prints as "2_Liefermenge"); both read shipment_doc_qty
     ABS(ROUND(sq.qty_sum, COALESCE(su.stdprecision, 0))) as shipmentqty,
     shipment_io.documentno as shipment_note,
     to_char(shipment_io.movementdate, 'DD.MM.YYYY') as shipment_date,
@@ -545,8 +516,7 @@ LEFT JOIN m_hu shipment_hu ON shipment_hu.m_hu_id = dp.shipment_hu_id
 LEFT JOIN ad_ref_list shipment_hulu_clearancestatus
        ON shipment_hulu_clearancestatus.ad_reference_id = 541540::numeric
       AND shipment_hulu_clearancestatus.value::text = shipment_hu.clearancestatus::text
--- the receipt document's isSOTrx/docstatus and the shipment document's are already enforced in
--- receipt_trace / shipment_trace_sel, so that both pairing branches see the same eligible documents
+-- isSOTrx/docstatus for both documents are already enforced in receipt_trace / shipment_trace_sel
 WHERE NOT EXISTS (
       -- this section is for products that were not manufactured
       SELECT 1 FROM M_HU_Trace pt

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
@@ -59,13 +59,13 @@ $$
 -- SHARED CTE BLOCK
 -- Used by SECTION 6 (DIRECT SALE DETAILS) only; the other sections do not reference it.
 -- It derives the receipt-to-shipment pairing from the M_HU_Trace transformation graph
--- (VHU_Source_ID -> VHU_ID edges) instead of from lot number and product alone, and labels
--- every emitted pair with the basis on which it was paired (link_basis).
+-- (VHU_Source_ID -> VHU_ID edges), and labels every emitted pair with the basis on which it was
+-- paired (link_basis) so a proven link is distinguishable from a guess.
 -- =====================================================================================
 WITH RECURSIVE
--- Every transformation edge: the source VHU became the target VHU. Measured on the customer
--- instance every target VHU has exactly one source, so the graph is a forest and attributing a
--- shipped VHU back to one received VHU is unambiguous. The walk below runs the other way --
+-- Every transformation edge: the source VHU became the target VHU. On a production dataset every
+-- target VHU has exactly one source, so the graph is a forest and attributing a shipped VHU back
+-- to one received VHU is unambiguous. The walk below runs the other way --
 -- forward, from a receipt to everything it became -- and may legitimately fan out, one received
 -- pallet split into many shipped pieces. Deliberately NOT restricted to T_Selection:
 -- TRANSFORM_LOAD is not one of the reported trace types, so the edges never appear in the
@@ -110,8 +110,8 @@ receipt_reach (M_HU_Trace_ID, VHU_ID, depth) AS (
     WHERE rr.depth < 15
 ),
 -- The MATERIAL_SHIPMENT rows this run is about, narrowed to rows whose document qualifies as a
--- customer shipment. Restricting the shipment side to the selection is new: previously only the
--- receipt side was restricted, so a shipment outside the report's scope could still be paired.
+-- customer shipment. Both sides are restricted to the report's selection, so a shipment outside
+-- the run's scope can never be paired.
 shipment_trace_sel AS (
     SELECT t.M_HU_Trace_ID, t.VHU_ID, t.M_HU_ID, t.M_Product_ID, t.LotNumber, t.M_InOut_ID, t.C_UOM_ID
     FROM M_HU_Trace t
@@ -137,13 +137,12 @@ traced_pair AS (
            min(st.M_HU_Trace_ID) AS shipment_trace_id,
            min(r.M_HU_ID)        AS receipt_hu_id,
            min(st.M_HU_ID)       AS shipment_hu_id,
-           -- assumes every trace row of one document/product/lot shares a UOM, which is how the
-           -- pre-rewrite body could take qty and UOM from one and the same trace row. The
-           -- quantities beside these are document-level sums, so a document that genuinely mixed
-           -- UOMs would print the sum under only one of them.
+           -- assumes every trace row of one document/product/lot shares a UOM. The quantities
+           -- beside these are document-level sums, so a document that genuinely mixed UOMs would
+           -- print the sum under only one of them.
            min(st.C_UOM_ID)      AS shipment_uom_id,
            min(r.C_UOM_ID)       AS receipt_uom_id,
-           -- client/org of the receipt TRACE ROW, the source the pre-rewrite prod_stock used.
+           -- client/org of the receipt TRACE ROW, which is what prod_stock below filters on.
            -- Reducing them with min() is safe because the rows of one group agree: the writer of a
            -- MATERIAL_RECEIPT trace takes its org from the document's own M_HU_Assignment rows
            -- (HUTraceEventsService.createAndAddEvents), and never sets the client at all, so the
@@ -491,8 +490,7 @@ SELECT
     NULL AS Inventory,
     receipt_io.movementdate AS DocumentDate,
     -- the receipt document's own quantity for this product and lot, summed over the document's
-    -- VHUs. Was always NULL in this section, which is why the received-versus-shipped proportion
-    -- could not be judged from the row.
+    -- VHUs -- so the received-versus-shipped proportion is readable from the row itself.
     ABS(ROUND(rq.qty_sum, COALESCE(ru.stdprecision, 0))) AS Qty,
     ru.uomsymbol AS UOM,
     'MATERIAL_SHIPMENT' as detail_type,
@@ -502,10 +500,10 @@ SELECT
     su.uomsymbol as finished_product_uom,
     dp.LotNumber as finished_product_lot,
     -- 1000029: M_Attribute (vendor lot) -- the FK m_hu_attribute.m_attribute_id, not the
-    -- m_hu_attribute PK. Carried over verbatim from the previous body.
+    -- m_hu_attribute PK
     (select value from m_hu_attribute vendorlot
       where vendorlot.m_hu_id = dp.receipt_hu_id and vendorlot.m_attribute_id = 1000029::numeric) as vendorlot,
-    -- 540020: M_Attribute HU_BestBeforeDate (Mindesthaltbarkeit), carried over verbatim
+    -- 540020: M_Attribute HU_BestBeforeDate (Mindesthaltbarkeit)
     (select to_char(valuedate, 'DD.MM.YYYY') from m_hu_attribute mhd
       where mhd.m_hu_id = dp.shipment_hu_id and mhd.m_attribute_id = 540020::numeric) as finished_product_mhd,
     shipment_hulu_clearancestatus.name as finished_product_clearance,
@@ -516,9 +514,8 @@ SELECT
     ABS(ROUND(sq.qty_sum, COALESCE(su.stdprecision, 0))) as shipmentqty,
     shipment_io.documentno as shipment_note,
     to_char(shipment_io.movementdate, 'DD.MM.YYYY') as shipment_date,
-    -- 1000017: M_Attribute Lot-Nummer. UOM and client/org come from the receipt TRACE ROW, the
-    -- same source the pre-rewrite expression used (t.c_uom_id / t.ad_client_id / t.ad_org_id).
-    -- All three are equality filters inside getcurrentstoragestock, so the source matters.
+    -- 1000017: M_Attribute Lot-Nummer. UOM and client/org come from the receipt trace row; all
+    -- three are equality filters inside getcurrentstoragestock, so which row they come from matters.
     getcurrentstoragestock(dp.M_Product_ID, dp.receipt_uom_id, 1000017, dp.LotNumber,
                            dp.receipt_client_id, dp.receipt_org_id) AS prod_stock,
     dp.shipment_trace_id AS traceid,
@@ -540,14 +537,14 @@ LEFT JOIN shipment_doc_qty sq
       AND sq.M_Product_ID = dp.M_Product_ID
       AND sq.LotNumber IS NOT DISTINCT FROM dp.LotNumber
 LEFT JOIN m_hu shipment_hu ON shipment_hu.m_hu_id = dp.shipment_hu_id
--- 541540: AD_Reference "Clearance", the HU clearance-status list, carried over verbatim
+-- 541540: AD_Reference "Clearance", the HU clearance-status list
 LEFT JOIN ad_ref_list shipment_hulu_clearancestatus
        ON shipment_hulu_clearancestatus.ad_reference_id = 541540::numeric
       AND shipment_hulu_clearancestatus.value::text = shipment_hu.clearancestatus::text
 -- the receipt document's isSOTrx/docstatus and the shipment document's are already enforced in
 -- receipt_trace / shipment_trace_sel, so that both pairing branches see the same eligible documents
 WHERE NOT EXISTS (
-      -- unchanged: this section is for products that were not manufactured
+      -- this section is for products that were not manufactured
       SELECT 1 FROM M_HU_Trace pt
        WHERE pt.LotNumber IS NOT DISTINCT FROM dp.LotNumber
          AND pt.M_Product_ID = dp.M_Product_ID

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
@@ -63,13 +63,16 @@ $$
 -- paired (link_basis) so a proven link is distinguishable from a guess.
 -- =====================================================================================
 WITH RECURSIVE
--- Every transformation edge: the source VHU became the target VHU. On a production dataset every
--- target VHU has exactly one source, so the graph is a forest and attributing a shipped VHU back
--- to one received VHU is unambiguous. The walk below runs the other way --
--- forward, from a receipt to everything it became -- and may legitimately fan out, one received
--- pallet split into many shipped pieces. Deliberately NOT restricted to T_Selection: whether a
--- TRANSFORM_LOAD edge is in the selection depends on how the caller's recursion happened to reach
--- it, so the walk must not depend on it.
+-- Every descent edge: any trace row that records a source VHU, whatever its trace type -- the
+-- transformation splits, and customer returns, which record the originally-shipped VHU as the
+-- source and so still run forward along physical descent. The COLUMN defines the edge set, not
+-- the type: adding a trace-type predicate here would silently drop return-chain traceability,
+-- and no test would go red. On a production dataset every target VHU has exactly one source, so
+-- the graph is a forest and attributing a shipped VHU back to one received VHU is unambiguous.
+-- The walk below runs the other way -- forward, from a receipt to everything it became -- and may
+-- legitimately fan out, one received pallet split into many shipped pieces. Deliberately not
+-- restricted by trace type or by T_Selection: whether such a row is in the selection depends on
+-- how the caller's recursion happened to reach it, so the walk must not depend on it.
 vhu_edge AS (
     SELECT DISTINCT t.VHU_Source_ID AS src, t.VHU_ID AS dst
     FROM M_HU_Trace t

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
@@ -103,9 +103,10 @@ receipt_reach (M_HU_Trace_ID, VHU_ID, depth) AS (
     FROM receipt_reach rr
     JOIN vhu_edge e ON e.src = rr.VHU_ID
     -- Termination guard against a runaway or cyclic transformation chain: UNION alone cannot stop
-    -- a cycle here because the depth column makes every revisit a distinct row. The longest chain
-    -- measured on a production dataset (25 816 trace rows, 12 908 transformation edges) was 2 hops,
-    -- so 15 is far above anything real while still bounding a corrupt graph.
+    -- a cycle here because the depth column makes every revisit a distinct row. On a production
+    -- dataset of 25 816 trace rows, of which 12 908 carry a source VHU (the distinct edge count is
+    -- at most that, since vhu_edge de-duplicates and drops self-edges), the longest chain measured
+    -- was 2 hops -- so 15 is far above anything real while still bounding a corrupt graph.
     WHERE rr.depth < 15
 ),
 -- The MATERIAL_SHIPMENT rows this run is about, narrowed to rows whose document qualifies as a
@@ -142,7 +143,14 @@ traced_pair AS (
            -- UOMs would print the sum under only one of them.
            min(st.C_UOM_ID)      AS shipment_uom_id,
            min(r.C_UOM_ID)       AS receipt_uom_id,
-           -- client/org of the receipt TRACE ROW, the source the pre-rewrite prod_stock used
+           -- client/org of the receipt TRACE ROW, the source the pre-rewrite prod_stock used.
+           -- Reducing them with min() is safe because the rows of one group agree: the writer of a
+           -- MATERIAL_RECEIPT trace takes its org from the document's own M_HU_Assignment rows
+           -- (HUTraceEventsService.createAndAddEvents), and never sets the client at all, so the
+           -- row carries the installation's default. Were that ever violated, min() would pick the
+           -- numerically smallest -- org '*' = 0 being the likely one -- and all three of product,
+           -- client and org are equality filters inside getcurrentstoragestock, so prod_stock
+           -- would silently read 0 instead of the real stock.
            min(r.AD_Client_ID)   AS receipt_client_id,
            min(r.AD_Org_ID)      AS receipt_org_id
     FROM receipt_trace r

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
@@ -166,7 +166,8 @@ traced_pair AS (
 -- guard above rejected: such a pair does not match here either, so it is DROPPED rather than
 -- demoted to a candidate. Deliberate. A relabelling the data does not explain is not evidence of
 -- a product-level link, and admitting one would re-open the cartesian at product granularity --
--- every receipt of the product against every shipment of it -- which is the defect being fixed.
+-- every receipt of the product against every shipment of it -- the very failure these pairing
+-- rules exist to prevent.
 -- Silence is the honest answer; PRODUCT_CANDIDATE keeps its single meaning of "neither side
 -- carries a lot number".
 -- The GROUP BY carries the same row identity as traced_pair above.

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
@@ -67,9 +67,9 @@ WITH RECURSIVE
 -- target VHU has exactly one source, so the graph is a forest and attributing a shipped VHU back
 -- to one received VHU is unambiguous. The walk below runs the other way --
 -- forward, from a receipt to everything it became -- and may legitimately fan out, one received
--- pallet split into many shipped pieces. Deliberately NOT restricted to T_Selection:
--- TRANSFORM_LOAD is not one of the reported trace types, so the edges never appear in the
--- selection even though the path between two selected rows runs over them.
+-- pallet split into many shipped pieces. Deliberately NOT restricted to T_Selection: whether a
+-- TRANSFORM_LOAD edge is in the selection depends on how the caller's recursion happened to reach
+-- it, so the walk must not depend on it.
 vhu_edge AS (
     SELECT DISTINCT t.VHU_Source_ID AS src, t.VHU_ID AS dst
     FROM M_HU_Trace t

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
@@ -47,7 +47,8 @@ create function m_hu_trace_report(p_ad_pinstance_id numeric)
         shipment_date              character varying,
         prod_stock                 numeric,
         traceid                    numeric,
-        reportdate                 character varying
+        reportdate                 character varying,
+        link_basis                 character varying
     )
     stable
     language sql
@@ -83,7 +84,8 @@ SELECT distinct
     null::varchar as shipment_date,
     null::numeric AS prod_stock,
     null::numeric AS traceid,
-    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    null as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
@@ -136,7 +138,8 @@ SELECT DISTINCT ON (t.m_inout_ID)
     null::varchar as shipment_date,
     null::numeric AS prod_stock,
     null::numeric AS traceid,
-    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    null as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
@@ -181,7 +184,8 @@ SELECT
     null::varchar as shipment_date,
     null::numeric AS prod_stock,
     null::numeric AS traceid,
-    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    null as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
@@ -223,7 +227,8 @@ SELECT DISTINCT ON (t.pp_cost_collector_id)
     null::varchar as shipment_date,
     null::numeric AS prod_stock,
     null::numeric AS traceid,
-    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    null as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
@@ -268,7 +273,8 @@ SELECT DISTINCT
     (select to_char(inout.movementdate, 'DD.MM.YYYY') from M_HU_Trace as trc left join m_inout inout on trc.m_inout_id = inout.m_inout_id where trc.lotnumber=prod_trace.lotnumber and trc.hutracetype='MATERIAL_RECEIPT' limit 1) as shipment_date,
     getcurrentstoragestock(t.m_product_id, t.c_uom_id, 1000017, prod_trace.lotnumber, t.ad_client_id, t.ad_org_id) AS prod_stock,
     prod_trace.m_hu_trace_id,
-    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    null as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
@@ -322,7 +328,8 @@ SELECT DISTINCT
     to_char(shipment_io.movementdate, 'DD.MM.YYYY') as shipment_date,
     getcurrentstoragestock(t.m_product_id, t.c_uom_id, 1000017, shipment_trace.lotnumber, t.ad_client_id, t.ad_org_id) AS prod_stock,
     shipment_trace.m_hu_trace_id,
-    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    null as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
@@ -393,7 +400,8 @@ SELECT
     null::varchar as shipment_date,
     null::numeric AS prod_stock,
     null::numeric AS traceid,
-    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    null as link_basis
 FROM M_HU_Trace t
 JOIN M_Product p ON t.m_product_id = p.m_product_id
 JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
@@ -13,7 +13,8 @@
 -- KEY CHANGES:
 -- - Added new section "DIRECT_SALE_DETAIL" (similar to PRODUCTION_RECEIPT_DETAL)
 -- - This new section traces non-manufactured products from purchase receipt to customer shipment
--- - Links purchase receipts (issotrx=N) to sales shipments (issotrx=Y) via lot numbers
+-- - Links purchase receipts (issotrx=N) to sales shipments (issotrx=Y) along the M_HU_Trace
+--   transformation graph, falling back to labelled lot-level guesses where the graph is silent
 -- - Shows vendor information from purchase and customer information from shipment
 -- - Enhanced Material Receipts and Material Shipments sections to better handle both flows
 -- =====================================================================================
@@ -54,6 +55,158 @@ create function m_hu_trace_report(p_ad_pinstance_id numeric)
     language sql
 as
 $$
+-- =====================================================================================
+-- SHARED CTE BLOCK
+-- Used by SECTION 6 (DIRECT SALE DETAILS) only; the other sections do not reference it.
+-- It derives the receipt-to-shipment pairing from the M_HU_Trace transformation graph
+-- (VHU_Source_ID -> VHU_ID edges) instead of from lot number and product alone, and labels
+-- every emitted pair with the basis on which it was paired (link_basis).
+-- =====================================================================================
+WITH RECURSIVE
+-- Every transformation edge: the source VHU became the target VHU. Measured on the customer
+-- instance every target VHU has exactly one source, so the graph is a forest and attributing a
+-- shipped VHU back to one received VHU is unambiguous. The walk below runs the other way --
+-- forward, from a receipt to everything it became -- and may legitimately fan out, one received
+-- pallet split into many shipped pieces. Deliberately NOT restricted to T_Selection:
+-- TRANSFORM_LOAD is not one of the reported trace types, so the edges never appear in the
+-- selection even though the path between two selected rows runs over them.
+vhu_edge AS (
+    SELECT DISTINCT t.VHU_Source_ID AS src, t.VHU_ID AS dst
+    FROM M_HU_Trace t
+    WHERE t.VHU_Source_ID IS NOT NULL
+      AND t.VHU_ID IS NOT NULL
+      AND t.VHU_Source_ID <> t.VHU_ID
+),
+-- The MATERIAL_RECEIPT rows this report run is about, already narrowed to rows whose document
+-- qualifies as a purchase receipt. Filtering here rather than in the final WHERE keeps the
+-- traced and the candidate branch working off exactly the same set of eligible receipts, so a
+-- pair that the final projection would discard can never suppress the candidates of its group.
+receipt_trace AS (
+    SELECT t.M_HU_Trace_ID, t.VHU_ID, t.M_HU_ID, t.M_Product_ID, t.LotNumber, t.M_InOut_ID, t.C_UOM_ID
+    FROM M_HU_Trace t
+    JOIN M_InOut receipt_io ON receipt_io.M_InOut_ID = t.M_InOut_ID
+    JOIN C_DocType receipt_dt ON receipt_dt.C_DocType_ID = receipt_io.C_DocType_ID
+    WHERE t.HUTraceType = 'MATERIAL_RECEIPT'
+      AND t.VHU_ID IS NOT NULL
+      AND receipt_dt.IsSOTrx = 'N'
+      AND receipt_io.DocStatus IN ('CO', 'CL')
+      AND EXISTS (SELECT 1 FROM T_Selection s
+                   WHERE s.AD_PInstance_ID = p_AD_PInstance_ID
+                     AND s.T_Selection_ID = t.M_HU_Trace_ID)
+),
+-- Forward walk from each receipt VHU. Depth 0 is the receipt's own VHU, which covers the
+-- received-and-shipped-without-repacking case; deeper rows follow the transformation edges.
+receipt_reach (M_HU_Trace_ID, VHU_ID, depth) AS (
+    SELECT r.M_HU_Trace_ID, r.VHU_ID, 0
+    FROM receipt_trace r
+    UNION
+    SELECT rr.M_HU_Trace_ID, e.dst, rr.depth + 1
+    FROM receipt_reach rr
+    JOIN vhu_edge e ON e.src = rr.VHU_ID
+    -- Termination guard against a runaway or cyclic transformation chain: UNION alone cannot stop
+    -- a cycle here because the depth column makes every revisit a distinct row. Measured on the
+    -- customer instance the chains are one hop long (see round2-results.md), so 15 is far above
+    -- anything real while still bounding a corrupt graph.
+    WHERE rr.depth < 15
+),
+-- The MATERIAL_SHIPMENT rows this run is about, narrowed to rows whose document qualifies as a
+-- customer shipment. Restricting the shipment side to the selection is new: previously only the
+-- receipt side was restricted, so a shipment outside the report's scope could still be paired.
+shipment_trace_sel AS (
+    SELECT t.M_HU_Trace_ID, t.VHU_ID, t.M_HU_ID, t.M_Product_ID, t.LotNumber, t.M_InOut_ID, t.C_UOM_ID
+    FROM M_HU_Trace t
+    JOIN M_InOut shipment_io ON shipment_io.M_InOut_ID = t.M_InOut_ID
+    JOIN C_DocType shipment_dt ON shipment_dt.C_DocType_ID = shipment_io.C_DocType_ID
+    WHERE t.HUTraceType = 'MATERIAL_SHIPMENT'
+      AND t.VHU_ID IS NOT NULL
+      AND shipment_dt.IsSOTrx = 'Y'
+      AND shipment_io.DocStatus IN ('CO', 'CL')
+      AND EXISTS (SELECT 1 FROM T_Selection s
+                   WHERE s.AD_PInstance_ID = p_AD_PInstance_ID
+                     AND s.T_Selection_ID = t.M_HU_Trace_ID)
+),
+-- A pair is TRACED when the shipped VHU is reachable from the receipt VHU AND the two trace rows
+-- agree on lot. Lot agreement is a consistency guard, not the pairing criterion: transformation
+-- edges do connect trace rows carrying different lot numbers, and the report must not assert a
+-- link across a relabelling it cannot explain.
+-- The GROUP BY is the report row's identity: one row per (receipt document, shipment document,
+-- product, lot), however many VHUs and trace rows the two documents carry for that product and
+-- lot. This is de-duplication by construction, not by a DISTINCT over the projected columns.
+traced_pair AS (
+    SELECT r.M_InOut_ID AS receipt_inout_id, r.M_Product_ID, r.LotNumber,
+           st.M_InOut_ID AS shipment_inout_id,
+           min(st.M_HU_Trace_ID) AS shipment_trace_id,
+           min(r.M_HU_ID)        AS receipt_hu_id,
+           min(st.M_HU_ID)       AS shipment_hu_id,
+           min(st.C_UOM_ID)      AS shipment_uom_id,
+           min(r.C_UOM_ID)       AS receipt_uom_id
+    FROM receipt_trace r
+    JOIN receipt_reach rr ON rr.M_HU_Trace_ID = r.M_HU_Trace_ID
+    JOIN shipment_trace_sel st
+           ON st.VHU_ID       = rr.VHU_ID
+          AND st.M_Product_ID = r.M_Product_ID
+          AND st.LotNumber IS NOT DISTINCT FROM r.LotNumber
+    GROUP BY r.M_InOut_ID, r.M_Product_ID, r.LotNumber, st.M_InOut_ID
+),
+-- Lot-level guesses, emitted ONLY for the (shipment document, product, lot) groups the graph
+-- leaves empty. A group with a traced receipt never also shows candidates.
+-- The lot condition below is also what decides the fate of a graph-connected pair that the lot
+-- guard above rejected: such a pair does not match here either, so it is DROPPED rather than
+-- demoted to a candidate. Deliberate. A relabelling the data does not explain is not evidence of
+-- a product-level link, and admitting one would re-open the cartesian at product granularity --
+-- every receipt of the product against every shipment of it -- which is the defect being fixed.
+-- Silence is the honest answer; PRODUCT_CANDIDATE keeps its single meaning of "neither side
+-- carries a lot number".
+-- The GROUP BY carries the same row identity as traced_pair above.
+candidate_pair AS (
+    SELECT r.M_InOut_ID AS receipt_inout_id, r.M_Product_ID, r.LotNumber,
+           st.M_InOut_ID AS shipment_inout_id,
+           min(st.M_HU_Trace_ID) AS shipment_trace_id,
+           min(r.M_HU_ID)        AS receipt_hu_id,
+           min(st.M_HU_ID)       AS shipment_hu_id,
+           min(st.C_UOM_ID)      AS shipment_uom_id,
+           min(r.C_UOM_ID)       AS receipt_uom_id
+    FROM receipt_trace r
+    JOIN shipment_trace_sel st
+           ON st.M_Product_ID = r.M_Product_ID
+          AND st.LotNumber IS NOT DISTINCT FROM r.LotNumber
+    WHERE NOT EXISTS (
+        SELECT 1 FROM traced_pair tp
+         WHERE tp.shipment_inout_id = st.M_InOut_ID
+           AND tp.M_Product_ID      = st.M_Product_ID
+           AND tp.LotNumber IS NOT DISTINCT FROM st.LotNumber
+    )
+    GROUP BY r.M_InOut_ID, r.M_Product_ID, r.LotNumber, st.M_InOut_ID
+),
+detail_pair AS (
+    SELECT tp.*, 'TRACED'::varchar AS link_basis FROM traced_pair tp
+    UNION ALL
+    -- No lot on either side means the pair rests on product equality alone; a shared lot number
+    -- is the stronger of the two guesses and is labelled apart from it.
+    SELECT cp.*,
+           (CASE WHEN cp.LotNumber IS NULL THEN 'PRODUCT_CANDIDATE' ELSE 'LOT_CANDIDATE' END)::varchar
+      FROM candidate_pair cp
+),
+-- Document-level received quantity per (receipt document, product, lot). GROUP BY puts all NULL
+-- lots in one group, which is what the IS NOT DISTINCT FROM join below matches; a combination
+-- with no rows produces no join partner and therefore a NULL quantity, exactly as a correlated
+-- SUM over no rows would.
+receipt_doc_qty AS (
+    SELECT rt.M_InOut_ID, rt.M_Product_ID, rt.LotNumber, SUM(rt.Qty) AS qty_sum
+    FROM M_HU_Trace rt
+    WHERE rt.HUTraceType = 'MATERIAL_RECEIPT'
+      AND rt.M_InOut_ID IS NOT NULL
+    GROUP BY rt.M_InOut_ID, rt.M_Product_ID, rt.LotNumber
+),
+-- Document-level shipped quantity per (shipment document, product, lot). finished_product_qty
+-- and shipmentqty are the same figure under two column names, so both read this one CTE.
+shipment_doc_qty AS (
+    SELECT stq.M_InOut_ID, stq.M_Product_ID, stq.LotNumber, SUM(stq.Qty) AS qty_sum
+    FROM M_HU_Trace stq
+    WHERE stq.HUTraceType = 'MATERIAL_SHIPMENT'
+      AND stq.M_InOut_ID IS NOT NULL
+    GROUP BY stq.M_InOut_ID, stq.M_Product_ID, stq.LotNumber
+)
 -- =====================================================================================
 -- SECTION 1: CURRENT STOCK
 -- Shows current inventory levels for all products (manufactured and non-manufactured)
@@ -297,76 +450,86 @@ WHERE t.hutracetype IN ('PRODUCTION_RECEIPT')
 UNION ALL
 
 -- =====================================================================================
--- SECTION 6: DIRECT SALE DETAILS (NEW - Non-Manufactured Products)
--- This is the NEW section that handles the direct purchase-to-sale flow
--- Links material receipts from vendors (issotrx=N) to material shipments to customers (issotrx=Y)
--- Provides complete traceability for non-manufactured products from purchase to sale
+-- SECTION 6: DIRECT SALE DETAILS (Non-Manufactured Products)
+-- Handles the direct purchase-to-sale flow: material receipts from vendors (issotrx=N) paired
+-- with material shipments to customers (issotrx=Y).
+-- The pairing is derived in the CTE block at the top of this function: a pair is TRACED when the
+-- shipped VHU is reachable from the received VHU along the transformation graph and both ends
+-- agree on lot; where the graph is silent for a (shipment document, product, lot) group, the
+-- lot-level or product-level guesses are emitted for that group instead, and say so in link_basis.
+-- One row per (receipt document, shipment document, product, lot) -- the aggregation that produces
+-- that identity lives in traced_pair / candidate_pair, so no DISTINCT is needed or wanted here:
+-- a duplicate would be a defect in the pairing and must stay visible rather than be swallowed.
 -- =====================================================================================
-SELECT DISTINCT
-    t.LotNumber AS LotNumber,
+SELECT
+    dp.LotNumber AS LotNumber,
     'DIRECT_SALE_DETAIL' AS HUTraceType,
     p.value || '_' || p.name AS Product,
     receipt_io.documentno AS InOut,
     NULL AS PPOrder,
     NULL AS Inventory,
     receipt_io.movementdate AS DocumentDate,
-    null::numeric AS Qty,
-    u.uomsymbol AS UOM,
-    shipment_trace.HUTraceType as detail_type,
-    shipment_product.value as finished_product_no,
-    shipment_product.name as finished_product_name,
-    ABS(ROUND(shipment_trace.qty, shipment_uom.stdprecision)) as finished_product_qty,
-    shipment_uom.uomsymbol as finished_product_uom,
-    shipment_trace.lotnumber as finished_product_lot,
-    (select value from m_hu_attribute vendorlot where m_hu_id = t.m_hu_id and m_attribute_id = 1000029::numeric) as vendorlot,
-    (select to_char(valuedate, 'DD.MM.YYYY') from m_hu_attribute mhd where mhd.m_hu_id = shipment_trace.m_hu_id and mhd.m_attribute_id = 540020::numeric) as finished_product_mhd,
+    -- the receipt document's own quantity for this product and lot, summed over the document's
+    -- VHUs. Was always NULL in this section, which is why the received-versus-shipped proportion
+    -- could not be judged from the row.
+    ABS(ROUND(rq.qty_sum, COALESCE(ru.stdprecision, 0))) AS Qty,
+    ru.uomsymbol AS UOM,
+    'MATERIAL_SHIPMENT' as detail_type,
+    p.value as finished_product_no,
+    p.name as finished_product_name,
+    ABS(ROUND(sq.qty_sum, COALESCE(su.stdprecision, 0))) as finished_product_qty,
+    su.uomsymbol as finished_product_uom,
+    dp.LotNumber as finished_product_lot,
+    -- 1000029: the vendor-lot M_HU_Attribute, carried over verbatim from the previous body
+    (select value from m_hu_attribute vendorlot
+      where vendorlot.m_hu_id = dp.receipt_hu_id and vendorlot.m_attribute_id = 1000029::numeric) as vendorlot,
+    -- 540020: M_Attribute HU_BestBeforeDate (Mindesthaltbarkeit), carried over verbatim
+    (select to_char(valuedate, 'DD.MM.YYYY') from m_hu_attribute mhd
+      where mhd.m_hu_id = dp.shipment_hu_id and mhd.m_attribute_id = 540020::numeric) as finished_product_mhd,
     shipment_hulu_clearancestatus.name as finished_product_clearance,
     shipment_bp.value as customer_no,
     shipment_bp.name as customer,
-    ABS(ROUND(shipment_trace.qty, shipment_uom.stdprecision)) as shipmentqty,
+    -- same figure as finished_product_qty above, under the column name the report prints as
+    -- "2_Liefermenge"; both read the one shipment_doc_qty CTE
+    ABS(ROUND(sq.qty_sum, COALESCE(su.stdprecision, 0))) as shipmentqty,
     shipment_io.documentno as shipment_note,
     to_char(shipment_io.movementdate, 'DD.MM.YYYY') as shipment_date,
-    getcurrentstoragestock(t.m_product_id, t.c_uom_id, 1000017, shipment_trace.lotnumber, t.ad_client_id, t.ad_org_id) AS prod_stock,
-    shipment_trace.m_hu_trace_id,
+    -- 1000017: M_Attribute Lot-Nummer. UOM and client/org are taken from the receipt side, which
+    -- is what the pre-rewrite expression used (t.c_uom_id / t.ad_client_id / t.ad_org_id).
+    getcurrentstoragestock(dp.M_Product_ID, dp.receipt_uom_id, 1000017, dp.LotNumber,
+                           receipt_io.ad_client_id, receipt_io.ad_org_id) AS prod_stock,
+    dp.shipment_trace_id AS traceid,
     to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
-    null::varchar as link_basis
-FROM M_HU_Trace t
-JOIN M_Product p ON t.m_product_id = p.m_product_id
-JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
--- Join to the material receipt (purchase from vendor, issotrx=N)
-LEFT JOIN M_InOut receipt_io ON t.m_inout_id = receipt_io.m_inout_id
-LEFT JOIN C_DocType receipt_dt ON receipt_io.c_doctype_id = receipt_dt.c_doctype_id
-LEFT JOIN c_bpartner receipt_bp ON receipt_io.c_bpartner_id = receipt_bp.c_bpartner_id
--- Join to the material shipment (sale to customer, issotrx=Y) via lot number and product
-LEFT JOIN M_HU_Trace as shipment_trace ON
-    shipment_trace.lotnumber IS NOT DISTINCT FROM t.lotnumber
-    AND shipment_trace.m_product_id = t.m_product_id
-    AND shipment_trace.hutracetype = 'MATERIAL_SHIPMENT'
-LEFT JOIN M_InOut shipment_io ON shipment_trace.m_inout_id = shipment_io.m_inout_id
-LEFT JOIN C_DocType shipment_dt ON shipment_io.c_doctype_id = shipment_dt.c_doctype_id
+    dp.link_basis
+FROM detail_pair dp
+JOIN M_Product p         ON p.m_product_id = dp.M_Product_ID
+JOIN M_InOut receipt_io  ON receipt_io.m_inout_id = dp.receipt_inout_id
+JOIN M_InOut shipment_io ON shipment_io.m_inout_id = dp.shipment_inout_id
 LEFT JOIN c_bpartner shipment_bp ON shipment_io.c_bpartner_id = shipment_bp.c_bpartner_id
-JOIN M_Product shipment_product ON shipment_trace.m_product_id = shipment_product.m_product_id
-LEFT JOIN C_UOM shipment_uom on shipment_trace.c_uom_id = shipment_uom.c_uom_id
-LEFT JOIN m_hu shipment_hu ON shipment_trace.m_hu_id = shipment_hu.m_hu_id
-LEFT JOIN ad_ref_list shipment_hulu_clearancestatus ON 
-    shipment_hulu_clearancestatus.ad_reference_id = 541540::numeric 
-    AND shipment_hulu_clearancestatus.value::text = shipment_hu.clearancestatus::text
-WHERE t.hutracetype IN ('MATERIAL_RECEIPT')
-  -- Ensure this is a purchase receipt (from vendor)
-  AND receipt_dt.isSOTrx = 'N'
-  AND receipt_io.docstatus IN ('CO', 'CL')
-  -- Ensure there is a corresponding shipment (to customer)
-  AND shipment_io.m_inout_id IS NOT NULL
-  AND shipment_dt.isSOTrx = 'Y'
-  AND shipment_io.docstatus IN ('CO', 'CL')
-  -- Ensure this product was NOT manufactured (no production order)
-  AND NOT EXISTS (
+LEFT JOIN C_UOM su ON su.c_uom_id = dp.shipment_uom_id
+LEFT JOIN C_UOM ru ON ru.c_uom_id = dp.receipt_uom_id
+LEFT JOIN receipt_doc_qty rq
+       ON rq.M_InOut_ID   = dp.receipt_inout_id
+      AND rq.M_Product_ID = dp.M_Product_ID
+      AND rq.LotNumber IS NOT DISTINCT FROM dp.LotNumber
+LEFT JOIN shipment_doc_qty sq
+       ON sq.M_InOut_ID   = dp.shipment_inout_id
+      AND sq.M_Product_ID = dp.M_Product_ID
+      AND sq.LotNumber IS NOT DISTINCT FROM dp.LotNumber
+LEFT JOIN m_hu shipment_hu ON shipment_hu.m_hu_id = dp.shipment_hu_id
+-- 541540: AD_Reference "Clearance", the HU clearance-status list, carried over verbatim
+LEFT JOIN ad_ref_list shipment_hulu_clearancestatus
+       ON shipment_hulu_clearancestatus.ad_reference_id = 541540::numeric
+      AND shipment_hulu_clearancestatus.value::text = shipment_hu.clearancestatus::text
+-- the receipt document's isSOTrx/docstatus and the shipment document's are already enforced in
+-- receipt_trace / shipment_trace_sel, so that both pairing branches see the same eligible documents
+WHERE NOT EXISTS (
+      -- unchanged: this section is for products that were not manufactured
       SELECT 1 FROM M_HU_Trace pt
-      WHERE pt.lotnumber IS NOT DISTINCT FROM t.lotnumber
-      AND pt.m_product_id = t.m_product_id
-      AND pt.hutracetype IN ('PRODUCTION_ISSUE', 'PRODUCTION_RECEIPT')
+       WHERE pt.LotNumber IS NOT DISTINCT FROM dp.LotNumber
+         AND pt.M_Product_ID = dp.M_Product_ID
+         AND pt.HUTraceType IN ('PRODUCTION_ISSUE', 'PRODUCTION_RECEIPT')
   )
-  AND EXISTS (SELECT 1 FROM T_Selection s WHERE s.AD_PInstance_ID = p_AD_PInstance_ID AND s.T_Selection_ID = t.m_hu_trace_id)
 
 UNION ALL
 

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/5821840_sys_M_HU_Trace_Report_GraphPairing.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/5821840_sys_M_HU_Trace_Report_GraphPairing.sql
@@ -1,0 +1,635 @@
+-- Source DDL: backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/M_HU_Trace_Report.sql
+
+-- =====================================================================================
+-- MODIFIED M_HU_Trace_Report Function
+-- =====================================================================================
+-- MODIFICATION SUMMARY:
+-- This function has been extended to support TWO product flows:
+-- 
+-- 1. MANUFACTURED PRODUCTS (Original Flow):
+--    Purchase → Material Receipt → Manufacturing (Production Issue/Receipt) → Shipment
+--
+-- 2. NON-MANUFACTURED PRODUCTS (New Flow - Added):
+--    Purchase → Material Receipt (issotrx=N) → Shipment (issotrx=Y)
+--
+-- KEY CHANGES:
+-- - Added new section "DIRECT_SALE_DETAIL" (similar to PRODUCTION_RECEIPT_DETAL)
+-- - This new section traces non-manufactured products from purchase receipt to customer shipment
+-- - Links purchase receipts (issotrx=N) to sales shipments (issotrx=Y) along the M_HU_Trace
+--   transformation graph, falling back to labelled lot-level guesses where the graph is silent
+-- - Shows vendor information from purchase and customer information from shipment
+-- - Enhanced Material Receipts and Material Shipments sections to better handle both flows
+-- =====================================================================================
+
+drop function if exists m_hu_trace_report(numeric);
+
+create function m_hu_trace_report(p_ad_pinstance_id numeric)
+    returns TABLE(
+        lotnumber                  character varying,
+        hutracetype                character varying,
+        product                    character varying,
+        "InOut"                    character varying,
+        pporder                    character varying,
+        inventory                  character varying,
+        documentdate               timestamp with time zone,
+        qty                        numeric,
+        uom                        character varying,
+        detail_type                character varying,
+        finished_product_no        character varying,
+        finished_product_name      character varying,
+        finished_product_qty       numeric,
+        finished_product_uom       character varying,
+        finished_product_lot       character varying,
+        vendor_lot                 character varying,
+        finished_product_mhd       character varying,
+        finished_product_clearance character varying,
+        customer_vendor_no         character varying,
+        customer_vendor            character varying,
+        shipmentqty                numeric,
+        shipment_note              character varying,
+        shipment_date              character varying,
+        prod_stock                 numeric,
+        traceid                    numeric,
+        reportdate                 character varying,
+        link_basis                 character varying
+    )
+    stable
+    language sql
+as
+$$
+-- =====================================================================================
+-- SHARED CTE BLOCK
+-- Used by SECTION 6 (DIRECT SALE DETAILS) only; the other sections do not reference it.
+-- It derives the receipt-to-shipment pairing from the M_HU_Trace transformation graph
+-- (VHU_Source_ID -> VHU_ID edges), and labels every emitted pair with the basis on which it was
+-- paired (link_basis) so a proven link is distinguishable from a guess.
+-- =====================================================================================
+WITH RECURSIVE
+-- Every descent edge: any trace row that records a source VHU, whatever its trace type -- the
+-- transformation splits, and customer returns, which record the originally-shipped VHU as the
+-- source and so still run forward along physical descent. The COLUMN defines the edge set, not
+-- the type: adding a trace-type predicate here would silently drop return-chain traceability,
+-- and no test would go red. On a production dataset every target VHU has exactly one source, so
+-- the graph is a forest and attributing a shipped VHU back to one received VHU is unambiguous.
+-- The walk below runs the other way -- forward, from a receipt to everything it became -- and may
+-- legitimately fan out, one received pallet split into many shipped pieces. Deliberately not
+-- restricted by trace type or by T_Selection: whether such a row is in the selection depends on
+-- how the caller's recursion happened to reach it, so the walk must not depend on it.
+vhu_edge AS (
+    SELECT DISTINCT t.VHU_Source_ID AS src, t.VHU_ID AS dst
+    FROM M_HU_Trace t
+    WHERE t.VHU_Source_ID IS NOT NULL
+      AND t.VHU_Source_ID <> t.VHU_ID
+),
+-- The MATERIAL_RECEIPT rows this report run is about, already narrowed to rows whose document
+-- qualifies as a purchase receipt. Filtering here rather than in the final WHERE keeps the
+-- traced and the candidate branch working off exactly the same set of eligible receipts, so a
+-- pair that the final projection would discard can never suppress the candidates of its group.
+receipt_trace AS (
+    SELECT t.M_HU_Trace_ID, t.VHU_ID, t.M_HU_ID, t.M_Product_ID, t.LotNumber, t.M_InOut_ID, t.C_UOM_ID,
+           t.AD_Client_ID, t.AD_Org_ID
+    FROM M_HU_Trace t
+    JOIN M_InOut receipt_io ON receipt_io.M_InOut_ID = t.M_InOut_ID
+    JOIN C_DocType receipt_dt ON receipt_dt.C_DocType_ID = receipt_io.C_DocType_ID
+    WHERE t.HUTraceType = 'MATERIAL_RECEIPT'
+      AND receipt_dt.IsSOTrx = 'N'
+      AND receipt_io.DocStatus IN ('CO', 'CL')
+      AND EXISTS (SELECT 1 FROM T_Selection s
+                   WHERE s.AD_PInstance_ID = p_AD_PInstance_ID
+                     AND s.T_Selection_ID = t.M_HU_Trace_ID)
+),
+-- Forward walk from each receipt VHU. Depth 0 is the receipt's own VHU, which covers the
+-- received-and-shipped-without-repacking case; deeper rows follow the transformation edges.
+receipt_reach (M_HU_Trace_ID, VHU_ID, depth) AS (
+    SELECT r.M_HU_Trace_ID, r.VHU_ID, 0
+    FROM receipt_trace r
+    UNION
+    SELECT rr.M_HU_Trace_ID, e.dst, rr.depth + 1
+    FROM receipt_reach rr
+    JOIN vhu_edge e ON e.src = rr.VHU_ID
+    -- Termination guard against a runaway or cyclic transformation chain: UNION alone cannot stop
+    -- a cycle here because the depth column makes every revisit a distinct row. On a production
+    -- dataset of 25 816 trace rows, of which 12 908 carry a source VHU (the distinct edge count is
+    -- at most that, since vhu_edge de-duplicates and drops self-edges), the longest chain measured
+    -- was 2 hops -- so 15 is far above anything real while still bounding a corrupt graph.
+    WHERE rr.depth < 15
+),
+-- The MATERIAL_SHIPMENT rows this run is about, narrowed to rows whose document qualifies as a
+-- customer shipment. Both sides are restricted to the report's selection, so a shipment outside
+-- the run's scope can never be paired.
+shipment_trace_sel AS (
+    SELECT t.M_HU_Trace_ID, t.VHU_ID, t.M_HU_ID, t.M_Product_ID, t.LotNumber, t.M_InOut_ID, t.C_UOM_ID
+    FROM M_HU_Trace t
+    JOIN M_InOut shipment_io ON shipment_io.M_InOut_ID = t.M_InOut_ID
+    JOIN C_DocType shipment_dt ON shipment_dt.C_DocType_ID = shipment_io.C_DocType_ID
+    WHERE t.HUTraceType = 'MATERIAL_SHIPMENT'
+      AND shipment_dt.IsSOTrx = 'Y'
+      AND shipment_io.DocStatus IN ('CO', 'CL')
+      AND EXISTS (SELECT 1 FROM T_Selection s
+                   WHERE s.AD_PInstance_ID = p_AD_PInstance_ID
+                     AND s.T_Selection_ID = t.M_HU_Trace_ID)
+),
+-- A pair is TRACED when the shipped VHU is reachable from the receipt VHU AND the two trace rows
+-- agree on lot. Lot agreement is a consistency guard, not the pairing criterion: transformation
+-- edges do connect trace rows carrying different lot numbers, and the report must not assert a
+-- link across a relabelling it cannot explain.
+-- The GROUP BY is the report row's identity: one row per (receipt document, shipment document,
+-- product, lot), however many VHUs and trace rows the two documents carry for that product and
+-- lot. This is de-duplication by construction, not by a DISTINCT over the projected columns.
+traced_pair AS (
+    SELECT r.M_InOut_ID AS receipt_inout_id, r.M_Product_ID, r.LotNumber,
+           st.M_InOut_ID AS shipment_inout_id,
+           min(st.M_HU_Trace_ID) AS shipment_trace_id,
+           min(r.M_HU_ID)        AS receipt_hu_id,
+           min(st.M_HU_ID)       AS shipment_hu_id,
+           -- assumes every trace row of one document/product/lot shares a UOM. The quantities
+           -- beside these are document-level sums, so a document that genuinely mixed UOMs would
+           -- print the sum under only one of them.
+           min(st.C_UOM_ID)      AS shipment_uom_id,
+           min(r.C_UOM_ID)       AS receipt_uom_id,
+           -- client/org of the receipt TRACE ROW, which is what prod_stock below filters on.
+           -- Reducing them with min() is safe because the rows of one group agree: the writer of a
+           -- MATERIAL_RECEIPT trace takes its org from the document's own M_HU_Assignment rows
+           -- (HUTraceEventsService.createAndAddEvents), and never sets the client at all, so the
+           -- row carries the installation's default. Were that ever violated, min() would pick the
+           -- numerically smallest -- org '*' = 0 being the likely one -- and all three of product,
+           -- client and org are equality filters inside getcurrentstoragestock, so prod_stock
+           -- would silently read 0 instead of the real stock.
+           min(r.AD_Client_ID)   AS receipt_client_id,
+           min(r.AD_Org_ID)      AS receipt_org_id
+    FROM receipt_trace r
+    JOIN receipt_reach rr ON rr.M_HU_Trace_ID = r.M_HU_Trace_ID
+    JOIN shipment_trace_sel st
+           ON st.VHU_ID       = rr.VHU_ID
+          AND st.M_Product_ID = r.M_Product_ID
+          AND st.LotNumber IS NOT DISTINCT FROM r.LotNumber
+    GROUP BY r.M_InOut_ID, r.M_Product_ID, r.LotNumber, st.M_InOut_ID
+),
+-- Lot-level guesses, emitted ONLY for the (shipment document, product, lot) groups the graph
+-- leaves empty. A group with a traced receipt never also shows candidates.
+-- The lot condition below is also what decides the fate of a graph-connected pair that the lot
+-- guard above rejected: such a pair does not match here either, so it is DROPPED rather than
+-- demoted to a candidate. Deliberate. A relabelling the data does not explain is not evidence of
+-- a product-level link, and admitting one would re-open the cartesian at product granularity --
+-- every receipt of the product against every shipment of it -- the very failure these pairing
+-- rules exist to prevent.
+-- Silence is the honest answer; PRODUCT_CANDIDATE keeps its single meaning of "neither side
+-- carries a lot number".
+-- The GROUP BY carries the same row identity as traced_pair above.
+candidate_pair AS (
+    SELECT r.M_InOut_ID AS receipt_inout_id, r.M_Product_ID, r.LotNumber,
+           st.M_InOut_ID AS shipment_inout_id,
+           min(st.M_HU_Trace_ID) AS shipment_trace_id,
+           min(r.M_HU_ID)        AS receipt_hu_id,
+           min(st.M_HU_ID)       AS shipment_hu_id,
+           -- same UOM and client/org assumptions as traced_pair above
+           min(st.C_UOM_ID)      AS shipment_uom_id,
+           min(r.C_UOM_ID)       AS receipt_uom_id,
+           min(r.AD_Client_ID)   AS receipt_client_id,
+           min(r.AD_Org_ID)      AS receipt_org_id
+    FROM receipt_trace r
+    JOIN shipment_trace_sel st
+           ON st.M_Product_ID = r.M_Product_ID
+          AND st.LotNumber IS NOT DISTINCT FROM r.LotNumber
+    WHERE NOT EXISTS (
+        SELECT 1 FROM traced_pair tp
+         WHERE tp.shipment_inout_id = st.M_InOut_ID
+           AND tp.M_Product_ID      = st.M_Product_ID
+           AND tp.LotNumber IS NOT DISTINCT FROM st.LotNumber
+    )
+    GROUP BY r.M_InOut_ID, r.M_Product_ID, r.LotNumber, st.M_InOut_ID
+),
+detail_pair AS (
+    SELECT tp.*, 'TRACED'::varchar AS link_basis FROM traced_pair tp
+    UNION ALL
+    -- No lot on either side means the pair rests on product equality alone; a shared lot number
+    -- is the stronger of the two guesses and is labelled apart from it.
+    SELECT cp.*,
+           (CASE WHEN cp.LotNumber IS NULL THEN 'PRODUCT_CANDIDATE' ELSE 'LOT_CANDIDATE' END)::varchar
+      FROM candidate_pair cp
+),
+-- Document-level received quantity per (receipt document, product, lot). GROUP BY puts all NULL
+-- lots in one group, which is what the IS NOT DISTINCT FROM join below matches; a combination
+-- with no rows produces no join partner and therefore a NULL quantity, exactly as a correlated
+-- SUM over no rows would.
+-- The IN restricts the set of DOCUMENTS grouped here, never the rows summed for one of them, so
+-- the quantity stays the document's full total. It is not a filter but a bound: the only document
+-- ids this CTE is ever probed with come from receipt_trace, and without it every invocation of the
+-- function would aggregate the whole of M_HU_Trace even when this section emits nothing.
+receipt_doc_qty AS (
+    SELECT rt.M_InOut_ID, rt.M_Product_ID, rt.LotNumber, SUM(rt.Qty) AS qty_sum
+    FROM M_HU_Trace rt
+    WHERE rt.HUTraceType = 'MATERIAL_RECEIPT'
+      AND rt.M_InOut_ID IN (SELECT M_InOut_ID FROM receipt_trace)
+    GROUP BY rt.M_InOut_ID, rt.M_Product_ID, rt.LotNumber
+),
+-- Document-level shipped quantity per (shipment document, product, lot). finished_product_qty
+-- and shipmentqty are the same figure under two column names, so both read this one CTE.
+-- Bounded to the shipment documents in scope for the same reason as receipt_doc_qty above.
+shipment_doc_qty AS (
+    SELECT stq.M_InOut_ID, stq.M_Product_ID, stq.LotNumber, SUM(stq.Qty) AS qty_sum
+    FROM M_HU_Trace stq
+    WHERE stq.HUTraceType = 'MATERIAL_SHIPMENT'
+      AND stq.M_InOut_ID IN (SELECT M_InOut_ID FROM shipment_trace_sel)
+    GROUP BY stq.M_InOut_ID, stq.M_Product_ID, stq.LotNumber
+)
+-- =====================================================================================
+-- SECTION 1: CURRENT STOCK
+-- Shows current inventory levels for all products (manufactured and non-manufactured)
+-- =====================================================================================
+SELECT distinct
+    t.LotNumber AS LotNumber,
+    'Current Stock' AS HUTraceType,
+    p.value || '_' || p.name AS Product,
+    NULL AS InOut,
+    NULL AS PPOrder,
+    NULL AS Inventory,
+    NOW() AS DocumentDate,
+    getcurrentstoragestock(t.m_product_id, t.c_uom_id, 1000017, t.lotnumber, t.ad_client_id, t.ad_org_id) AS Qty,
+    u.uomsymbol AS UOM,
+    null as detail_type,
+    null as finished_product_no,
+    null as finished_product_name,
+    null::numeric as finished_product_qty,
+    null as finished_product_uom,
+    null as finished_product_lot,
+    null as vendorlot,
+    null::varchar as finished_product_mhd,
+    null as finished_product_clearance,
+    null as customer_no,
+    null as customer,
+    null::numeric as shipmentqty,
+    null as shipment_note,
+    null::varchar as shipment_date,
+    null::numeric AS prod_stock,
+    null::numeric AS traceid,
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    null::varchar as link_basis
+FROM M_HU_Trace t
+JOIN M_Product p ON t.m_product_id = p.m_product_id
+JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
+LEFT JOIN M_InOut io ON t.m_inout_id = io.m_inout_id
+LEFT JOIN PP_Order po ON t.pp_order_id = po.pp_order_id
+LEFT JOIN M_Inventory i ON t.M_Inventory_ID = i.m_inventory_id
+WHERE t.hutracetype IN ('PRODUCTION_ISSUE', 'PRODUCTION_RECEIPT', 'MATERIAL_RECEIPT', 'MATERIAL_SHIPMENT', 'MATERIAL_INVENTORY')
+  AND EXISTS (SELECT 1 FROM T_Selection s WHERE s.AD_PInstance_ID = p_AD_PInstance_ID AND s.T_Selection_ID = t.m_hu_trace_id)
+
+UNION ALL
+
+-- =====================================================================================
+-- SECTION 2: MATERIAL RECEIPTS
+-- Handles incoming goods from vendors (issotrx=N)
+-- Used for BOTH manufactured (raw materials) and non-manufactured (purchase for resale) products
+-- =====================================================================================
+SELECT DISTINCT ON (t.m_inout_ID)
+    t.LotNumber AS LotNumber,
+    'MATERIAL_RECEIPT' AS HUTraceType,
+    p.value || '_' || p.name AS Product,
+    io.documentno AS InOut,
+    NULL AS PPOrder,
+    NULL AS Inventory,
+    io.movementdate AS DocumentDate,
+    CASE WHEN dt.isSOTrx = 'Y' THEN -1 ELSE 1 END * (SELECT SUM(uomconvert(p.m_product_id, iol.c_uom_id, p.c_uom_id, iol.movementqty))
+                                                     FROM m_inoutline iol
+                                                     WHERE io.m_inout_id = iol.m_inout_id
+                                                     AND iol.m_product_id = p.m_product_id
+                                                     AND EXISTS (SELECT 1 FROM m_hu_assignment hua JOIN m_hu_attribute huat ON hua.m_hu_id = huat.m_hu_id
+                                                                 WHERE hua.ad_table_id = get_table_id('M_InOutLine')
+                                                                 AND hua.record_id = iol.m_inoutline_id
+                                                                 AND huat.m_attribute_id = 1000017
+                                                                 AND ((t.lotnumber IS NOT NULL AND huat.value = t.lotnumber)
+                                                                      OR (t.lotnumber IS NULL AND huat.value IS NULL)
+                                                                 ))) AS Qty,
+    u.uomsymbol AS UOM,
+    null as detail_type,
+    null as finished_product_no,
+    null as finished_product_name,
+    null::numeric as finished_product_qty,
+    null as finished_product_uom,
+    null as finished_product_lot,
+    null as vendorlot,
+    null::varchar as finished_product_mhd,
+    null as finished_product_clearance,
+    null as customer_no,
+    null as customer,
+    null::numeric as shipmentqty,
+    null as shipment_note,
+    null::varchar as shipment_date,
+    null::numeric AS prod_stock,
+    null::numeric AS traceid,
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    null::varchar as link_basis
+FROM M_HU_Trace t
+JOIN M_Product p ON t.m_product_id = p.m_product_id
+JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
+LEFT JOIN M_InOut io ON t.m_inout_id = io.m_inout_id
+LEFT JOIN C_DocType dt ON io.c_doctype_id = dt.c_doctype_id
+LEFT JOIN c_bpartner bp ON io.c_bpartner_id=bp.c_bpartner_id
+LEFT JOIN m_hu_attribute huattrib ON huattrib.m_hu_id=t.m_hu_id AND huattrib.m_hu_attribute_id=1000029
+WHERE t.hutracetype IN ('MATERIAL_RECEIPT')
+  AND io.docstatus IN ('CO', 'CL')
+  AND EXISTS (SELECT 1 FROM T_Selection s WHERE s.AD_PInstance_ID = p_AD_PInstance_ID AND s.T_Selection_ID = t.m_hu_trace_id)
+
+UNION ALL
+
+-- =====================================================================================
+-- SECTION 3: MATERIAL SHIPMENTS
+-- Handles outgoing goods to customers (issotrx=Y)
+-- Used for BOTH manufactured products and non-manufactured (direct resale) products
+-- =====================================================================================
+SELECT
+    t.LotNumber AS LotNumber,
+    'MATERIAL_SHIPMENT' AS HUTraceType,
+    p.value || '_' || p.name AS Product,
+    io.documentno AS InOut,
+    NULL AS PPOrder,
+    NULL AS Inventory,
+    io.movementdate AS DocumentDate,
+    CASE WHEN dt.isSOTrx = 'Y' THEN -1 ELSE 1 END * ROUND(t.qty, u.stdprecision) AS Qty,
+    u.uomsymbol AS UOM,
+    null as detail_type,
+    null as finished_product_no,
+    null as finished_product_name,
+    null::numeric as finished_product_qty,
+    null as finished_product_uom,
+    null as finished_product_lot,
+    null as vendorlot,
+    null::varchar as finished_product_mhd,
+    null as finished_product_clearance,
+    null as customer_no,
+    null as customer,
+    null::numeric as shipmentqty,
+    null as shipment_note,
+    null::varchar as shipment_date,
+    null::numeric AS prod_stock,
+    null::numeric AS traceid,
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    null::varchar as link_basis
+FROM M_HU_Trace t
+JOIN M_Product p ON t.m_product_id = p.m_product_id
+JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
+LEFT JOIN M_InOut io ON t.m_inout_id = io.m_inout_id
+LEFT JOIN C_DocType dt ON io.c_doctype_id = dt.c_doctype_id
+WHERE t.hutracetype IN ('MATERIAL_SHIPMENT')
+  AND io.docstatus IN ('CO', 'CL')
+  AND EXISTS (SELECT 1 FROM T_Selection s WHERE s.AD_PInstance_ID = p_AD_PInstance_ID AND s.T_Selection_ID = t.m_hu_trace_id)
+
+UNION ALL
+
+-- =====================================================================================
+-- SECTION 4: PRODUCTION ISSUE/RECEIPT (Original - Manufactured Products Only)
+-- Handles manufacturing operations: raw materials consumed and finished goods produced
+-- =====================================================================================
+SELECT DISTINCT ON (t.pp_cost_collector_id)
+    t.LotNumber AS LotNumber,
+    t.hutracetype AS HUTraceType,
+    p.value || '_' || p.name AS Product,
+    io.documentno AS InOut,
+    po.documentno AS PPOrder,
+    i.documentno AS Inventory,
+    COALESCE(io.movementdate, cc.movementdate, po.datepromised, i.movementdate) AS DocumentDate,
+    CASE WHEN t.hutracetype = 'PRODUCTION_ISSUE' THEN -1 ELSE 1 END * ROUND(t.qty, u.stdprecision) AS Qty,
+    u.uomsymbol AS UOM,
+    null as detail_type,
+    null as finished_product_no,
+    null as finished_product_name,
+    null::numeric as finished_product_qty,
+    null as finished_product_uom,
+    null as finished_product_lot,
+    null as vendorlot,
+    null::varchar as finished_product_mhd,
+    null as finished_product_clearance,
+    null as customer_no,
+    null as customer,
+    null::numeric as shipmentqty,
+    null as shipment_note,
+    null::varchar as shipment_date,
+    null::numeric AS prod_stock,
+    null::numeric AS traceid,
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    null::varchar as link_basis
+FROM M_HU_Trace t
+JOIN M_Product p ON t.m_product_id = p.m_product_id
+JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
+LEFT JOIN M_InOut io ON t.m_inout_id = io.m_inout_id
+LEFT JOIN PP_cost_collector cc ON t.pp_cost_collector_id = cc.pp_cost_collector_id
+LEFT JOIN PP_Order po ON t.pp_order_id = po.pp_order_id
+LEFT JOIN M_Inventory i ON t.M_Inventory_ID = i.m_inventory_id
+WHERE t.hutracetype IN ('PRODUCTION_ISSUE', 'PRODUCTION_RECEIPT')
+  AND po.docstatus IN ('CO', 'CL')
+  AND EXISTS (SELECT 1 FROM T_Selection s WHERE s.AD_PInstance_ID = p_AD_PInstance_ID AND s.T_Selection_ID = t.m_hu_trace_id)
+
+UNION ALL
+
+-- =====================================================================================
+-- SECTION 5: PRODUCTION RECEIPT DETAILS (Original - Manufactured Products Only)
+-- Shows detailed traceability from raw materials to finished manufactured products
+-- Links production receipts to the raw materials used (production issues)
+-- =====================================================================================
+SELECT DISTINCT
+    t.LotNumber AS LotNumber,
+    'PRODUCTION_RECEIPT_DETAL' AS HUTraceType,
+    p.value || '_' || p.name AS Product,
+    io.documentno AS InOut,
+    po.documentno AS PPOrder,
+    i.documentno AS Inventory,
+    COALESCE(io.movementdate, cc.movementdate, po.datepromised, i.movementdate) AS DocumentDate,
+    null::numeric AS Qty,
+    u.uomsymbol AS UOM,
+    prod_trace.HUTraceType as detail_type,
+    prod_product.value as finished_product_no,
+    prod_product.name as finished_product_name,
+    po.qtyordered as finished_product_qty,
+    prod_uom.uomsymbol as finished_product_uom,
+    prod_trace.lotnumber as finished_product_lot,
+    (select  value from m_hu_attribute vendorlot where m_hu_id = prod_trace.m_hu_id and m_attribute_id = 1000029::numeric) as   vendorlot,
+    (select to_char(valuedate, 'DD.MM.YYYY') from m_hu_attribute mhd where mhd.m_hu_id = prod_trace.m_hu_id and mhd.m_attribute_id = 540020::numeric) as finished_product_mhd,
+    hulu_clearancestatus.name as finished_product_clearance,
+    bp.value as customer_no,
+    bp.name as customer,
+    0 as receivedqty,
+    (select STRING_AGG(distinct inout.documentno, ',') from M_HU_Trace as trc left join m_inout inout on trc.m_inout_id = inout.m_inout_id where trc.lotnumber=prod_trace.lotnumber and trc.hutracetype='MATERIAL_RECEIPT') as receipt_note,
+    (select to_char(inout.movementdate, 'DD.MM.YYYY') from M_HU_Trace as trc left join m_inout inout on trc.m_inout_id = inout.m_inout_id where trc.lotnumber=prod_trace.lotnumber and trc.hutracetype='MATERIAL_RECEIPT' limit 1) as shipment_date,
+    getcurrentstoragestock(t.m_product_id, t.c_uom_id, 1000017, prod_trace.lotnumber, t.ad_client_id, t.ad_org_id) AS prod_stock,
+    prod_trace.m_hu_trace_id,
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    null::varchar as link_basis
+FROM M_HU_Trace t
+JOIN M_Product p ON t.m_product_id = p.m_product_id
+JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
+LEFT JOIN M_InOut io ON t.m_inout_id = io.m_inout_id
+LEFT JOIN PP_cost_collector cc ON t.pp_cost_collector_id = cc.pp_cost_collector_id
+LEFT JOIN PP_Order po ON t.pp_order_id = po.pp_order_id
+LEFT JOIN M_Inventory i ON t.M_Inventory_ID = i.m_inventory_id
+LEFT JOIN M_HU_Trace as prod_trace ON prod_trace.pp_order_id=po.pp_order_id and prod_trace.hutracetype='PRODUCTION_ISSUE'
+JOIN M_Product prod_product ON prod_trace.m_product_id = prod_product.m_product_id
+LEFT JOIN C_UOM prod_uom on prod_trace.c_uom_id = prod_uom.c_uom_id
+LEFT JOIN m_hu hu ON prod_trace.m_hu_id = hu.m_hu_id
+LEFT JOIN m_inout inout on inout.m_inout_id = prod_trace.m_inout_id
+LEFT JOIN c_bpartner bp ON inout.c_bpartner_id = bp.c_bpartner_id
+LEFT JOIN m_hu_attribute mhd ON mhd.m_hu_id = prod_trace.m_hu_id AND mhd.m_attribute_id = 540020::numeric
+LEFT JOIN ad_ref_list hulu_clearancestatus ON hulu_clearancestatus.ad_reference_id = 541540::numeric AND hulu_clearancestatus.value::text = hu.clearancestatus::text
+WHERE t.hutracetype IN ('PRODUCTION_RECEIPT')
+  AND po.docstatus IN ('CO', 'CL')
+  AND EXISTS (SELECT 1 FROM T_Selection s WHERE s.AD_PInstance_ID = p_AD_PInstance_ID AND s.T_Selection_ID = t.m_hu_trace_id)
+
+UNION ALL
+
+-- =====================================================================================
+-- SECTION 6: DIRECT SALE DETAILS (Non-Manufactured Products)
+-- Handles the direct purchase-to-sale flow: material receipts from vendors (issotrx=N) paired
+-- with material shipments to customers (issotrx=Y).
+-- The pairing is derived in the CTE block at the top of this function: a pair is TRACED when the
+-- shipped VHU is reachable from the received VHU along the transformation graph and both ends
+-- agree on lot; where the graph is silent for a (shipment document, product, lot) group, the
+-- lot-level or product-level guesses are emitted for that group instead, and say so in link_basis.
+-- One row per (receipt document, shipment document, product, lot) -- the aggregation that produces
+-- that identity lives in traced_pair / candidate_pair, so no DISTINCT is needed or wanted here:
+-- a duplicate would be a defect in the pairing and must stay visible rather than be swallowed.
+-- =====================================================================================
+SELECT
+    dp.LotNumber AS LotNumber,
+    'DIRECT_SALE_DETAIL' AS HUTraceType,
+    p.value || '_' || p.name AS Product,
+    receipt_io.documentno AS InOut,
+    NULL AS PPOrder,
+    NULL AS Inventory,
+    receipt_io.movementdate AS DocumentDate,
+    -- the receipt document's own quantity for this product and lot, summed over the document's
+    -- VHUs -- so the received-versus-shipped proportion is readable from the row itself.
+    ABS(ROUND(rq.qty_sum, COALESCE(ru.stdprecision, 0))) AS Qty,
+    ru.uomsymbol AS UOM,
+    'MATERIAL_SHIPMENT' as detail_type,
+    p.value as finished_product_no,
+    p.name as finished_product_name,
+    ABS(ROUND(sq.qty_sum, COALESCE(su.stdprecision, 0))) as finished_product_qty,
+    su.uomsymbol as finished_product_uom,
+    dp.LotNumber as finished_product_lot,
+    -- 1000029: M_Attribute (vendor lot) -- the FK m_hu_attribute.m_attribute_id, not the
+    -- m_hu_attribute PK
+    (select value from m_hu_attribute vendorlot
+      where vendorlot.m_hu_id = dp.receipt_hu_id and vendorlot.m_attribute_id = 1000029::numeric) as vendorlot,
+    -- 540020: M_Attribute HU_BestBeforeDate (Mindesthaltbarkeit)
+    (select to_char(valuedate, 'DD.MM.YYYY') from m_hu_attribute mhd
+      where mhd.m_hu_id = dp.shipment_hu_id and mhd.m_attribute_id = 540020::numeric) as finished_product_mhd,
+    shipment_hulu_clearancestatus.name as finished_product_clearance,
+    shipment_bp.value as customer_no,
+    shipment_bp.name as customer,
+    -- same figure as finished_product_qty above, under the column name the report prints as
+    -- "2_Liefermenge"; both read the one shipment_doc_qty CTE
+    ABS(ROUND(sq.qty_sum, COALESCE(su.stdprecision, 0))) as shipmentqty,
+    shipment_io.documentno as shipment_note,
+    to_char(shipment_io.movementdate, 'DD.MM.YYYY') as shipment_date,
+    -- 1000017: M_Attribute Lot-Nummer. UOM and client/org come from the receipt trace row; all
+    -- three are equality filters inside getcurrentstoragestock, so which row they come from matters.
+    getcurrentstoragestock(dp.M_Product_ID, dp.receipt_uom_id, 1000017, dp.LotNumber,
+                           dp.receipt_client_id, dp.receipt_org_id) AS prod_stock,
+    dp.shipment_trace_id AS traceid,
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    dp.link_basis
+FROM detail_pair dp
+JOIN M_Product p         ON p.m_product_id = dp.M_Product_ID
+JOIN M_InOut receipt_io  ON receipt_io.m_inout_id = dp.receipt_inout_id
+JOIN M_InOut shipment_io ON shipment_io.m_inout_id = dp.shipment_inout_id
+LEFT JOIN c_bpartner shipment_bp ON shipment_io.c_bpartner_id = shipment_bp.c_bpartner_id
+LEFT JOIN C_UOM su ON su.c_uom_id = dp.shipment_uom_id
+LEFT JOIN C_UOM ru ON ru.c_uom_id = dp.receipt_uom_id
+LEFT JOIN receipt_doc_qty rq
+       ON rq.M_InOut_ID   = dp.receipt_inout_id
+      AND rq.M_Product_ID = dp.M_Product_ID
+      AND rq.LotNumber IS NOT DISTINCT FROM dp.LotNumber
+LEFT JOIN shipment_doc_qty sq
+       ON sq.M_InOut_ID   = dp.shipment_inout_id
+      AND sq.M_Product_ID = dp.M_Product_ID
+      AND sq.LotNumber IS NOT DISTINCT FROM dp.LotNumber
+LEFT JOIN m_hu shipment_hu ON shipment_hu.m_hu_id = dp.shipment_hu_id
+-- 541540: AD_Reference "Clearance", the HU clearance-status list
+LEFT JOIN ad_ref_list shipment_hulu_clearancestatus
+       ON shipment_hulu_clearancestatus.ad_reference_id = 541540::numeric
+      AND shipment_hulu_clearancestatus.value::text = shipment_hu.clearancestatus::text
+-- the receipt document's isSOTrx/docstatus and the shipment document's are already enforced in
+-- receipt_trace / shipment_trace_sel, so that both pairing branches see the same eligible documents
+WHERE NOT EXISTS (
+      -- this section is for products that were not manufactured
+      SELECT 1 FROM M_HU_Trace pt
+       WHERE pt.LotNumber IS NOT DISTINCT FROM dp.LotNumber
+         AND pt.M_Product_ID = dp.M_Product_ID
+         AND pt.HUTraceType IN ('PRODUCTION_ISSUE', 'PRODUCTION_RECEIPT')
+  )
+
+UNION ALL
+
+-- =====================================================================================
+-- SECTION 7: MATERIAL INVENTORY (Original - Both Product Types)
+-- Handles inventory adjustments for all products
+-- =====================================================================================
+SELECT
+    t.LotNumber AS LotNumber,
+    'MATERIAL_INVENTORY' AS HUTraceType,
+    p.value || '_' || p.name AS Product,
+    io.documentno AS InOut,
+    po.documentno AS PPOrder,
+    i.documentno AS Inventory,
+    COALESCE(io.movementdate, cc.movementdate, po.datepromised, i.movementdate) AS DocumentDate,
+    CASE WHEN i.C_Doctype_ID = 540948 THEN -1 ELSE 1 END * ROUND(t.qty, u.stdprecision) AS Qty,
+    u.uomsymbol AS UOM,
+    null as detail_type,
+    null as finished_product_no,
+    null as finished_product_name,
+    null::numeric as finished_product_qty,
+    null as finished_product_uom,
+    null as finished_product_lot,
+    null as vendorlot,
+    null::varchar as finished_product_mhd,
+    null as finished_product_clearance,
+    null as customer_no,
+    null as customer,
+    null::numeric as shipmentqty,
+    null as shipment_note,
+    null::varchar as shipment_date,
+    null::numeric AS prod_stock,
+    null::numeric AS traceid,
+    to_char(now(), 'DD.MM.YYYY HH24:MM') as reportdate,
+    null::varchar as link_basis
+FROM M_HU_Trace t
+JOIN M_Product p ON t.m_product_id = p.m_product_id
+JOIN C_UOM u ON t.C_UOM_ID = u.c_uom_id
+LEFT JOIN M_InOut io ON t.m_inout_id = io.m_inout_id
+LEFT JOIN PP_cost_collector cc ON t.pp_cost_collector_id = cc.pp_cost_collector_id
+LEFT JOIN PP_Order po ON t.pp_order_id = po.pp_order_id
+LEFT JOIN M_Inventory i ON t.M_Inventory_ID = i.m_inventory_id
+WHERE t.hutracetype = 'MATERIAL_INVENTORY'
+  AND i.docstatus IN ('CO', 'CL')
+  AND EXISTS (SELECT 1 FROM T_Selection s WHERE s.AD_PInstance_ID = p_AD_PInstance_ID AND s.T_Selection_ID = t.m_hu_trace_id)
+
+ORDER BY LotNumber, pporder, HUTraceType, DocumentDate
+$$;
+
+alter function m_hu_trace_report(numeric) owner to metasfresh;
+
+-- =====================================================================================
+-- END OF MODIFIED FUNCTION
+-- =====================================================================================
+-- USAGE NOTES:
+-- 
+-- The modified function now returns results for both flows:
+-- 
+-- For MANUFACTURED products, the result set includes:
+-- - Current Stock
+-- - Material Receipt (raw materials from vendor)
+-- - Production Issue (raw materials consumed in manufacturing)
+-- - Production Receipt (finished goods produced)
+-- - Production Receipt Detail (traceability from raw materials to finished goods)
+-- - Material Shipment (finished goods shipped to customer)
+-- - Material Inventory (inventory adjustments)
+--
+-- For NON-MANUFACTURED products, the result set includes:
+-- - Current Stock
+-- - Material Receipt (products purchased from vendor, issotrx=N)
+-- - Direct Sale Detail (NEW - traceability from purchase to sale with customer info)
+-- - Material Shipment (products shipped to customer, issotrx=Y)
+-- - Material Inventory (inventory adjustments)
+--
+-- The new "DIRECT_SALE_DETAIL" section provides similar detailed traceability for
+-- non-manufactured products as "PRODUCTION_RECEIPT_DETAL" does for manufactured ones.
+-- =====================================================================================


### PR DESCRIPTION
## What this changes

The `DIRECT_SALE_DETAIL` section of `m_hu_trace_report(numeric)` paired purchase receipts to sales
shipments on **lot + product alone** — an N×M cartesian. A shipment drawing on six receipts printed
six rows with no indication which receipt actually supplied the goods, so the report could not answer
the question it exists to answer.

It now pairs along the HU trace graph: a shipped VHU is matched to the received VHU it descends from
(`VHU_Source_ID` edges, or the same VHU), guarded by lot agreement. Where the graph is silent, the
old lot/product pairing is kept but **labelled as a guess** rather than presented as a finding — so
nothing the report shows today disappears, it is just no longer indistinguishable from a proven
pairing.

A 27th column, `Verknüpfung` (`link_basis`), carries that distinction: `TRACED`, `LOT_CANDIDATE`, or
`PRODUCT_CANDIDATE`.

## Files

| File | Change |
|---|---|
| `.../ddl/functions/M_HU_Trace_Report.sql` | section 6 rewritten; `link_basis` added as the 27th column (`null::varchar` in the other six arms) |
| `.../system/5821840_sys_M_HU_Trace_Report_GraphPairing.sql` | deploys the function |
| `.../70-de.metas.fresh/5821850_sys_HU_Trace_Report_LinkBasis_Element.sql` | `AD_Element` for the German header |
| `.../70-de.metas.fresh/5821870_sys_HU_Trace_Report_Description_LinkBasis.sql` | process description |
| `.../trace/process/M_HU_Trace_Report_Excel.java` | one appended header entry |
| `.../features/hu/huTraceability.feature` + its step definitions | eight new scenarios |

## Tests

Ten cucumber scenarios in `huTraceability.feature`, all green against a stack reset from scratch and
migrated only by the migration tool — so the function under test is the one the migration deploys,
not a hand-deployed one. The two pre-existing scenarios (`BugA`, `BugB`) are unmodified and still
pass; `BugB` in particular pins the candidate branch, since it requires a lot-less pair with no VHU
link to still produce a row.

Scenarios cover: a graph-traced receipt suppressing the others of its lot; lot disagreement across a
transformation edge; same-VHU (depth 0); a two-hop transformation chain; candidate suppression per
shipment rather than globally; no-lot/no-link; receipt quantity plus document-level de-duplication;
and an ineligible (outbound) receipt document not silencing its group's candidates.

## Reconciling the numbers on a `DIRECT_SALE_DETAIL` sheet

**Read `Verknüpfung` (`link_basis`) first. It is what separates a proven pairing from a guess, and
the two must be counted differently.**

Section 6 emits one row per **(receipt document, shipment document, product, lot)** pairing — not
one row per receipt and not one row per shipment. What that means for the columns:
## Reconciling the numbers on a `DIRECT_SALE_DETAIL` sheet

**Read `Verknüpfung` (`link_basis`) first. It is what separates a proven pairing from a guess, and
the two must be counted differently.**

Section 6 emits one row per **(receipt document, shipment document, product, lot)** pairing — not
one row per receipt and not one row per shipment. What that means for the columns:

- **`TRACED`** — the shipped HU is reachable from the received HU along the `M_HU_Trace`
  transformation graph (`VHU_Source_ID` edges, or the same VHU), and both ends carry the same lot.
  This is a statement of fact about the goods. For a `(shipment, product, lot)` group that the graph
  resolves, **only** traced rows are emitted; the guesses are suppressed.
- **`LOT_CANDIDATE`** — the graph is silent for this group, and the pairing rests on the two
  documents sharing a lot number and a product. A possibility, not a finding.
- **`PRODUCT_CANDIDATE`** — as above, but neither side carries a lot number at all, so only the
  product is shared. The weakest of the three.

### The one thing that will otherwise be misread

**Within a group the graph cannot resolve, the candidate branch still fans out: every receipt of
that lot is paired against every shipment of it.** A group with 3 candidate receipts and 4 shipments
produces 12 rows. That is intended — those rows are the honest "we cannot tell which" answer, and
suppressing them would delete information the report shows today (36 % of shipment documents in the
measured probe get no graph answer).

The consequence for anyone adding up a column:

- **`Menge` (column H) — the receipt document's total for that product and lot — REPEATS on every
  pairing row that receipt appears in. It does NOT sum down the column.** Summing `Menge` over a
  candidate group multiplies the received quantity by the number of shipments it was paired against.
  The same applies to `2_Menge` / `2_Liefermenge`, which are the shipment document's total for that
  product and lot and repeat across that shipment's pairing rows.
- To total received or shipped quantity, **de-duplicate by document first** — one `Menge` per
  distinct receipt document, one `2_Liefermenge` per distinct shipment document, within the product
  and lot.
- Rows marked `TRACED` do not fan out this way in practice: the graph pins a group to its actual
  receipt(s), so the pairing rows and the documents largely coincide. It is the candidate rows that
  multiply.

### Measured on the target instance, before and after

Two read-only probes over 1 570 shipment documents (`round1-results.md`, `round2-results.md`):

| measure | before | after |
|---|---:|---:|
| detail rows printed | 64 175 | **5 865** (−91 %) |
| receipts offered per shipment, average | 40.88 | **1.14** |
| shipments the graph pins to exactly one receipt | — | 452 |
| shipments the graph resolves at all | — | 1 009 of 1 570 (64 %) |
| shipments falling back to labelled candidates | — | 560 of 1 570 (36 %) |

Both counts are keyed on the shipment document, so a document spanning several products unions their
receipt sets; the ratios are sound, the absolute figures are "of this scope" rather than whole-report
totals.

**The worked example from the issue** — shipment document `546661`. It genuinely draws on six
receipts, but **each on a different lot**, which is why the old lot-only rule made it look
ambiguous. The graph pairs exactly one receipt per lot. For lot `100925150`, the lot the reporter
was chasing, the answer is receipt **`1000462`** of 2025-09-22 — one row, not six. And with `Menge`
now populated, the row itself shows 576 received against 24 shipped, which is the proportion the
reporter asked about and could not previously see anywhere on the report.

### Also new on these rows

- **`Menge` (column H)** was always empty in this section. It now carries the receipt document's
  quantity for the row's product and lot.
- **`2_Menge` and `2_Liefermenge`** previously showed one arbitrary trace row's quantity; they now
  carry the shipment document's total for that product and lot.
- The shipment side is now restricted to the report's own selection, as the receipt side always was.
- Columns `A`–`Z` keep their positions, headers and meanings; `Verknüpfung` is appended as the 27th.

---

