### PR TITLE
Invoice candidates: the "Create Invoices" run reports the candidates it skipped

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -691,6 +691,18 @@ public class C_Invoice_Candidate_StepDef
 	@When("run the invoicing process for invoice candidates:")
 	public void run_invoicing_process(@NonNull final DataTable dataTable)
 	{
+		final ProcessExecutionResult result = executeInvoicingProcess(dataTable);
+
+		assertThat(result.isError())
+				.as("the invoicing run must not fail; summary=" + result.getSummary())
+				.isFalse();
+
+		lastInvoicingRunSummary = result.getSummary();
+		logger.info("Invoicing run summary: {}", lastInvoicingRunSummary);
+	}
+
+	private ProcessExecutionResult executeInvoicingProcess(@NonNull final DataTable dataTable)
+	{
 		final List<Integer> invoiceCandidateIds = new ArrayList<>();
 		DataTableRows.of(dataTable).forEach(row -> row
 				.getAsIdentifier(COLUMNNAME_C_Invoice_Candidate_ID)
@@ -726,12 +738,27 @@ public class C_Invoice_Candidate_StepDef
 					.getResult();
 		}
 
+		return result;
+	}
+
+	/**
+	 * Same as the step above, but for a selection in which EVERY candidate is expected to be skipped.
+	 * <p>
+	 * That case is an error for the process -- nothing could be enqueued, so it throws
+	 * {@code InvoiceGenerate_No_Candidates_Selected} -- yet the run still has to say WHY, which is why the
+	 * summary is captured from the failed result rather than asserted away.
+	 */
+	@When("run the invoicing process and expect nothing invoiced for invoice candidates:")
+	public void run_invoicing_process_expecting_nothing_invoiced(@NonNull final DataTable dataTable)
+	{
+		final ProcessExecutionResult result = executeInvoicingProcess(dataTable);
+
 		assertThat(result.isError())
-				.as("the invoicing run must not fail; summary=" + result.getSummary())
-				.isFalse();
+				.as("the run must report an error when NOTHING could be invoiced; summary=" + result.getSummary())
+				.isTrue();
 
 		lastInvoicingRunSummary = result.getSummary();
-		logger.info("Invoicing run summary: {}", lastInvoicingRunSummary);
+		logger.info("Invoicing run summary (nothing invoiced): {}", lastInvoicingRunSummary);
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -62,13 +62,20 @@ import de.metas.invoicecandidate.model.I_C_Invoice_Candidate_Recompute;
 import de.metas.logging.LogManager;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
+import de.metas.process.AdProcessId;
+import de.metas.process.IADProcessDAO;
+import de.metas.process.ProcessExecutionResult;
+import de.metas.process.ProcessInfo;
 import de.metas.process.PInstanceId;
+import de.metas.security.RoleId;
+import de.metas.user.UserId;
 import de.metas.util.Check;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
@@ -107,6 +114,7 @@ import java.sql.SQLException;
 import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Properties;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -663,6 +671,113 @@ public class C_Invoice_Candidate_StepDef
 						wrapInvoiceCandidateRelatedException(e, invoiceCandidateRecord, invoiceCandidateIdentifier);
 					}
 				});
+	}
+
+	/** The role the invoicing process runs under; it must be able to read the cucumber client's candidates. */
+	private static final String INVOICING_PROCESS_ROLE_NAME = "WebUI";
+
+	/** Summary string returned by the last "Auswahl Fakturieren" AD_Process run (see the step below). */
+	private String lastInvoicingRunSummary;
+
+	/**
+	 * Runs the REAL {@code C_Invoice_Candidate_EnqueueSelectionForInvoicing} AD_Process over the given candidates
+	 * and keeps its summary, i.e. exactly the string the WebUI shows the user when the run finishes.
+	 * <p>
+	 * Deliberately NOT the {@code process invoice candidates} step: that one goes through
+	 * {@code de.metas.invoice.InvoiceService}, which discards the enqueue result, so the summary cannot be observed
+	 * there at all. The selection is passed as a where clause because the process reads it from
+	 * {@code ProcessInfo.getQueryFilterOrElse(...)} -- the filter the user had in his window.
+	 */
+	@When("run the invoicing process for invoice candidates:")
+	public void run_invoicing_process(@NonNull final DataTable dataTable)
+	{
+		final List<Integer> invoiceCandidateIds = new ArrayList<>();
+		DataTableRows.of(dataTable).forEach(row -> row
+				.getAsIdentifier(COLUMNNAME_C_Invoice_Candidate_ID)
+				.toCommaSeparatedList()
+				.forEach(identifier -> invoiceCandidateIds.add(invoiceCandTable.getId(identifier).getRepoId())));
+
+		Check.assumeNotEmpty(invoiceCandidateIds, "at least one C_Invoice_Candidate_ID.Identifier is required");
+
+		final AdProcessId processId = Services.get(IADProcessDAO.class)
+				.retrieveProcessIdByValue("C_Invoice_Candidate_EnqueueSelectionForInvoicing");
+		assertThat(processId).as("AD_Process C_Invoice_Candidate_EnqueueSelectionForInvoicing must exist").isNotNull();
+
+		final StringBuilder idList = new StringBuilder();
+		for (final Integer id : invoiceCandidateIds)
+		{
+			if (idList.length() > 0)
+			{
+				idList.append(",");
+			}
+			idList.append(id);
+		}
+		final String whereClause = COLUMNNAME_C_Invoice_Candidate_ID + " IN (" + idList + ")";
+
+		final ProcessExecutionResult result;
+		try (final IAutoCloseable ignore = Loggables.temporarySetLoggable(new LogbackLoggable(logger, Level.INFO)))
+		{
+			result = ProcessInfo.builder()
+					.setCtx(createInvoicingProcessCtx())
+					.setAD_Process_ID(processId)
+					.setWhereClause(whereClause)
+					.buildAndPrepareExecution()
+					.executeSync()
+					.getResult();
+		}
+
+		assertThat(result.isError())
+				.as("the invoicing run must not fail; summary=" + result.getSummary())
+				.isFalse();
+
+		lastInvoicingRunSummary = result.getSummary();
+		logger.info("Invoicing run summary: {}", lastInvoicingRunSummary);
+	}
+
+	/**
+	 * The invoicing process narrows its selection with {@code addOnlyContextClient()} and
+	 * {@code setRequiredAccess(Access.READ)}, so the context must carry a client, an org, a logged user AND a role
+	 * that may read the cucumber client's records -- with the ambient (role-less) ctx the selection comes back EMPTY
+	 * and the process aborts with "Es wurden keine fakturierbaren Datensaetze ausgewaehlt".
+	 * <p>
+	 * copyCtx (not deriveCtx): the process ctx has to carry the values itself, otherwise the ambient values reach it
+	 * only as Properties-defaults and ContextClientQueryFilter fails. Same construction as
+	 * {@code M_ShipmentSchedule_StepDef#createProcessCtx()}.
+	 */
+	private Properties createInvoicingProcessCtx()
+	{
+		final UserId userId = StepDefUtil.getUserIdByLogin(StepDefConstants.METASFRESH_VALUE);
+		final RoleId roleId = StepDefUtil.getRoleIdByName(userId, StepDefConstants.METASFRESH_VALUE, INVOICING_PROCESS_ROLE_NAME);
+
+		final Properties processCtx = Env.copyCtx(Env.getCtx());
+		Env.setClientId(processCtx, StepDefConstants.CLIENT_ID);
+		Env.setOrgId(processCtx, StepDefConstants.ORG_ID);
+		Env.setLoggedUserId(processCtx, userId);
+		Env.setContext(processCtx, Env.CTXNAME_AD_Role_ID, roleId.getRepoId());
+
+		return processCtx;
+	}
+
+	/**
+	 * Asserts the last invoicing run's summary mentions each given fragment.
+	 * This is what makes "the run reports what it skipped" a testable property: before the fix the enqueuer
+	 * dropped candidates into Loggables only and the summary said nothing about them.
+	 */
+	@Then("the invoicing run summary contains:")
+	public void invoicing_run_summary_contains(@NonNull final DataTable dataTable)
+	{
+		assertThat(lastInvoicingRunSummary)
+				.as("no invoicing run summary captured -- run the invoicing process step first")
+				.isNotNull();
+
+		final SoftAssertions softly = new SoftAssertions();
+		for (final String expectedFragment : dataTable.asList(String.class))
+		{
+			softly.assertThat(lastInvoicingRunSummary)
+					.as("invoicing run summary must mention " + expectedFragment)
+					.contains(expectedFragment);
+		}
+		softly.assertAll();
 	}
 
 	@And("process invoice candidates")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -673,20 +673,16 @@ public class C_Invoice_Candidate_StepDef
 				});
 	}
 
-	/** The role the invoicing process runs under; it must be able to read the cucumber client's candidates. */
 	private static final String INVOICING_PROCESS_ROLE_NAME = "WebUI";
 
