### PR TITLE
BP print-format spec — match the Yes option on both branches' dropdown contracts

### DIFF
--- a/e2e/frontend-webui/tests/spec/bp-print-format-config-fields.spec.js
+++ b/e2e/frontend-webui/tests/spec/bp-print-format-config-fields.spec.js
@@ -27,23 +27,30 @@ import { getIncludedRecordData } from '../utils/WebAPIValidation';
  *      (fieldsByName.IsAutoPrint.value.key === 'Y') after a full page reload.
  *
  * Selectors are language-invariant (data-testid / data-cy / DB ColumnName /
- * structural class); the "Yes" option is picked by its `data-test-id`, which begins with the
- * language-invariant AD_Ref_List VALUE key ("Y"). The persisted value is verified
- * language-invariantly via the WebAPI value key ("Y").
+ * structural class); the "Yes" option is picked by the language-invariant AD_Ref_List VALUE
+ * key ("Y"). The persisted value is verified language-invariantly via the WebAPI value
+ * key ("Y").
  */
 
 const PRINT_FORMAT_TAB = 'AD_Tab-540653'; // C_BP_PrintFormat included tab of window 123
 
 // A List (_YesNo) widget renders its options at document level (tethered) as
-// `.input-dropdown-list-option`. Each option carries data-test-id = `${key}${caption}`
-// (SelectionDropdown.renderOption), so it ALWAYS begins with the AD_Ref_List VALUE key
-// ("Y" for Yes, "N" for No) — a truly language-invariant handle. This matters beyond
-// language: the *visible caption* also varies with developer mode — MLookupFactory renders
-// list captions as "Value_Name" (e.g. "Y_Yes") when de.metas.adempiere.debug is on and as
-// the plain translated name (e.g. "Yes" / "Ja") when off (the CI/production default). Only
-// the data-test-id key prefix is stable across BOTH, so selecting by it — mirroring
-// cost-revaluation-copyfrom-field.spec.js — is the correct, config-independent approach.
+// `.input-dropdown-list-option`, each carrying the AD_Ref_List VALUE key ("Y" for Yes, "N"
+// for No) — a truly language-invariant handle. That matters beyond language: the *visible
+// caption* also varies with developer mode — MLookupFactory renders list captions as
+// "Value_Name" (e.g. "Y_Yes") when de.metas.adempiere.debug is on and as the plain
+// translated name (e.g. "Yes" / "Ja") when off (the CI/production default). Only the key is
+// stable across BOTH, so selecting by it is the correct, config-independent approach.
+//
+// The ATTRIBUTE carrying that key differs by branch, so match both — this spec lives on
+// every branch of the propagation chain and a single-contract selector is green on one and
+// deterministically red on the others:
+//   - new_dawn_uat renders data-testid=`option-${key}` (SelectionDropdown.renderOption,
+//     renamed by a5351b4fb3d / pull/22098, which migrated the specs existing at the time);
+//   - intensive_care_hotfix / _release still render data-test-id=`${key}${caption}`.
+// Same dual-contract approach as PaymentPage.js, which keeps a legacy data-test-id fallback.
 const YES_OPTION_BY_KEY =