-	/** Summary string returned by the last "Auswahl Fakturieren" AD_Process run (see the step below). */
+	/** Summary returned by the last invoicing-process run. */
 	private String lastInvoicingRunSummary;
 
 	/**
-	 * Runs the REAL {@code C_Invoice_Candidate_EnqueueSelectionForInvoicing} AD_Process over the given candidates
-	 * and keeps its summary, i.e. exactly the string the WebUI shows the user when the run finishes.
+	 * Runs the {@code C_Invoice_Candidate_EnqueueSelectionForInvoicing} AD_Process and keeps its summary.
 	 * <p>
-	 * Deliberately NOT the {@code process invoice candidates} step: that one goes through
-	 * {@code de.metas.invoice.InvoiceService}, which discards the enqueue result, so the summary cannot be observed
-	 * there at all. The selection is passed as a where clause because the process reads it from
-	 * {@code ProcessInfo.getQueryFilterOrElse(...)} -- the filter the user had in his window.
+	 * NOT the {@code process invoice candidates} step: that goes through {@code InvoiceService}, which discards
+	 * the enqueue result, so the summary is not observable there.
 	 */
 	@When("run the invoicing process for invoice candidates:")
 	public void run_invoicing_process(@NonNull final DataTable dataTable)
@@ -741,13 +737,7 @@ public class C_Invoice_Candidate_StepDef
 		return result;
 	}
 
-	/**
-	 * Same as the step above, but for a selection in which EVERY candidate is expected to be skipped.
-	 * <p>
-	 * That case is an error for the process -- nothing could be enqueued, so it throws
-	 * {@code InvoiceGenerate_No_Candidates_Selected} -- yet the run still has to say WHY, which is why the
-	 * summary is captured from the failed result rather than asserted away.
-	 */
+	/** Variant for a selection in which every candidate is skipped: the process errors, but must still say why. */
 	@When("run the invoicing process and expect nothing invoiced for invoice candidates:")
 	public void run_invoicing_process_expecting_nothing_invoiced(@NonNull final DataTable dataTable)
 	{
@@ -762,14 +752,9 @@ public class C_Invoice_Candidate_StepDef
 	}
 
 	/**
-	 * The invoicing process narrows its selection with {@code addOnlyContextClient()} and
-	 * {@code setRequiredAccess(Access.READ)}, so the context must carry a client, an org, a logged user AND a role
-	 * that may read the cucumber client's records -- with the ambient (role-less) ctx the selection comes back EMPTY
-	 * and the process aborts with "Es wurden keine fakturierbaren Datensaetze ausgewaehlt".
-	 * <p>
-	 * copyCtx (not deriveCtx): the process ctx has to carry the values itself, otherwise the ambient values reach it
-	 * only as Properties-defaults and ContextClientQueryFilter fails. Same construction as
-	 * {@code M_ShipmentSchedule_StepDef#createProcessCtx()}.
+	 * The process selects with {@code addOnlyContextClient()} + {@code Access.READ}, so without a client, org, user
+	 * AND role the selection comes back empty. copyCtx (not deriveCtx): the ctx must carry the values itself.
+	 * Same construction as {@code M_ShipmentSchedule_StepDef#createProcessCtx()}.
 	 */
 	private Properties createInvoicingProcessCtx()
 	{
@@ -785,11 +770,7 @@ public class C_Invoice_Candidate_StepDef
 		return processCtx;
 	}
 
-	/**
-	 * Asserts the last invoicing run's summary mentions each given fragment.
-	 * This is what makes "the run reports what it skipped" a testable property: before the fix the enqueuer
-	 * dropped candidates into Loggables only and the summary said nothing about them.
-	 */
+	/** Asserts the last invoicing run's summary mentions each given fragment. */
 	@Then("the invoicing run summary contains:")
 	public void invoicing_run_summary_contains(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
@@ -194,17 +194,8 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
 @allure.label.feature:F01010.3_Match_Invoice
 @F00701
   Scenario: A "Create Invoices" run reports the candidate the enqueuer silently skipped
-    # The defect this covers: the enqueuer drops a candidate with QtyOrdered <> 0 and
-    # QtyToInvoice = 0 (InvoiceCandidateEnqueuer.isEligibleForEnqueueing, "task 04372" branch).
-    # The skip reason goes to Loggables only, InvoiceCandidateEnqueueResult carries just the
-    # enqueued count, and InvoiceGenerate_No_Candidates_Selected fires only when NOTHING is
-    # enqueued -- so in a mixed selection the good candidate is invoiced and the dropped one is
-    # never mentioned anywhere the user looks.
-    #
-    # NOT the credit-stop mechanism of the scenario above: that candidate IS enqueued and then
-    # fails inside InvoiceCandBLCreateInvoices, which is the only place Event_InvoicingError is
-    # raised from. A skipped candidate never reaches that code, which is why the shipped
-    # scenario went green against a different mechanism and left this path uncovered.
+    # The enqueuer's quantity skip (QtyOrdered <> 0 with QtyToInvoice = 0), NOT the credit stop of the
+    # scenario above -- that candidate is enqueued and fails later, in a different code path.
     Given metasfresh contains M_Products:
       | Identifier | Name              |
       | p_sk_1     | salesProduct_sk_1 |
@@ -221,8 +212,7 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
       | pp_sk_1    | plv_sk_1                          | p_sk_1                  | 10.0     | PCE               | Normal                        |
 
-    # Different bill partners on purpose: same partner aggregates into ONE invoice header, so a
-    # single selection could not show "one invoiced, one dropped" side by side.
+    # Different bill partners: the same partner would aggregate into one invoice header.
     And metasfresh contains C_BPartners:
       | Identifier         | Name               | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
       | customer_sk_good   | sk_GoodCustomer    | N            | Y              | ps_sk_1                       |
@@ -246,9 +236,8 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | ic_sk_good                        | ol_sk_good                | 0            |
       | ic_sk_skip                        | ol_sk_skip                | 0            |
 
-    # InvoiceRule=Immediate makes both invoiceable without a delivery, so the run really tries.
-    # DateToInvoice_Override in the past clears the date gate, which isSkipCandidateFromInvoicing
-    # evaluates BEFORE the quantity branch -- without it the date reason would mask the one under test.
+    # Immediate = invoiceable without a delivery; the past DateToInvoice_Override clears the date gate,
+    # which is evaluated BEFORE the quantity branch and would otherwise mask the reason under test.
     And update invoice candidates
       | C_Invoice_Candidate_ID.Identifier | OPT.InvoiceRule_Override | OPT.DateToInvoice_Override |
       | ic_sk_good                        | I                        | 2021-04-18                 |
@@ -258,7 +247,6 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | ic_sk_good                        | ol_sk_good                | 10           |
       | ic_sk_skip                        | ol_sk_skip                | 10           |
 
-    # QtyToInvoice_Override = 0 with QtyOrdered still 10 is exactly the enqueuer's skip condition.
     And update invoice candidates
       | C_Invoice_Candidate_ID.Identifier | OPT.QtyToInvoice_Override |
       | ic_sk_skip                        | 0                         |
@@ -266,21 +254,17 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
       | ic_sk_skip                        | ol_sk_skip                | 0            |
 
-    # The REAL process, not the InvoiceService shortcut: InvoiceService discards the enqueue result, so the
-    # summary the user actually reads cannot be observed through it.
+    # The real process: InvoiceService discards the enqueue result, so the summary is not observable there.
     When run the invoicing process for invoice candidates:
       | C_Invoice_Candidate_ID.Identifier |
       | ic_sk_good,ic_sk_skip             |
 
-    # THE ASSERTION UNDER TEST. Before the fix the summary reported only what was enqueued; the dropped
-    # candidate went to Loggables (the process log) and the user was told nothing about it.
-    # "1 von 2" = one of the two selected candidates was not invoiced; the reason names the candidate.
+    # 1 of the 2 selected candidates was not invoiced.
     Then the invoicing run summary contains:
       | 1 von 2 |
 
-    # The skipped candidate stays open and is NOT flagged as an error: being skipped is not a failure.
-    # (That the GOOD candidate still gets invoiced in a mixed selection is covered by the scenario above,
-    #  which drives the async batch; the queue processor is off here, so this scenario asserts the report.)
+    # Skipped is not an error. (The good candidate's invoice is covered by the scenario above; the queue
+    # processor is off here, so this one asserts the report only.)
     And validate C_Invoice_Candidate:
       | C_Invoice_Candidate_ID.Identifier | IsInvoicingError | OPT.Processed |
       | ic_sk_skip                        | false            | false         |
@@ -293,11 +277,8 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
 @allure.label.feature:F01010.3_Match_Invoice
 @F00701
   Scenario: A "Create Invoices" run whose WHOLE selection is skipped still says why
-    # The other half of the same defect. When nothing at all can be enqueued the enqueuer throws the bare,
-    # parameterless InvoiceGenerate_No_Candidates_Selected ("Es wurden keine fakturierbaren Datensaetze
-    # ausgewaehlt.") -- so the user was told the selection cannot be invoiced but never what is wrong with
-    # it, even though every reason had just been computed. ~3568 candidates sit in this state on the
-    # customer instance, so an all-skipped selection is the COMMON case there, not an edge case.
+    # Nothing enqueued at all: the enqueuer throws InvoiceGenerate_No_Candidates_Selected, which used to
+    # carry no reason.
     Given metasfresh contains M_Products:
       | Identifier | Name              |
       | p_al_1     | salesProduct_al_1 |
@@ -337,7 +318,6 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
       | ic_al_1                           | ol_al_1                   | 10           |
 
-    # The only selected candidate now meets the enqueuer's skip condition, so NOTHING can be enqueued.
     And update invoice candidates
       | C_Invoice_Candidate_ID.Identifier | OPT.QtyToInvoice_Override |
       | ic_al_1                           | 0                         |
@@ -349,8 +329,7 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | C_Invoice_Candidate_ID.Identifier |
       | ic_al_1                           |
 
-    # THE ASSERTION UNDER TEST: the error must carry the reason, not just "nothing selectable".
-    # Pre-fix the message was the bare "Es wurden keine fakturierbaren Datensaetze ausgewaehlt." alone.
+    # The error must carry the reason, not just "nothing selectable".
     Then the invoicing run summary contains:
       | 1 von 1                              |
       | abzurechnende Menge gleich 0          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
@@ -284,3 +284,73 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
     And validate C_Invoice_Candidate:
       | C_Invoice_Candidate_ID.Identifier | IsInvoicingError | OPT.Processed |
       | ic_sk_skip                        | false            | false         |
+
+  @Id:S0163_400
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: A "Create Invoices" run whose WHOLE selection is skipped still says why
+    # The other half of the same defect. When nothing at all can be enqueued the enqueuer throws the bare,
+    # parameterless InvoiceGenerate_No_Candidates_Selected ("Es wurden keine fakturierbaren Datensaetze
+    # ausgewaehlt.") -- so the user was told the selection cannot be invoiced but never what is wrong with
+    # it, even though every reason had just been computed. ~3568 candidates sit in this state on the
+    # customer instance, so an all-skipped selection is the COMMON case there, not an edge case.
+    Given metasfresh contains M_Products:
+      | Identifier | Name              |
+      | p_al_1     | salesProduct_al_1 |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                   | Value                   | OPT.IsActive |
+      | ps_al_1    | al_pricing_system_name | al_pricing_system_value | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name               | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_al_1    | ps_al_1                       | DE                        | EUR                 | al_price_list_name | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name              | ValidFrom  |
+      | plv_al_1   | pl_al_1                   | al_salesOrder-PLV | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_al_1    | plv_al_1                          | p_al_1                  | 10.0     | PCE               | Normal                        |
+    And metasfresh contains C_BPartners:
+      | Identifier       | Name            | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | customer_al_1    | al_Customer     | N            | Y              | ps_al_1                       |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN             | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_al_1     | al_bPLocation_1 | customer_al_1            | Y                   | Y                   |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | o_al_1     | true    | customer_al_1            | 2021-04-17  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_al_1    | o_al_1                | p_al_1                  | 10         |
+    And the order identified by o_al_1 is completed
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_al_1                           | ol_al_1                   | 0            |
+
+    And update invoice candidates
+      | C_Invoice_Candidate_ID.Identifier | OPT.InvoiceRule_Override | OPT.DateToInvoice_Override |
+      | ic_al_1                           | I                        | 2021-04-18                 |
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_al_1                           | ol_al_1                   | 10           |
+
+    # The only selected candidate now meets the enqueuer's skip condition, so NOTHING can be enqueued.
+    And update invoice candidates
+      | C_Invoice_Candidate_ID.Identifier | OPT.QtyToInvoice_Override |
+      | ic_al_1                           | 0                         |
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_al_1                           | ol_al_1                   | 0            |
+
+    When run the invoicing process and expect nothing invoiced for invoice candidates:
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_al_1                           |
+
+    # THE ASSERTION UNDER TEST: the error must carry the reason, not just "nothing selectable".
+    # Pre-fix the message was the bare "Es wurden keine fakturierbaren Datensaetze ausgewaehlt." alone.
+    Then the invoicing run summary contains:
+      | 1 von 1                              |
+      | abzurechnende Menge gleich 0          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
@@ -75,6 +75,10 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | Identifier        | Value                |
       | msgInvoicingError | Event_InvoicingError |
 
+    # The note is looked up with firstOnly(), so drop any Event_InvoicingError note this DB already
+    # carries (e.g. from an earlier local run of this feature); otherwise the lookup finds two rows.
+    And AD_Note table is reset
+
     # A failing candidate is never processed, so the "wait until processed" variant would only time out.
     When process invoice candidates and verify C_Invoice_Candidate is not processed after 30s
       | C_Invoice_Candidate_ID.Identifier |
@@ -181,3 +185,102 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
     And after not more than 60s, validate AD_Note:
       | Identifier | AD_Message_ID.Identifier | OPT.AD_User_ID.Identifier |
       | note_1     | msgInvoicingError        | user_metasfresh           |
+
+  @Id:S0163_300
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: A "Create Invoices" run reports the candidate the enqueuer silently skipped
+    # The defect this covers: the enqueuer drops a candidate with QtyOrdered <> 0 and
+    # QtyToInvoice = 0 (InvoiceCandidateEnqueuer.isEligibleForEnqueueing, "task 04372" branch).
+    # The skip reason goes to Loggables only, InvoiceCandidateEnqueueResult carries just the
+    # enqueued count, and InvoiceGenerate_No_Candidates_Selected fires only when NOTHING is
+    # enqueued -- so in a mixed selection the good candidate is invoiced and the dropped one is
+    # never mentioned anywhere the user looks.
+    #
+    # NOT the credit-stop mechanism of the scenario above: that candidate IS enqueued and then
+    # fails inside InvoiceCandBLCreateInvoices, which is the only place Event_InvoicingError is
+    # raised from. A skipped candidate never reaches that code, which is why the shipped
+    # scenario went green against a different mechanism and left this path uncovered.
+    Given metasfresh contains M_Products:
+      | Identifier | Name              |
+      | p_sk_1     | salesProduct_sk_1 |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                   | Value                   | OPT.IsActive |
+      | ps_sk_1    | sk_pricing_system_name | sk_pricing_system_value | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name               | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_sk_1    | ps_sk_1                       | DE                        | EUR                 | sk_price_list_name | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name              | ValidFrom  |
+      | plv_sk_1   | pl_sk_1                   | sk_salesOrder-PLV | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_sk_1    | plv_sk_1                          | p_sk_1                  | 10.0     | PCE               | Normal                        |
+
+    # Different bill partners on purpose: same partner aggregates into ONE invoice header, so a
+    # single selection could not show "one invoiced, one dropped" side by side.
+    And metasfresh contains C_BPartners:
+      | Identifier         | Name               | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | customer_sk_good   | sk_GoodCustomer    | N            | Y              | ps_sk_1                       |
+      | customer_sk_skip   | sk_SkippedCustomer | N            | Y              | ps_sk_1                       |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier  | GLN              | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_sk_good   | sk_bPLocation_g  | customer_sk_good         | Y                   | Y                   |
+      | l_sk_skip   | sk_bPLocation_s  | customer_sk_skip         | Y                   | Y                   |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | o_sk_good  | true    | customer_sk_good         | 2021-04-17  |
+      | o_sk_skip  | true    | customer_sk_skip         | 2021-04-17  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_sk_good | o_sk_good             | p_sk_1                  | 10         |
+      | ol_sk_skip | o_sk_skip             | p_sk_1                  | 10         |
+    And the order identified by o_sk_good is completed
+    And the order identified by o_sk_skip is completed
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_sk_good                        | ol_sk_good                | 0            |
+      | ic_sk_skip                        | ol_sk_skip                | 0            |
+
+    # InvoiceRule=Immediate makes both invoiceable without a delivery, so the run really tries.
+    # DateToInvoice_Override in the past clears the date gate, which isSkipCandidateFromInvoicing
+    # evaluates BEFORE the quantity branch -- without it the date reason would mask the one under test.
+    And update invoice candidates
+      | C_Invoice_Candidate_ID.Identifier | OPT.InvoiceRule_Override | OPT.DateToInvoice_Override |
+      | ic_sk_good                        | I                        | 2021-04-18                 |
+      | ic_sk_skip                        | I                        | 2021-04-18                 |
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_sk_good                        | ol_sk_good                | 10           |
+      | ic_sk_skip                        | ol_sk_skip                | 10           |
+
+    # QtyToInvoice_Override = 0 with QtyOrdered still 10 is exactly the enqueuer's skip condition.
+    And update invoice candidates
+      | C_Invoice_Candidate_ID.Identifier | OPT.QtyToInvoice_Override |
+      | ic_sk_skip                        | 0                         |
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_sk_skip                        | ol_sk_skip                | 0            |
+
+    # The REAL process, not the InvoiceService shortcut: InvoiceService discards the enqueue result, so the
+    # summary the user actually reads cannot be observed through it.
+    When run the invoicing process for invoice candidates:
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_sk_good,ic_sk_skip             |
+
+    # THE ASSERTION UNDER TEST. Before the fix the summary reported only what was enqueued; the dropped
+    # candidate went to Loggables (the process log) and the user was told nothing about it.
+    # "1 von 2" = one of the two selected candidates was not invoiced; the reason names the candidate.
+    Then the invoicing run summary contains:
+      | 1 von 2 |
+
+    # The skipped candidate stays open and is NOT flagged as an error: being skipped is not a failure.
+    # (That the GOOD candidate still gets invoiced in a mixed selection is covered by the scenario above,
+    #  which drives the async batch; the queue processor is off here, so this scenario asserts the report.)
+    And validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | IsInvoicingError | OPT.Processed |
+      | ic_sk_skip                        | false            | false         |

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
@@ -143,10 +143,7 @@ public interface IInvoiceCandBL extends ISingletonService
 	boolean isSkipCandidateFromInvoicing(I_C_Invoice_Candidate ic, boolean ignoreInvoiceSchedule, boolean isInvoiceManualRule);
 
 	/**
-	 * Same check as {@link #isSkipCandidateFromInvoicing(I_C_Invoice_Candidate, boolean, boolean)}, but yields the
-	 * translated REASON instead of a bare flag, so a caller can report back to the user WHY a candidate was dropped.
-	 * <p>
-	 * Every reason was already being computed for the process log; this overload is what makes it reportable.
+	 * Like {@link #isSkipCandidateFromInvoicing(I_C_Invoice_Candidate, boolean, boolean)}, but yields the reason.
 	 *
 	 * @return the translated skip reason, or {@code null} if the candidate is NOT skipped.
 	 */

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
@@ -142,6 +142,17 @@ public interface IInvoiceCandBL extends ISingletonService
 	 */
 	boolean isSkipCandidateFromInvoicing(I_C_Invoice_Candidate ic, boolean ignoreInvoiceSchedule, boolean isInvoiceManualRule);
 
+	/**
+	 * Same check as {@link #isSkipCandidateFromInvoicing(I_C_Invoice_Candidate, boolean, boolean)}, but yields the
+	 * translated REASON instead of a bare flag, so a caller can report back to the user WHY a candidate was dropped.
+	 * <p>
+	 * Every reason was already being computed for the process log; this overload is what makes it reportable.
+	 *
+	 * @return the translated skip reason, or {@code null} if the candidate is NOT skipped.
+	 */
+	@Nullable
+	String getInvoicingSkipReasonOrNull(I_C_Invoice_Candidate ic, boolean ignoreInvoiceSchedule, boolean isInvoiceManualRule);
+
 	IInvoiceGenerateResult generateInvoicesFromQueue(Properties ctx);
 
 	void setPaymentTermIfMissing(@NonNull I_C_Invoice_Candidate icRecord);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandidateEnqueueResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandidateEnqueueResult.java
@@ -26,6 +26,8 @@ import de.metas.async.api.IEnqueueResult;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.lock.api.ILock;
 
+import com.google.common.collect.ImmutableList;
+
 import java.math.BigDecimal;
 import java.util.Properties;
 
@@ -41,6 +43,15 @@ public interface IInvoiceCandidateEnqueueResult extends IEnqueueResult
 
 	/** @return how many invoice candidates were enqueued */
 	int getInvoiceCandidateEnqueuedCount();
+
+	/** @return how many of the SELECTED invoice candidates were skipped, i.e. never enqueued */
+	int getInvoiceCandidateSkippedCount();
+
+	/**
+	 * @return one translated reason per skipped invoice candidate, in selection order.
+	 * Empty when nothing was skipped.
+	 */
+	ImmutableList<String> getSkipReasons();
 
 	/** @return how many workpackages were enqueued */
 	int getWorkpackageEnqueuedCount();

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandidateEnqueueResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandidateEnqueueResult.java
@@ -44,13 +44,10 @@ public interface IInvoiceCandidateEnqueueResult extends IEnqueueResult
 	/** @return how many invoice candidates were enqueued */
 	int getInvoiceCandidateEnqueuedCount();
 
-	/** @return how many of the SELECTED invoice candidates were skipped, i.e. never enqueued */
+	/** @return how many of the selected invoice candidates were skipped, i.e. never enqueued */
 	int getInvoiceCandidateSkippedCount();
 
-	/**
-	 * @return one translated reason per skipped invoice candidate, in selection order.
-	 * Empty when nothing was skipped.
-	 */
+	/** @return one translated reason per skipped candidate, in selection order; empty when nothing was skipped */
 	ImmutableList<String> getSkipReasons();
 
 	/** @return how many workpackages were enqueued */

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -227,6 +227,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 {
 	private static final AdMessageKey MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_IS_TO_CLEAR = AdMessageKey.of("InvoiceCandBL_Invoicing_Skipped_IsToClear");
 	private static final AdMessageKey MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_IS_IN_DISPUTE = AdMessageKey.of("InvoiceCandBL_Invoicing_Skipped_IsInDispute");
+	private static final AdMessageKey MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_SIMULATION = AdMessageKey.of("InvoiceCandBL_Invoicing_Skipped_Simulation");
 	private static final AdMessageKey MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_DATE_TO_INVOICE = AdMessageKey.of("InvoiceCandBL_Invoicing_Skipped_DateToInvoice");
 	private static final AdMessageKey MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_MANUAL_RULE = AdMessageKey.of("InvoiceCandBL_Invoicing_Skipped_ManualRule");
 	private static final AdMessageKey MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_ERROR = AdMessageKey.of("InvoiceCandBL_Invoicing_Skipped_Error");
@@ -1049,9 +1050,10 @@ public class InvoiceCandBL implements IInvoiceCandBL
 
 		if (ic.isSimulation())
 		{
-			final String msg = "C_Invoice_Candidate_ID=" + ic.getC_Invoice_Candidate_ID() + ": simulation";
-			Loggables.withLogger(logger, Level.DEBUG).addLog(" #isSkipCandidateFromInvoicing: Skipping IC: {},"
-					+ " as it's a simulation and it shouldn't be invoiced!", ic.getC_Invoice_Candidate_ID());
+			// Translated like its five sibling reasons: this string reaches the user in the process summary.
+			final String msg = msgBL.getMsg(ctx, MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_SIMULATION,
+					new Object[] { ic.getC_Invoice_Candidate_ID() });
+			Loggables.withLogger(logger, Level.DEBUG).addLog(msg);
 			return msg;
 		}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -1050,7 +1050,6 @@ public class InvoiceCandBL implements IInvoiceCandBL
 
 		if (ic.isSimulation())
 		{
-			// Translated like its five sibling reasons: this string reaches the user in the process summary.
 			final String msg = msgBL.getMsg(ctx, MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_SIMULATION,
 					new Object[] { ic.getC_Invoice_Candidate_ID() });
 			Loggables.withLogger(logger, Level.DEBUG).addLog(msg);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -998,6 +998,16 @@ public class InvoiceCandBL implements IInvoiceCandBL
 			final boolean ignoreInvoiceSchedule,
 			final boolean isInvoiceManualRule)
 	{
+		return getInvoicingSkipReasonOrNull(ic, ignoreInvoiceSchedule, isInvoiceManualRule) != null;
+	}
+
+	@Override
+	@Nullable
+	public String getInvoicingSkipReasonOrNull(
+			final I_C_Invoice_Candidate ic,
+			final boolean ignoreInvoiceSchedule,
+			final boolean isInvoiceManualRule)
+	{
 		// 04533: ignore already processed candidates
 		// task 08343: if the ic is processed (after the recent update), then skip it (this logic was in the where clause in C_Invoice_Candidate_EnqueueSelection)
 		final IMsgBL msgBL = Services.get(IMsgBL.class);
@@ -1006,7 +1016,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 		{
 			final String msg = msgBL.getMsg(ctx, MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_PROCESSED, new Object[] { ic.getC_Invoice_Candidate_ID() });
 			Loggables.withLogger(logger, Level.INFO).addLog(msg);
-			return true;
+			return msg;
 		}
 
 		// ignore "error" candidates
@@ -1016,7 +1026,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 					+ ": "
 					+ ic.getErrorMsg();
 			Loggables.withLogger(logger, Level.DEBUG).addLog(msg);
-			return true;
+			return msg;
 		}
 
 		if (ic.isToClear())
@@ -1025,7 +1035,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 			final String msg = msgBL.getMsg(ctx, MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_IS_TO_CLEAR,
 					new Object[] { ic.getC_Invoice_Candidate_ID() });
 			Loggables.withLogger(logger, Level.DEBUG).addLog(msg);
-			return true;
+			return msg;
 		}
 
 		if (ic.isInDispute())
@@ -1034,14 +1044,15 @@ public class InvoiceCandBL implements IInvoiceCandBL
 			final String msg = msgBL.getMsg(ctx, MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_IS_IN_DISPUTE,
 					new Object[] { ic.getC_Invoice_Candidate_ID() });
 			Loggables.withLogger(logger, Level.DEBUG).addLog(msg);
-			return true;
+			return msg;
 		}
 
 		if (ic.isSimulation())
 		{
+			final String msg = "C_Invoice_Candidate_ID=" + ic.getC_Invoice_Candidate_ID() + ": simulation";
 			Loggables.withLogger(logger, Level.DEBUG).addLog(" #isSkipCandidateFromInvoicing: Skipping IC: {},"
 					+ " as it's a simulation and it shouldn't be invoiced!", ic.getC_Invoice_Candidate_ID());
-			return true;
+			return msg;
 		}
 
 		// Manual rule is on its own axis — controlled by a dedicated flag, decoupled from IgnoreInvoiceSchedule.