+  '.input-dropdown-list .input-dropdown-list-option[data-testid="option-Y"], ' +
   '.input-dropdown-list .input-dropdown-list-option[data-test-id^="Y"]';
 
 /**

--- a/e2e/frontend-webui/tests/spec/bp-print-format-config-fields.spec.js
+++ b/e2e/frontend-webui/tests/spec/bp-print-format-config-fields.spec.js
@@ -42,13 +42,10 @@ const PRINT_FORMAT_TAB = 'AD_Tab-540653'; // C_BP_PrintFormat included tab of wi
 // translated name (e.g. "Yes" / "Ja") when off (the CI/production default). Only the key is
 // stable across BOTH, so selecting by it is the correct, config-independent approach.
 //
-// The ATTRIBUTE carrying that key differs by branch, so match both — this spec lives on
-// every branch of the propagation chain and a single-contract selector is green on one and
-// deterministically red on the others:
-//   - new_dawn_uat renders data-testid=`option-${key}` (SelectionDropdown.renderOption,
-//     renamed by a5351b4fb3d / pull/22098, which migrated the specs existing at the time);
-//   - intensive_care_hotfix / _release still render data-test-id=`${key}${caption}`.
-// Same dual-contract approach as PaymentPage.js, which keeps a legacy data-test-id fallback.
+// SelectionDropdown renders that key under a different ATTRIBUTE per branch line —
+// `data-testid` = `option-${key}` on one, `data-test-id` = `${key}${caption}` on the other —
+// so match both: this spec lives on every branch of the propagation chain, and a
+// single-contract selector is green on one and deterministically red on the rest.
 const YES_OPTION_BY_KEY =
   '.input-dropdown-list .input-dropdown-list-option[data-testid="option-Y"], ' +
   '.input-dropdown-list .input-dropdown-list-option[data-test-id^="Y"]';


### PR DESCRIPTION
## What

The BP print-format spec picked the "Yes" option of the `IsAutoPrint` / `IsDropShip` List widgets by
`data-test-id=` + the AD_Ref_List value key — the attribute `SelectionDropdown` renders on the
`intensive_care` line. On `new_dawn_uat` that attribute was renamed to ``data-testid=`option-${key}` `` by
https://github.com/metasfresh/metasfresh/commit/a5351b4fb3d
(https://github.com/metasfresh/metasfresh/pull/22098), which migrated the specs existing at the time.

This spec was authored afterwards, on the hotfix line, against the hotfix contract — green here, and
deterministically red once propagation carried it up. Being a new file it never conflicts, so nothing flagged
the mismatch.

This change matches both attributes. There is precedent for the same dual-contract handling in
`PaymentPage.js` — though note that file exists only on `new_dawn_uat`, added by the same commit that did the
rename. Test-only; no production code, no migration.

## Evidence

Verified (runtime, CI): https://github.com/metasfresh/metasfresh/actions/runs/33780802579/job/100744321696 —
job `frontend webui test (1/3)` on `new_dawn_uat` at `28f5aef11b1`, spec
`bp-print-format-config-fields.spec.js:103`, both languages, 3/3 retries on every run attempt, never once
passing. The job's own call log shows
`waiting for locator('.input-dropdown-list .input-dropdown-list-option[data-test-id^="Y"]')` timing out at 20 s.

Verified (runtime, shipped artifact): `docker run --rm metasfresh/metas-frontend:5.175-new-dawn-uat.43108` and
grep of the served JS bundle → `"data-testid":"option-".concat(o)` sits immediately beside
`input-dropdown-list-option`, and the string `data-test-id` has zero occurrences anywhere in the bundle. The
attribute this spec selects on is not rendered by the build that ran.

Confirmed via `git show origin/<branch>:frontend/src/__tests__/components/widget/SelectionDropdown.test.js`:
each branch's own jest test asserts its own contract — `new_dawn_uat` → `data-testid="option-${newOption.key}"`;
`intensive_care_hotfix` → `data-test-id="${newOption.key}${newOption.caption}"`.

Verified (runtime, DB query — rules out an AD defect): `psql` against throwaway containers of the two CI DB
images `metas-db:5.175-new-dawn-uat.43108-preloaded` and `metas-db:5.175-intensive-care-hotfix.43080-preloaded`,
with `SELECT` over `AD_Column` / `AD_Ref_List` / `AD_Field` / `AD_UI_Element`. `AD_Column` 593459 `IsAutoPrint`
and 593458 `IsDropShip` are identical on both: `AD_Reference_ID=17` (List) over `AD_Reference_Value_ID=319`
(`_YesNo`), same `AD_Ref_List` entries with both translations, same fields and UI elements. Corroborated by the
failing run itself: `db-apply-migrations` and `health check` were green there, and the spec's earlier step
asserting `.form-field-IsAutoPrint.widgetType-List` is visible passes — only the option-pick fails.

So the field renders correctly on `new_dawn_uat` and its metadata is right; the spec encodes an obsolete DOM
contract. Fixing the spec is the root-cause fix, not a workaround.

## Why on `intensive_care_hotfix`

The spec lives on every branch of the propagation chain and the two frontend contracts differ, so the fix
belongs on the lowest affected branch and propagates up. A `new_dawn_uat`-only fix would break the same spec on
`_hotfix` / `_release` and guarantee a conflict at the next propagation.

## Not addressed here

The underlying divergence remains: any new frontend spec authored on `_hotfix` against the old contract is the
same silent landmine. Removing it properly means forward-porting the `SelectionDropdown` rename to `_hotfix` /
`_release` — a frontend change on a customer hotfix branch with a much wider blast radius, so it wants its own
issue.