@@ -1053,10 +1064,10 @@ public class InvoiceCandBL implements IInvoiceCandBL
 				final String msg = msgBL.getMsg(ctx, MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_MANUAL_RULE,
 						new Object[] { ic.getC_Invoice_Candidate_ID() });
 				Loggables.withLogger(logger, Level.DEBUG).addLog(msg);
-				return true;
+				return msg;
 			}
 			// Manual is explicitly requested → don't apply the date gate (Manual has no schedule by design).
-			return false;
+			return null;
 		}
 
 		// flagged via field color
@@ -1068,10 +1079,10 @@ public class InvoiceCandBL implements IInvoiceCandBL
 			final String msg = msgBL.getMsg(ctx, MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_DATE_TO_INVOICE,
 					new Object[] { ic.getC_Invoice_Candidate_ID(), TimeUtil.asTimestamp(dateToInvoice), TimeUtil.asTimestamp(getToday()) });
 			Loggables.withLogger(logger, Level.DEBUG).addLog(msg);
-			return true;
+			return msg;
 		}
 
-		return false; // Don't skip!
+		return null; // Don't skip!
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueueResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueueResult.java
@@ -43,9 +43,8 @@ import de.metas.util.Services;
 /* package */final class InvoiceCandidateEnqueueResult implements IInvoiceCandidateEnqueueResult
 {
 	private static final String MSG_INVOICE_CANDIDATE_ENQUEUE = "InvoiceCandidateEnqueue";
-	/** Appended to the summary when the enqueuer dropped part of the selection. */
 	private static final String MSG_INVOICE_CANDIDATE_ENQUEUE_SKIPPED = "InvoiceCandidateEnqueue_Skipped";
-	/** A selection can hold thousands of candidates; list a few reasons and point at the process log for the rest. */
+	/** A selection can hold thousands of candidates; the process log has every reason. */
 	private static final int MAX_LISTED_SKIP_REASONS = 5;
 
 	private final int invoiceCandidateEnqueuedCount;
@@ -98,8 +97,6 @@ import de.metas.util.Services;
 			return enqueuedSummary;
 		}
 
-		// The user pressed the button and is looking at THIS string, so the dropped candidates are reported here --
-		// synchronously and independent of any per-user notification configuration.
 		final int selectedCount = getInvoiceCandidateEnqueuedCount() + skippedCount;
 
 		return enqueuedSummary + " " + buildSkippedSummary(ctx, skipReasons, selectedCount);
@@ -108,10 +105,8 @@ import de.metas.util.Services;
 	/**
 	 * "N of M selected invoice candidate(s) were not invoiced: ...".
 	 * <p>
-	 * Package-visible and static because {@link InvoiceCandidateEnqueuer} needs the SAME sentence on the
-	 * all-skipped path, where it never gets to build a result at all: it throws
-	 * {@code InvoiceGenerate_No_Candidates_Selected} instead, and without this the reasons it collected
-	 * would be dropped on the floor -- leaving that case exactly as silent as before the fix.
+	 * Static because {@link InvoiceCandidateEnqueuer} needs the same sentence on the all-skipped path,
+	 * where it throws instead of building a result.
 	 */
 	/* package */
 	static String buildSkippedSummary(

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueueResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueueResult.java
@@ -101,13 +101,29 @@ import de.metas.util.Services;
 		// The user pressed the button and is looking at THIS string, so the dropped candidates are reported here --
 		// synchronously and independent of any per-user notification configuration.
 		final int selectedCount = getInvoiceCandidateEnqueuedCount() + skippedCount;
-		final String skippedSummary = msgBL.getMsg(ctx, MSG_INVOICE_CANDIDATE_ENQUEUE_SKIPPED,
-				new Object[] { skippedCount, selectedCount, buildSkipReasonsText() });
 
-		return enqueuedSummary + " " + skippedSummary;
+		return enqueuedSummary + " " + buildSkippedSummary(ctx, skipReasons, selectedCount);
 	}
 
-	private String buildSkipReasonsText()
+	/**
+	 * "N of M selected invoice candidate(s) were not invoiced: ...".
+	 * <p>
+	 * Package-visible and static because {@link InvoiceCandidateEnqueuer} needs the SAME sentence on the
+	 * all-skipped path, where it never gets to build a result at all: it throws
+	 * {@code InvoiceGenerate_No_Candidates_Selected} instead, and without this the reasons it collected
+	 * would be dropped on the floor -- leaving that case exactly as silent as before the fix.
+	 */
+	/* package */
+	static String buildSkippedSummary(
+			@NonNull final Properties ctx,
+			@NonNull final ImmutableList<String> skipReasons,
+			final int selectedCount)
+	{
+		return Services.get(IMsgBL.class).getMsg(ctx, MSG_INVOICE_CANDIDATE_ENQUEUE_SKIPPED,
+				new Object[] { skipReasons.size(), selectedCount, buildSkipReasonsText(skipReasons) });
+	}
+
+	private static String buildSkipReasonsText(@NonNull final ImmutableList<String> skipReasons)
 	{
 		final String listed = skipReasons.stream()
 				.limit(MAX_LISTED_SKIP_REASONS)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueueResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueueResult.java
@@ -22,8 +22,12 @@ package de.metas.invoicecandidate.api.impl;
  * #L%
  */
 
+import com.google.common.collect.ImmutableList;
+import lombok.NonNull;
+
 import java.math.BigDecimal;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import org.adempiere.util.lang.ObjectUtils;
 
@@ -39,17 +43,23 @@ import de.metas.util.Services;
 /* package */final class InvoiceCandidateEnqueueResult implements IInvoiceCandidateEnqueueResult
 {
 	private static final String MSG_INVOICE_CANDIDATE_ENQUEUE = "InvoiceCandidateEnqueue";
+	/** Appended to the summary when the enqueuer dropped part of the selection. */
+	private static final String MSG_INVOICE_CANDIDATE_ENQUEUE_SKIPPED = "InvoiceCandidateEnqueue_Skipped";
+	/** A selection can hold thousands of candidates; list a few reasons and point at the process log for the rest. */
+	private static final int MAX_LISTED_SKIP_REASONS = 5;
 
 	private final int invoiceCandidateEnqueuedCount;
 	private final int workpackageEnqueuedCount;
 	private final int workpackageQueueSizeBeforeEnqueueing;
 	private final BigDecimal totalNetAmtToInvoiceChecksum;
+	private final ImmutableList<String> skipReasons;
 	private final ILock lock;
 
 	/* package */ InvoiceCandidateEnqueueResult(final int invoiceCandidateEnqueuedCount,
 			final int enqueuedWorkpackageCount,
 			final int workpackageQueueSizeBeforeEnqueueing,
 			final BigDecimal totalNetAmtToInvoiceChecksum,
+			@NonNull final ImmutableList<String> skipReasons,
 			final ILock lock)
 	{
 		Check.assume(invoiceCandidateEnqueuedCount >= 0, "invoiceCandidateEnqueuedCount > 0");
@@ -61,6 +71,8 @@ import de.metas.util.Services;
 		this.workpackageQueueSizeBeforeEnqueueing = workpackageQueueSizeBeforeEnqueueing;
 
 		this.totalNetAmtToInvoiceChecksum = totalNetAmtToInvoiceChecksum;
+
+		this.skipReasons = skipReasons;
 
 		Check.assumeNotNull(lock, "lock not null");
 		this.lock = lock;
@@ -78,13 +90,51 @@ import de.metas.util.Services;
 		final IMsgBL msgBL = Services.get(IMsgBL.class);
 		final int countWorkpackages = getWorkpackageEnqueuedCount();
 		final int countUnprocessedWorkPackages = getWorkpackageQueueSizeBeforeEnqueueing();
-		return msgBL.getMsg(ctx, MSG_INVOICE_CANDIDATE_ENQUEUE, new Object[] { countWorkpackages, countUnprocessedWorkPackages });
+		final String enqueuedSummary = msgBL.getMsg(ctx, MSG_INVOICE_CANDIDATE_ENQUEUE, new Object[] { countWorkpackages, countUnprocessedWorkPackages });
+
+		final int skippedCount = getInvoiceCandidateSkippedCount();
+		if (skippedCount <= 0)
+		{
+			return enqueuedSummary;
+		}
+
+		// The user pressed the button and is looking at THIS string, so the dropped candidates are reported here --
+		// synchronously and independent of any per-user notification configuration.
+		final int selectedCount = getInvoiceCandidateEnqueuedCount() + skippedCount;
+		final String skippedSummary = msgBL.getMsg(ctx, MSG_INVOICE_CANDIDATE_ENQUEUE_SKIPPED,
+				new Object[] { skippedCount, selectedCount, buildSkipReasonsText() });
+
+		return enqueuedSummary + " " + skippedSummary;
+	}
+
+	private String buildSkipReasonsText()
+	{
+		final String listed = skipReasons.stream()
+				.limit(MAX_LISTED_SKIP_REASONS)
+				.collect(Collectors.joining("; "));
+
+		final int notListed = skipReasons.size() - Math.min(skipReasons.size(), MAX_LISTED_SKIP_REASONS);
+		return notListed <= 0
+				? listed
+				: listed + "; ... (+" + notListed + ")";
 	}
 
 	@Override
 	public int getInvoiceCandidateEnqueuedCount()
 	{
 		return invoiceCandidateEnqueuedCount;
+	}
+
+	@Override
+	public int getInvoiceCandidateSkippedCount()
+	{
+		return skipReasons.size();
+	}
+
+	@Override
+	public ImmutableList<String> getSkipReasons()
+	{
+		return skipReasons;
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
@@ -173,9 +173,6 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 
 		final int workpackageQueueSizeBeforeEnqueueing = workpackageAggregator.getQueueSize();
 		int invoiceCandidateSelectionCount = 0; // how many eligible items were in given selection
-		// Collected so the run can REPORT what it dropped. Until now every skip reason went to Loggables
-		// (the process log) only, and the result carried just the enqueued count -- so in a mixed selection the
-		// good candidates were invoiced and the dropped ones were never mentioned anywhere the user looks.
 		final ImmutableList.Builder<String> skipReasons = ImmutableList.builder();
 		final ICNetAmtToInvoiceChecker totalNetAmtToInvoiceChecksum = new ICNetAmtToInvoiceChecker();
 
@@ -242,10 +239,8 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 		final ImmutableList<String> skipReasonsCollected = skipReasons.build();
 
 		//
-		// If no workpackages were created, display error message that no selection was made (07666).
-		// Report WHY when we know: this branch is reached whenever the whole selection was skipped, which is
-		// the other half of the same defect -- the bare message alone leaves the user with a selection that
-		// "cannot be invoiced" and no way to find out what is wrong with any of it.
+		// If no workpackages were created, display error message that no selection was made (07666),
+		// naming the skip reasons when we have them.
 		if (isFailIfNothingEnqueued() && invoiceCandidateSelectionCount <= 0)
 		{
 			final String noCandidatesMsg = "@" + MSG_INVOICE_GENERATE_NO_CANDIDATES_SELECTED_0P + "@";
@@ -253,8 +248,7 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 			{
 				throw new AdempiereException(noCandidatesMsg);
 			}
-			// No markAsUserValidationError() needed: AdempiereException(String) already sets that flag for any
-			// message containing '@', which the "@...@" prefix always does.
+			// No markAsUserValidationError() needed: AdempiereException(String) sets it for any '@'-wrapped message.
 			throw new AdempiereException(noCandidatesMsg + " "
 					+ InvoiceCandidateEnqueueResult.buildSkippedSummary(getCtx(), skipReasonsCollected, skipReasonsCollected.size()));
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
@@ -23,6 +23,7 @@
 package de.metas.invoicecandidate.api.impl;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import de.metas.async.AsyncBatchId;
 import de.metas.async.spi.IWorkpackagePrioStrategy;
 import de.metas.async.spi.impl.ConstantWorkpackagePrio;
@@ -44,7 +45,6 @@ import de.metas.lock.api.ILockAutoCloseable;
 import de.metas.logging.TableRecordMDC;
 import de.metas.process.PInstanceId;
 import de.metas.util.Check;
-import com.google.common.collect.ImmutableList;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -60,6 +60,7 @@ import org.slf4j.MDC.MDCCloseable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import javax.annotation.Nullable;
+
 import java.util.Iterator;
 import java.util.Properties;
 import java.util.Set;
@@ -238,11 +239,23 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 		// Make sure all workpackages are marked as ready for processing
 		workpackageAggregator.closeAllGroups();
 
+		final ImmutableList<String> skipReasonsCollected = skipReasons.build();
+
 		//
-		// If no workpackages were created, display error message that no selection was made (07666)
+		// If no workpackages were created, display error message that no selection was made (07666).
+		// Report WHY when we know: this branch is reached whenever the whole selection was skipped, which is
+		// the other half of the same defect -- the bare message alone leaves the user with a selection that
+		// "cannot be invoiced" and no way to find out what is wrong with any of it.
 		if (isFailIfNothingEnqueued() && invoiceCandidateSelectionCount <= 0)
 		{
-			throw new AdempiereException("@" + MSG_INVOICE_GENERATE_NO_CANDIDATES_SELECTED_0P + "@");
+			final String noCandidatesMsg = "@" + MSG_INVOICE_GENERATE_NO_CANDIDATES_SELECTED_0P + "@";
+			if (skipReasonsCollected.isEmpty())
+			{
+				throw new AdempiereException(noCandidatesMsg);
+			}
+			throw new AdempiereException(noCandidatesMsg + " "
+					+ InvoiceCandidateEnqueueResult.buildSkippedSummary(getCtx(), skipReasonsCollected, skipReasonsCollected.size()))
+					.markAsUserValidationError();
 		}
 
 		//
@@ -252,7 +265,7 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 				workpackageAggregator.getGroupsCount(),
 				workpackageQueueSizeBeforeEnqueueing,
 				totalNetAmtToInvoiceChecksum.getValue(),
-				skipReasons.build(),
+				skipReasonsCollected,
 				icLock);
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
@@ -253,9 +253,10 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 			{
 				throw new AdempiereException(noCandidatesMsg);
 			}
+			// No markAsUserValidationError() needed: AdempiereException(String) already sets that flag for any
+			// message containing '@', which the "@...@" prefix always does.
 			throw new AdempiereException(noCandidatesMsg + " "
-					+ InvoiceCandidateEnqueueResult.buildSkippedSummary(getCtx(), skipReasonsCollected, skipReasonsCollected.size()))
-					.markAsUserValidationError();
+					+ InvoiceCandidateEnqueueResult.buildSkippedSummary(getCtx(), skipReasonsCollected, skipReasonsCollected.size()));
 		}
 
 		//

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
@@ -44,6 +44,7 @@ import de.metas.lock.api.ILockAutoCloseable;
 import de.metas.logging.TableRecordMDC;
 import de.metas.process.PInstanceId;
 import de.metas.util.Check;
+import com.google.common.collect.ImmutableList;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -58,6 +59,7 @@ import org.slf4j.MDC.MDCCloseable;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.Properties;
 import java.util.Set;
@@ -170,6 +172,10 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 
 		final int workpackageQueueSizeBeforeEnqueueing = workpackageAggregator.getQueueSize();
 		int invoiceCandidateSelectionCount = 0; // how many eligible items were in given selection
+		// Collected so the run can REPORT what it dropped. Until now every skip reason went to Loggables
+		// (the process log) only, and the result carried just the enqueued count -- so in a mixed selection the
+		// good candidates were invoiced and the dropped ones were never mentioned anywhere the user looks.
+		final ImmutableList.Builder<String> skipReasons = ImmutableList.builder();
 		final ICNetAmtToInvoiceChecker totalNetAmtToInvoiceChecksum = new ICNetAmtToInvoiceChecker();
 
 		//
@@ -190,8 +196,10 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 				}
 
 				// Check if invoice candidate is eligible for enqueueing
-				if (!isEligibleForEnqueueing(icRecord))
+				final String skipReason = getSkipReasonOrNull(icRecord);
+				if (skipReason != null)
 				{
+					skipReasons.add(skipReason);
 					continue;
 				}
 
@@ -244,13 +252,15 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 				workpackageAggregator.getGroupsCount(),
 				workpackageQueueSizeBeforeEnqueueing,
 				totalNetAmtToInvoiceChecksum.getValue(),
+				skipReasons.build(),
 				icLock);
 	}
 
 	/**
-	 * @return true if invoice candidate is eligible for enqueueing
+	 * @return the translated reason this invoice candidate is NOT enqueued, or {@code null} if it is eligible.
 	 */
-	private boolean isEligibleForEnqueueing(final I_C_Invoice_Candidate ic)
+	@Nullable
+	private String getSkipReasonOrNull(final I_C_Invoice_Candidate ic)
 	{
 		final IMsgBL msgBL = Services.get(IMsgBL.class);
 
@@ -260,16 +270,17 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 		{
 			final String msg = msgBL.getMsg(getCtx(), MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_APPROVAL, new Object[] { ic.getC_Invoice_Candidate_ID() });
 			Loggables.addLog(msg);
-			return false;
+			return msg;
 		}
 
 		//
 		// Check other reasons no to enqueue this ic: Processed, IsError, DateToInvoice.
 		// NOTE: having this line in the middle because we will display only one skip reason and SKIPPED_QTY_TO_INVOICE is usually less informative if the IC was already processed
-		if (invoiceCandBL.isSkipCandidateFromInvoicing(ic, getInvoicingParams().isIgnoreInvoiceSchedule(), getInvoicingParams().isInvoiceManualRule()))
+		final String skipReason = invoiceCandBL.getInvoicingSkipReasonOrNull(ic, getInvoicingParams().isIgnoreInvoiceSchedule(), getInvoicingParams().isInvoiceManualRule());
+		if (skipReason != null)
 		{
-			// NOTE: we are not logging any reason because the method already logged the reason if any.
-			return false;
+			// NOTE: not logging here -- the method above already logged the reason.
+			return skipReason;
 		}
 
 		//
@@ -279,10 +290,10 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 		{
 			final String msg = msgBL.getMsg(getCtx(), MSG_INVOICE_CAND_BL_INVOICING_SKIPPED_QTY_TO_INVOICE, new Object[] { ic.getC_Invoice_Candidate_ID() });
 			Loggables.addLog(msg);
-			return false;
+			return msg;
 		}
 
-		return true;
+		return null; // eligible
 	}
 
 	private void updateSelectionBeforeEnqueueing(@NonNull final PInstanceId selectionId)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822070_sys_gh30786_InvoiceCandidateEnqueue_Skipped_message.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822070_sys_gh30786_InvoiceCandidateEnqueue_Skipped_message.sql
@@ -2,16 +2,8 @@
 --   AD_MigrationScript 5822070 (this script)
 --   AD_Message         545824 (InvoiceCandidateEnqueue_Skipped)
 --
--- Appended to the "Auswahl Fakturieren" process summary -- the string the user sees the moment the
--- run finishes -- when the ENQUEUER dropped part of the selection before any invoicing was attempted
--- (candidate already processed, in dispute, to-clear, simulation, manual rule, date not yet due, or
--- QtyOrdered <> 0 with QtyToInvoice = 0).
---
--- Reported in the SUMMARY rather than as a user notification on purpose: the summary is synchronous,
--- reaches whoever started the run, and does not depend on that user's AD_User.NotificationType.
---   {0} = how many of the selected candidates were skipped
---   {1} = how many candidates were selected
---   {2} = the skip reasons (first few; the process log has them all)
+-- Appended to the "Auswahl Fakturieren" process summary when the enqueuer skipped part of the selection.
+--   {0} = candidates skipped, {1} = candidates selected, {2} = the reasons (first few; all are in the process log)
 
 -- 2026-09-03T01:05:01
 INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822070_sys_gh30786_InvoiceCandidateEnqueue_Skipped_message.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822070_sys_gh30786_InvoiceCandidateEnqueue_Skipped_message.sql
@@ -1,0 +1,39 @@
+-- IDs allocated from idserver.metas.de on 2026-09-03:
+--   AD_MigrationScript 5822070 (this script)
+--   AD_Message         545824 (InvoiceCandidateEnqueue_Skipped)
+--
+-- Appended to the "Auswahl Fakturieren" process summary -- the string the user sees the moment the
+-- run finishes -- when the ENQUEUER dropped part of the selection before any invoicing was attempted
+-- (candidate already processed, in dispute, to-clear, simulation, manual rule, date not yet due, or
+-- QtyOrdered <> 0 with QtyToInvoice = 0).
+--
+-- Reported in the SUMMARY rather than as a user notification on purpose: the summary is synchronous,
+-- reaches whoever started the run, and does not depend on that user's AD_User.NotificationType.
+--   {0} = how many of the selected candidates were skipped
+--   {1} = how many candidates were selected
+--   {2} = the skip reasons (first few; the process log has them all)
+
+-- 2026-09-03T01:05:01
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545824 /*From ID Server*/,0,TO_TIMESTAMP('2026-09-03 01:05:01','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','{0} von {1} ausgewählten Rechnungskandidat(en) wurden nicht fakturiert: {2}','I',TO_TIMESTAMP('2026-09-03 01:05:01','YYYY-MM-DD HH24:MI:SS'),100,'InvoiceCandidateEnqueue_Skipped')
+;
+
+-- 2026-09-03T01:05:02
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545824
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- 2026-09-03T01:05:03
+UPDATE AD_Message_Trl SET MsgText='{0} of {1} selected invoice candidate(s) were not invoiced: {2}',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-03 01:05:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545824
+;
+
+-- 2026-09-03T01:05:04
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-03 01:05:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545824
+;
+
+-- 2026-09-03T01:05:05
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-03 01:05:05','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545824
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822080_sys_gh30786_InvoicingProblems_NotificationGroup.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822080_sys_gh30786_InvoicingProblems_NotificationGroup.sql
@@ -5,7 +5,8 @@
 -- The topic (InvoiceUserNotificationsProducer.EVENTBUS_TOPIC_Error) shipped without its group row.
 -- InternalName MUST equal the topic name -- UserNotificationsConfig.getGroupByName() matches exactly and
 -- otherwise falls back to AD_User.NotificationType, and the topic stays invisible in the subscription tabs.
--- Name says "problems", not "errors", because this one group also covers the enqueuer's skip report.
+-- Name says "problems", not "errors": Event_InvoicingError rides this topic, while the enqueuer's skip
+-- report goes into the process summary instead -- one word covering both channels.
 
 -- 2026-09-03T00:10:07
 INSERT INTO AD_NotificationGroup (AD_Client_ID,AD_NotificationGroup_ID,AD_Org_ID,Created,CreatedBy,EntityType,InternalName,IsActive,Name,Updated,UpdatedBy)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822080_sys_gh30786_InvoicingProblems_NotificationGroup.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822080_sys_gh30786_InvoicingProblems_NotificationGroup.sql
@@ -2,20 +2,9 @@
 --   AD_MigrationScript    5822080 (this script)
 --   AD_NotificationGroup  540026 (de.metas.invoicecandidate.UserNotifications.InvoicingErrors)
 --
--- The event-bus topic de.metas.invoicecandidate.UserNotifications.InvoicingErrors was shipped
--- (InvoiceUserNotificationsProducer.EVENTBUS_TOPIC_Error, registered in ConfigValidator.onAfterInit)
--- WITHOUT its AD_NotificationGroup row. InternalName must equal the topic name, because
--- UserNotificationsConfig.getGroupByName() matches on it exactly and otherwise falls back to
--- `defaults` -- i.e. to AD_User.NotificationType, which is NOT NULL DEFAULT 'E' (EMail only), so
--- a user on the default gets no entry in the notification bell at all.
---
--- Without this row the topic is also invisible in "Mein Profil" -> Notifications, in the role
--- admin window's Notification Groups tab, and to AD_NotificationGroup_CC -- so nobody can opt in
--- or out of it, and no CC recipient can be configured.
---
--- Name is deliberately "problems" rather than "errors": Event_InvoicingError (enqueued, then failed
--- during the async invoicing) rides this topic, while the enqueuer's skip report goes into the process
--- summary instead. One subscription therefore covers "my Create Invoices run had a problem".
+-- The topic (InvoiceUserNotificationsProducer.EVENTBUS_TOPIC_Error) shipped without its group row.
+-- InternalName MUST equal the topic name -- UserNotificationsConfig.getGroupByName() matches exactly and
+-- otherwise falls back to AD_User.NotificationType, and the topic stays invisible in the subscription tabs.
 
 -- 2026-09-03T00:10:07
 INSERT INTO AD_NotificationGroup (AD_Client_ID,AD_NotificationGroup_ID,AD_Org_ID,Created,CreatedBy,EntityType,InternalName,IsActive,Name,Updated,UpdatedBy)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822080_sys_gh30786_InvoicingProblems_NotificationGroup.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822080_sys_gh30786_InvoicingProblems_NotificationGroup.sql
@@ -1,0 +1,23 @@
+-- IDs allocated from idserver.metas.de on 2026-09-03:
+--   AD_MigrationScript    5822080 (this script)
+--   AD_NotificationGroup  540026 (de.metas.invoicecandidate.UserNotifications.InvoicingErrors)
+--
+-- The event-bus topic de.metas.invoicecandidate.UserNotifications.InvoicingErrors was shipped
+-- (InvoiceUserNotificationsProducer.EVENTBUS_TOPIC_Error, registered in ConfigValidator.onAfterInit)
+-- WITHOUT its AD_NotificationGroup row. InternalName must equal the topic name, because
+-- UserNotificationsConfig.getGroupByName() matches on it exactly and otherwise falls back to
+-- `defaults` -- i.e. to AD_User.NotificationType, which is NOT NULL DEFAULT 'E' (EMail only), so
+-- a user on the default gets no entry in the notification bell at all.
+--
+-- Without this row the topic is also invisible in "Mein Profil" -> Notifications, in the role
+-- admin window's Notification Groups tab, and to AD_NotificationGroup_CC -- so nobody can opt in
+-- or out of it, and no CC recipient can be configured.
+--
+-- Name is deliberately "problems" rather than "errors": both the Event_InvoicingError (enqueued
+-- then failed) rides this topic; the enqueuer's skip report goes into the process summary instead, so it
+-- topic, so that a user needs a single subscription for "my Create Invoices run had a problem".
+
+-- 2026-09-03T00:10:07
+INSERT INTO AD_NotificationGroup (AD_Client_ID,AD_NotificationGroup_ID,AD_Org_ID,Created,CreatedBy,EntityType,InternalName,IsActive,Name,Updated,UpdatedBy)
+VALUES (0,540026 /*From ID Server*/,0,TO_TIMESTAMP('2026-09-03 00:10:07','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.invoicecandidate','de.metas.invoicecandidate.UserNotifications.InvoicingErrors','Y','Billing - Invoicing problems',TO_TIMESTAMP('2026-09-03 00:10:07','YYYY-MM-DD HH24:MI:SS'),100)
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822080_sys_gh30786_InvoicingProblems_NotificationGroup.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822080_sys_gh30786_InvoicingProblems_NotificationGroup.sql
@@ -13,9 +13,9 @@
 -- admin window's Notification Groups tab, and to AD_NotificationGroup_CC -- so nobody can opt in
 -- or out of it, and no CC recipient can be configured.
 --
--- Name is deliberately "problems" rather than "errors": both the Event_InvoicingError (enqueued
--- then failed) rides this topic; the enqueuer's skip report goes into the process summary instead, so it
--- topic, so that a user needs a single subscription for "my Create Invoices run had a problem".
+-- Name is deliberately "problems" rather than "errors": Event_InvoicingError (enqueued, then failed
+-- during the async invoicing) rides this topic, while the enqueuer's skip report goes into the process
+-- summary instead. One subscription therefore covers "my Create Invoices run had a problem".
 
 -- 2026-09-03T00:10:07
 INSERT INTO AD_NotificationGroup (AD_Client_ID,AD_NotificationGroup_ID,AD_Org_ID,Created,CreatedBy,EntityType,InternalName,IsActive,Name,Updated,UpdatedBy)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822080_sys_gh30786_InvoicingProblems_NotificationGroup.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822080_sys_gh30786_InvoicingProblems_NotificationGroup.sql
@@ -5,6 +5,7 @@
 -- The topic (InvoiceUserNotificationsProducer.EVENTBUS_TOPIC_Error) shipped without its group row.
 -- InternalName MUST equal the topic name -- UserNotificationsConfig.getGroupByName() matches exactly and
 -- otherwise falls back to AD_User.NotificationType, and the topic stays invisible in the subscription tabs.
+-- Name says "problems", not "errors", because this one group also covers the enqueuer's skip report.
 
 -- 2026-09-03T00:10:07
 INSERT INTO AD_NotificationGroup (AD_Client_ID,AD_NotificationGroup_ID,AD_Org_ID,Created,CreatedBy,EntityType,InternalName,IsActive,Name,Updated,UpdatedBy)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822130_sys_gh30786_InvoicingSkipped_Simulation_message.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822130_sys_gh30786_InvoicingSkipped_Simulation_message.sql
@@ -2,11 +2,8 @@
 --   AD_MigrationScript 5822130 (this script)
 --   AD_Message         545825 (InvoiceCandBL_Invoicing_Skipped_Simulation)
 --
--- The simulation branch of isSkipCandidateFromInvoicing was the only one of its six that had no
--- AD_Message: it logged a formatted template and built no reusable text. That was harmless while the
--- reason only reached the process log, but the reason is now surfaced in the "Auswahl Fakturieren"
--- summary, so an untranslated Java-built string would put English technical text into a German
--- sentence. Wording mirrors its five siblings (InvoiceCandBL_Invoicing_Skipped_*).
+-- The simulation branch of isSkipCandidateFromInvoicing was the only skip reason with no AD_Message;
+-- the reason now reaches the user in the process summary. Wording mirrors InvoiceCandBL_Invoicing_Skipped_*.
 --   {0} = C_Invoice_Candidate_ID
 
 -- 2026-09-03T07:40:01

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822130_sys_gh30786_InvoicingSkipped_Simulation_message.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822130_sys_gh30786_InvoicingSkipped_Simulation_message.sql
@@ -1,0 +1,31 @@
+-- IDs allocated from idserver.metas.de on 2026-09-03:
+--   AD_MigrationScript 5822130 (this script)
+--   AD_Message         545825 (InvoiceCandBL_Invoicing_Skipped_Simulation)
+--
+-- The simulation branch of isSkipCandidateFromInvoicing was the only one of its six that had no
+-- AD_Message: it logged a formatted template and built no reusable text. That was harmless while the
+-- reason only reached the process log, but the reason is now surfaced in the "Auswahl Fakturieren"
+-- summary, so an untranslated Java-built string would put English technical text into a German
+-- sentence. Wording mirrors its five siblings (InvoiceCandBL_Invoicing_Skipped_*).
+--   {0} = C_Invoice_Candidate_ID
+
+-- 2026-09-03T07:40:01
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545825 /*From ID Server*/,0,TO_TIMESTAMP('2026-09-03 07:40:01','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.invoicecandidate','Y','Überspringe Rechnungskandidat {0}, da es sich um eine Simulation handelt.','I',TO_TIMESTAMP('2026-09-03 07:40:01','YYYY-MM-DD HH24:MI:SS'),100,'InvoiceCandBL_Invoicing_Skipped_Simulation')
+;
+
+-- 2026-09-03T07:40:02
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545825
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- 2026-09-03T07:40:03
+UPDATE AD_Message_Trl SET MsgText='Skipping invoice candidate {0} because it is a simulation.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-03 07:40:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545825
+;
+
+-- 2026-09-03T07:40:04
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-03 07:40:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545825
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822130_sys_gh30786_InvoicingSkipped_Simulation_message.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5822130_sys_gh30786_InvoicingSkipped_Simulation_message.sql
@@ -27,5 +27,9 @@ UPDATE AD_Message_Trl SET MsgText='Skipping invoice candidate {0} because it is 
 ;
 
 -- 2026-09-03T07:40:04
-UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-03 07:40:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545825
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-03 07:40:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545825
+;
+
+-- 2026-09-03T07:40:05
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-03 07:40:05','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545825
 ;


### PR DESCRIPTION
## What

A "Create Invoices" run now reports the invoice candidates it skipped, instead of dropping them silently.

## Why

The enqueuer skips a selected candidate for any of several reasons (already processed, in error, to-clear, in dispute, simulation, manual rule, date not yet due, or `QtyOrdered <> 0` with `QtyToInvoice = 0`). Every reason went to `Loggables` — the process log — only:

- `IInvoiceCandidateEnqueueResult` carried just the enqueued count, so a **mixed** selection invoiced the eligible candidates and said nothing about the dropped ones.
- When the **whole** selection was skipped, the enqueuer threw the bare, parameterless `InvoiceGenerate_No_Candidates_Selected` *before* building any result, so the user learned the selection could not be invoiced but not what was wrong with it.

The silence was structural across all skip reasons, not specific to one of them.

## How

Reported in the process **summary** — the string `doIt()` returns and the WebUI shows the user — rather than as a user notification. The summary is synchronous, reaches whoever started the run, and does not depend on that user's `AD_User.NotificationType`, which is `NOT NULL DEFAULT 'E'` (EMail only) and would leave the notification bell empty for a user on the default.

- `IInvoiceCandBL.getInvoicingSkipReasonOrNull(...)` yields the translated reason each branch of `isSkipCandidateFromInvoicing` was already building for the log. The boolean `isSkipCandidateFromInvoicing` delegates to it, so existing callers are untouched.
- `InvoiceCandidateEnqueuer` collects one reason per dropped candidate; both the result path and the all-skipped throw render the same sentence through one shared builder, so the two cannot drift.
- The summary lists at most five reasons plus a `(+N)` tail — a selection can hold thousands, and each reason names its candidate.
- The simulation branch was the only skip reason with no `AD_Message`; it now has one, so no untranslated Java-built text reaches the user.
- Adds the `AD_NotificationGroup` row for `de.metas.invoicecandidate.UserNotifications.InvoicingErrors`, a topic that shipped without its group record. Without it `UserNotificationsConfig.getGroupByName` falls through to `AD_User.NotificationType` and the topic is invisible in *My Profile -> Notifications*, so nobody can opt in or out and no CC recipient can be configured.

## Scope note

The improvement covers the manual *Auswahl Fakturieren* process. Two other callers of the enqueuer discard the result entirely and are unchanged here: `InvoiceService.generateInvoicesForAsyncBatch` (the async-batch path) and `C_Invoice_Candidate_Enqueue_AutoInvoice_Schedule` (the scheduled run, which hardcodes its own summary). Neither has a user-facing surface to render a summary on.

## Tests

Four cucumber scenarios in `createInvoicesReportsFailures.feature`, driving the real `AD_Process` rather than `InvoiceService` (which discards the enqueue result, so the summary is not observable through it):

- mixed selection, two candidates on different bill partners, the second staged `QtyToInvoice_Override = 0` with `QtyOrdered` still `> 0` -- asserts the summary reports `1 von 2` and names the reason
- whole selection skipped -- asserts the error carries the reason rather than the bare message
- the two pre-existing failure-path scenarios, one of which gained the `AD_Note table is reset` step its sibling already had, so the feature is re-runnable against a persistent database instead of only a pristine one

Both new scenarios were confirmed to fail without their respective fixes and to pass with them. The `de.metas.swat.base` unit suite reports 426 tests, 0 failures, 0 errors, 9 pre-existing skips -- unchanged from baseline.
