### PR TITLE
Order-board jump — open Traffic Management on the unassigned schedules, as a clearable filter

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5822540_sys_OrderBoard_to_TrafficManagement_IsUseAutoFilters.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5822540_sys_OrderBoard_to_TrafficManagement_IsUseAutoFilters.sql
@@ -1,0 +1,29 @@
+-- Auftrags-Board -> Traffic Management jump: open the overlay on the schedules that still need a
+-- workplace, by letting the target window's own default filters apply.
+--
+-- The jump process (AD_Process 585657, Value M_Picking_OrderBoard_Overview_v_to_TrafficManagement) was
+-- created with IsUseAutoFilters='N', i.e. it showed every schedule the relation resolved. Traffic
+-- Management's IsAssigned column carries FilterDefaultValue='N' and is that window's ONLY auto-filter
+-- (it is the sole column of M_Picking_Job_Schedule_view with a non-null FilterDefaultValue), so
+-- switching this flag to 'Y' makes the overlay open pre-filtered to the not-yet-assigned schedules --
+-- intersected, as before, with the relation's own where-clause, which keeps the jump to rows the board
+-- itself shows (isassigned='Y' OR qtyonhand>0).
+--
+-- Deliberately a DEFAULT FILTER rather than a where-clause term: this is a first draft for a customer
+-- feedback round, so the restriction has to be the overlay's opening state and NOT a decision baked
+-- into the relation. Arriving as a filter value, it is rendered in the overlay's filter bar, and the
+-- operator can clear or change it to bring the already-assigned schedules back into view. A
+-- where-clause term would give the same opening rows with no way to look past them.
+--
+-- The relation's target where-clause (AD_Ref_Table for AD_Reference 542136) is deliberately left
+-- untouched: its trailing board-visibility test is a hard invariant, not a user preference.
+--
+-- Ordinary navigation to Traffic Management is unaffected -- IsUseAutoFilters is read per AD_Process
+-- when the overlay view is built, not when the window is opened from the menu.
+
+UPDATE AD_Process
+SET IsUseAutoFilters = 'Y',
+    Updated          = TO_TIMESTAMP('2026-09-03 23:56:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy        = 100
+WHERE AD_Process_ID = 585657
+;

--- a/e2e/frontend-webui/tests/spec/order-board-jump-to-traffic-management.spec.js
+++ b/e2e/frontend-webui/tests/spec/order-board-jump-to-traffic-management.spec.js
@@ -1052,11 +1052,17 @@ default filter independently hides the assigned line, so the grid holds 1 row be
 after). The soft half has its own coverage: the "fully-assigned board row" and mixed-tuple-with-stock
 tests.
 
-It is backed by an UPPER BOUND that survives that same ambiguity: the jump may never return more rows
-than the board row itself covers (OrderLineCount = 1 here). That bound holds on both sides of the change
-while still failing loudly -- at 2 rows -- if the where-clause's trailing term were dropped and the
-unstocked sibling reappeared. Without it the containment check alone would be close to vacuous in the
-post-change state, where the array it inspects is empty.
+It is accompanied by an UPPER BOUND -- the jump may never return more rows than the board row itself
+covers (OrderLineCount = 1 here) -- which guards a DIFFERENT bug class: duplication / join fan-out in
+the relation, which the containment check cannot see because every duplicated row still carries a
+legitimate qty.
+
+The two are not interchangeable, and the containment check is the one that matters here. Simulating the
+regression on a running stack (dropping the where-clause's trailing term, then re-running this test)
+showed the leak surfacing as EXACTLY ONE row -- the IsAssigned auto-filter removes the assigned line in
+the same fetch -- so the observed array was \`[4]\`: containment fired, the bound (1 <= 1) did not. Do
+not conclude from the bound's presence that the containment assertion is redundant; it is the only
+assertion in this file that catches an unstocked sibling leaking past the where-clause.
 
 Neither assertion is vacuous: the test first asserts that BOTH schedules genuinely exist (each
 carrier-resolved and reachable in Traffic Management's own view before the assignment), that the board
@@ -1130,11 +1136,14 @@ row covers exactly one of them, and that the jump still opens Traffic Management
       returnedQtys,
       'the unassigned line has no stock, so the board does not show it -- the jump\'s where-clause must not return it either'
     ).not.toContain(unassignedQty);
-    // Upper bound, deliberately not an exact count -- see the description for why this test stays
-    // agnostic about the IsAssigned default filter. The jump can never show more schedules than the
-    // board row it was launched from claims to hold, so a leaked unstocked sibling fails here too, on
-    // the count, and not only on the containment check above (which inspects an empty array once the
-    // default filter has also removed the assigned line).
+    // A SEPARATE bug class, not a second line of defence for the check above -- do not treat the
+    // containment assertion as redundant because this one exists. Verified by simulating the
+    // regression on a running stack (dropping the where-clause's trailing term, then re-running this
+    // test): the leak surfaces as EXACTLY ONE row, because the IsAssigned auto-filter removes the
+    // assigned line in the same fetch. The observed result array was `[4]` -- the containment check
+    // fired; this bound (1 <= 1) did not. What the bound does catch is a row count the board itself
+    // cannot justify: duplication / join fan-out in the relation, which containment cannot see
+    // because every returned row would still carry a legitimate qty.
     expect(
       targetView.result.length,
       'the jump must never return more rows than the board row covers (OrderLineCount)'

--- a/e2e/frontend-webui/tests/spec/order-board-jump-to-traffic-management.spec.js
+++ b/e2e/frontend-webui/tests/spec/order-board-jump-to-traffic-management.spec.js
@@ -20,16 +20,24 @@ async function expectDashboardVisible(page) {
  *
  * The Auftrags-Board's Uebersicht tab aggregates M_Picking_Job_Schedule_view rows by product / UOM /
  * delivery date / delivery country / client / org (M_Picking_OrderBoard_Overview_v). This spec proves
- * that selecting one or more board rows and running the (not-yet-existing) jump quick action opens
- * Traffic Management scoped to exactly those rows' schedules -- including rows that are already fully
- * assigned to a workplace, which is exactly the case the customer originally reported as an empty grid.
+ * that selecting one or more board rows and running the jump quick action opens Traffic Management
+ * scoped to exactly the schedules the board row covers that are still WAITING FOR AN ASSIGNMENT.
  *
- * RED-by-construction: the AD_Process / AD_RelationType / AD_Table_Process wiring that offers the jump
- * on the board does not exist yet (a follow-up migration script adds it). Tests 1-4 are therefore
- * expected to FAIL because the Aktionen dropdown never offers
- * [data-testid="quick-action-M_Picking_OrderBoard_Overview_v_to_TrafficManagement"]. Test 5 does not
- * depend on that action at all -- it guards the Traffic Management window's OWN default filter and must
- * pass from the start.
+ * Two independent mechanisms shape what the jump shows, and every test below turns on one of them:
+ *
+ *   - HARD, in the relation's target where-clause: only schedules the BOARD itself admits. The board's
+ *     inclusion test is `isassigned='Y' OR qtyonhand>0`, and the where-clause repeats it on the target
+ *     row, so a schedule sharing the board row's grouping tuple but invisible on the board (an
+ *     unassigned one with no stock) never comes through. The user cannot switch this off.
+ *
+ *   - SOFT, as the target window's own DEFAULT FILTER: only UNASSIGNED schedules. Traffic Management's
+ *     `IsAssigned` column carries FilterDefaultValue='N', and AD_Process.IsUseAutoFilters='Y' makes the
+ *     overlay apply that default. So the jump OPENS on the schedules that still need a workplace -- but
+ *     the restriction arrives as a filter the operator can see and clear in the overlay, not as SQL.
+ *     Clearing it brings the already-assigned schedules back into view.
+ *
+ * The soft half is deliberate: this is a first draft for customer feedback, so "only unassigned" has to
+ * be the opening state, not a decision baked into the relation.
  *
  * Everything is asserted through data-testid / data-cy / REST JSON field names -- never localized UI
  * text (e2e/frontend-webui/CLAUDE.md "Specs MUST be language-independent").
@@ -38,26 +46,22 @@ async function expectDashboardVisible(page) {
 const ORDER_BOARD_WINDOW_ID = 542168; // AD_Window "Auftrags-Board", Uebersicht tab (root), table M_Picking_OrderBoard_Overview_v (542626)
 const TRAFFIC_MANAGEMENT_WINDOW_ID = 541929; // AD_Window "Traffic Management", table M_Picking_Job_Schedule_view (542514)
 
-// AD_Process.Value the follow-up migration is required to use so this data-testid is stable.
+// AD_Process.Value (set by migration 5822100), which is what makes this data-testid stable.
 // QuickActionsDropdown.js renders data-testid="quick-action-" + (action.internalName || action.processId).
 const JUMP_ACTION_TESTID = 'quick-action-M_Picking_OrderBoard_Overview_v_to_TrafficManagement';
-
-// frontend/src/utils/documentListHelper.js DEFAULT_PAGE_LENGTH -- the grid page size a window falls
-// back to when its own layout does not set one (neither the board nor Traffic Management does here).
-const GRID_DEFAULT_PAGE_LENGTH = 15;
 
 /**
  * Poll a grid view (board or Traffic Management) until a row matching `predicate` appears.
  *
- * Neither window has a server-side "default" filter PARAMETER to narrow the fetch to one product
- * (verified against the running stack: the board's Uebersicht tab has no AD_Field marked
- * IsFilterField='Y'), so -- unlike the Material Cockpit v2 / forecast specs -- a single unfiltered
- * fetch (pageLength=500) is used to LOCATE the row via REST. That fetch's order matches what the grid
- * renders (verified: a requested `orderBy` override on the create-view call is silently ignored -- the
- * response always echoes back M_Picking_OrderBoard_Overview_v_ID ascending), so the row's index in it
- * also tells us which GRID PAGE (GRID_DEFAULT_PAGE_LENGTH per page) the UI will show it on -- see
- * `pageNumber` below and selectRow(). Both views can and do accumulate more than one page's worth of
- * rows over a spec run (each test seeds its own uniquely-named product), so this must not assume page 1.
+ * The board's Uebersicht tab has no server-side filter PARAMETER to narrow the fetch to one product
+ * (verified against the running stack: no AD_Field on that tab is marked IsFilterField='Y'), so --
+ * unlike the Material Cockpit v2 / forecast specs -- a single unfiltered fetch (pageLength=500) is used
+ * to LOCATE the row via REST. Traffic Management does have such a parameter, but is polled the same way
+ * here for one predicate shape across both windows.
+ *
+ * This only RESOLVES the row's id; the UI never navigates the view created here. selectBoardRow() /
+ * selectScheduleRow() re-scope to a view holding just the row(s) in question, so where a row would have
+ * landed in the unfiltered grid's paging is irrelevant.
  */
 async function waitForViewRow(page, windowId, predicate, { timeout = 60000 } = {}) {
   const deadline = Date.now() + timeout;
@@ -85,17 +89,9 @@ async function waitForViewRow(page, windowId, predicate, { timeout = 60000 } = {
       return { viewId, result: body.result };
     }, { windowId });
 
-    const rowIndex = view?.result?.findIndex(predicate) ?? -1;
-    if (rowIndex >= 0) {
-      const row = view.result[rowIndex];
-      // The grid renders GRID_DEFAULT_PAGE_LENGTH rows per page (frontend/src/utils/documentListHelper.js
-      // DEFAULT_PAGE_LENGTH); the Overview/Traffic Management views accept no client-requested `orderBy`
-      // override (verified against the running stack -- the create-view response always echoes back
-      // M_Picking_OrderBoard_Overview_v_ID ascending regardless of what is requested), so a freshly-seeded
-      // row can land on any page once this window accumulates more than one page's worth of rows. Compute
-      // which page it is on so selectRow() can navigate there instead of assuming page 1.
-      const pageNumber = Math.floor(rowIndex / GRID_DEFAULT_PAGE_LENGTH) + 1;
-      return { viewId: view.viewId, rowId: row.id, row, pageNumber };
+    const row = view?.result?.find(predicate);
+    if (row) {
+      return { rowId: row.id, row };
     }
     await page.waitForTimeout(2000);
   }
@@ -137,37 +133,8 @@ async function waitForScheduleCarrierResolvedByQty(page, productId, qty, opts) {
 }
 
 /**
- * Create a NEW board view scoped to exactly `rowIds`, via the generic `filterOnlyIds` mechanism
- * (JSONCreateViewRequest.filterOnlyIds -> SqlViewFactory: a server-side sticky `keyColumn IN (...)`
- * filter -- de.metas.ui.web.base SqlViewFactory.java "if (!request.getFilterOnlyIds().isEmpty())";
- * already used the same way by picking-terminal.spec.js). Needed because the Uebersicht tab exposes
- * no AD_Field filter parameter to narrow by product (see waitForViewRow()), so two freshly-seeded rows
- * can otherwise land on different grid pages once the board accumulates more than
- * GRID_DEFAULT_PAGE_LENGTH rows from earlier runs. A view containing only `rowIds` makes their page
- * co-location deterministic (both always fit on page 1) regardless of how many unrelated rows exist
- * in the unfiltered board view. This is a server-side filter on the SAME underlying table/rows, not a
- * different data set -- RelationTypeInOverlayProcess#getSelectedSourceRecordRefs() resolves the
- * selected records from the AD_PInstance selection where-clause, not from the view's own filters, so
- * selecting from this filtered view is equivalent to selecting from the unfiltered one.
- */
-async function createFilteredBoardView(page, rowIds) {
-  return page.evaluate(async ({ windowId, rowIds }) => {
-    const apiUrl = config.API_URL; // see waitForViewRow() for why an absolute base URL is required
-    const created = await fetch(`${apiUrl}/documentView/${windowId}`, {
-      method: 'POST',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-      body: JSON.stringify({ windowId: String(windowId), viewType: 'grid', filterOnlyIds: rowIds }),
-    });
-    if (!created.ok) throw new Error(`create filtered board view failed: ${created.status}`);
-    const { viewId } = await created.json();
-    return viewId;
-  }, { windowId: ORDER_BOARD_WINDOW_ID, rowIds });
-}
-
-/**
- * Poll Traffic Management's OWN default view (its "not assigned" filter -- see test 5 -- already shows
- * a freshly-created, not-yet-assigned schedule) until the row for `productId` has a resolved
+ * Poll Traffic Management's OWN default view (its "not assigned" filter -- see the last test -- already
+ * shows a freshly-created, not-yet-assigned schedule) until the row for `productId` has a resolved
  * Carrier_Product_ID. Needed before the "Schedule" quick action can run: assigning a workplace requires
  * the schedule's carrier already resolved (CreateOrUpdatePickingJobSchedulesCommand.assumeCarrierProductSet,
  * gated by AD_SysConfig de.metas.handlingunits.picking.job_schedule.RequireCarrierProductSet='Y' on this
@@ -185,12 +152,80 @@ async function waitForScheduleCarrierResolved(page, productId, opts) {
   );
 }
 
-/** Navigate to a window/view and select a single row (mirrors material-cockpit-v2-jump-preconditions.spec.js). */
-async function selectRow(page, windowId, viewId, rowId, { pageNumber = 1 } = {}) {
+/**
+ * Create a NEW board view scoped to exactly `rowIds`, via the generic `filterOnlyIds` mechanism
+ * (JSONCreateViewRequest.filterOnlyIds -> SqlViewFactory: a server-side sticky `keyColumn IN (...)`
+ * filter -- de.metas.ui.web.base SqlViewFactory.java "if (!request.getFilterOnlyIds().isEmpty())";
+ * already used the same way by picking-terminal.spec.js).
+ *
+ * Every board selection this spec makes goes through such a view. The Uebersicht tab exposes no
+ * AD_Field filter parameter to narrow by product (see waitForViewRow()), so its unfiltered view
+ * accumulates every row this stack has ever had, and a freshly-seeded row lands on an arbitrary grid
+ * page. A view containing only `rowIds` puts them all on page 1, which removes grid paging from this
+ * spec entirely -- and, for the two-row case, guarantees the page co-location a ctrl-click needs.
+ *
+ * This is a server-side filter on the SAME underlying table/rows, not a different data set --
+ * RelationTypeInOverlayProcess#getSelectedSourceRecordRefs() resolves the selected records from the
+ * AD_PInstance selection where-clause, not from the view's own filters, so selecting from this filtered
+ * view is equivalent to selecting from the unfiltered one.
+ *
+ * `filterOnlyIds` is board-only on purpose: it deserializes to Integer, and Traffic Management's rows
+ * carry the COMPOSED key `<M_ShipmentSchedule_ID>$<M_Picking_Job_Schedule_ID>` (verified against the
+ * running stack -- passing one back yields HTTP 400 "Cannot deserialize value of type Integer").
+ * createScheduleViewForProduct() narrows that window instead.
+ */
+async function createBoardViewScopedTo(page, rowIds) {
+  return page.evaluate(async ({ windowId, rowIds }) => {
+    const apiUrl = config.API_URL; // see waitForViewRow() for why an absolute base URL is required
+    const created = await fetch(`${apiUrl}/documentView/${windowId}`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ windowId: String(windowId), viewType: 'grid', filterOnlyIds: rowIds }),
+    });
+    if (!created.ok) throw new Error(`create scoped board view failed: ${created.status}`);
+    const { viewId } = await created.json();
+    return viewId;
+  }, { windowId: ORDER_BOARD_WINDOW_ID, rowIds });
+}
+
+/**
+ * Create a Traffic Management view narrowed to one product, so a row this spec seeded is always on grid
+ * page 1 no matter how many unrelated schedules the window holds. Unlike the board, Traffic Management
+ * DOES expose filter parameters (its `default` filter carries an M_Product_ID Lookup -- verified against
+ * the running stack's view layout), which is what makes this the workable narrowing here given that
+ * filterOnlyIds cannot address its composed row key (see createBoardViewScopedTo()).
+ *
+ * Note this REPLACES the window's own default filter for this view, so the result contains the product's
+ * schedules whether assigned or not. That is what the callers want: this is used only to reach a row and
+ * act on it (assigning a workplace), never to assert what the JUMP returns -- those assertions always run
+ * against the view the jump itself opened.
+ */
+async function createScheduleViewForProduct(page, productId) {
+  return page.evaluate(async ({ windowId, productId }) => {
+    const apiUrl = config.API_URL; // see waitForViewRow() for why an absolute base URL is required
+    const created = await fetch(`${apiUrl}/documentView/${windowId}`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({
+        windowId: String(windowId),
+        viewType: 'grid',
+        filters: [{ filterId: 'default', parameters: [{ parameterName: 'M_Product_ID', value: productId }] }],
+      }),
+    });
+    if (!created.ok) throw new Error(`create product-scoped Traffic Management view failed: ${created.status}`);
+    const { viewId } = await created.json();
+    return viewId;
+  }, { windowId: TRAFFIC_MANAGEMENT_WINDOW_ID, productId });
+}
+
+/**
+ * Navigate to an already-created view and select `rowId` in it (mirrors
+ * material-cockpit-v2-jump-preconditions.spec.js).
+ */
+async function selectRowInView(page, windowId, viewId, rowId) {
   await page.goto(`${FRONTEND_BASE_URL}/window/${windowId}?viewId=${viewId}`);
-  if (pageNumber > 1) {
-    await goToGridPage(page, pageNumber);
-  }
   const row = page.locator(`tbody tr[data-testid="table-row-${rowId}"]`);
   await row.waitFor({ state: 'visible', timeout: 30000 });
   // A click right after the grid renders does not always land as a selection -- assert it, retrying.
@@ -201,22 +236,18 @@ async function selectRow(page, windowId, viewId, rowId, { pageNumber = 1 } = {})
   return row;
 }
 
-/** Board-scoped convenience wrapper around selectRow(). */
-async function selectBoardRow(page, viewId, rowId, opts) {
-  return selectRow(page, ORDER_BOARD_WINDOW_ID, viewId, rowId, opts);
+/** Select one board row, in a view scoped to just that row. */
+async function selectBoardRow(page, rowId) {
+  const viewId = await createBoardViewScopedTo(page, [rowId]);
+  return selectRowInView(page, ORDER_BOARD_WINDOW_ID, viewId, rowId);
 }
 
-/**
- * Navigate the currently-loaded grid to `pageNumber` (1-based). Needed because a freshly-seeded row can
- * land beyond page 1 once a view accumulates more than GRID_DEFAULT_PAGE_LENGTH rows -- see
- * waitForViewRow(). TablePagination.js renders every page number directly (no "..." compression) for
- * up to 7 pages (`pages < 8`); this deliberately does not handle the compressed/goToPage case, since 7
- * pages (105 rows) is well beyond what this spec's own seeding accumulates in the window's lifetime.
- */
-async function goToGridPage(page, pageNumber) {
-  const pageLink = page.locator('.pagination-wrapper li.page-item a').filter({ hasText: new RegExp(`^${pageNumber}$`) });
-  await pageLink.first().click({ timeout: 15000 });
+/** Select one Traffic Management row, in a view narrowed to its product. */
+async function selectScheduleRow(page, productId, rowId) {
+  const viewId = await createScheduleViewForProduct(page, productId);
+  return selectRowInView(page, TRAFFIC_MANAGEMENT_WINDOW_ID, viewId, rowId);
 }
+
 
 /**
  * Navigate to the board and select TWO rows via ctrl-click (Table.js:191 `e.metaKey || e.ctrlKey` ->
@@ -225,22 +256,12 @@ async function goToGridPage(page, pageNumber) {
  * this gesture was derived from frontend/src/components/table/Table.js and is verified by this test run
  * itself (both rows must show the row-selected class, independent of whether the jump action exists).
  */
-async function selectTwoBoardRows(page, viewId, rowIdFirst, rowIdSecond, { pageNumberFirst = 1, pageNumberSecond = 1 } = {}) {
-  // Both rows must render on the SAME grid page for a ctrl-click to add the second to the first's
-  // selection -- selection state is not verified to survive a page-to-page navigation in this suite
-  // (no precedent), so a cross-page pair is a genuine limitation of this helper, surfaced explicitly
-  // rather than silently attempted. See waitForViewRow() for why a row's page can vary at all.
-  if (pageNumberFirst !== pageNumberSecond) {
-    throw new Error(
-      `Cannot multi-select: row ${rowIdFirst} is on grid page ${pageNumberFirst} but row ${rowIdSecond} is on page ${pageNumberSecond}. ` +
-      'This helper only supports ctrl-clicking two rows on the same page.'
-    );
-  }
-
+async function selectTwoBoardRows(page, rowIdFirst, rowIdSecond) {
+  // A ctrl-click can only ADD to a selection when both rows render on the same grid page, so the pair
+  // gets its own two-row view (see createBoardViewScopedTo()) -- page co-location is then guaranteed
+  // rather than depending on how many unrelated rows the board has accumulated.
+  const viewId = await createBoardViewScopedTo(page, [rowIdFirst, rowIdSecond]);
   await page.goto(`${FRONTEND_BASE_URL}/window/${ORDER_BOARD_WINDOW_ID}?viewId=${viewId}`);
-  if (pageNumberFirst > 1) {
-    await goToGridPage(page, pageNumberFirst);
-  }
 
   const firstRow = page.locator(`tbody tr[data-testid="table-row-${rowIdFirst}"]`);
   await firstRow.waitFor({ state: 'visible', timeout: 30000 });
@@ -292,8 +313,8 @@ const SCHEDULE_ACTION_TESTID = 'quick-action-PickingJobScheduleView_Schedule';
  * as compensation-group-bundle.spec.js already does for a window's own product lookup); the modal's
  * start button carries a stable data-testid (frontend/src/components/app/Modal.js:743).
  */
-async function assignWorkplaceViaScheduleAction(page, viewId, rowId, workplaceName, { pageNumber = 1 } = {}) {
-  await selectRow(page, TRAFFIC_MANAGEMENT_WINDOW_ID, viewId, rowId, { pageNumber });
+async function assignWorkplaceViaScheduleAction(page, productId, rowId, workplaceName) {
+  await selectScheduleRow(page, productId, rowId);
   const dropdown = await openQuickActionsDropdown(page);
   const entry = dropdown.getByTestId(SCHEDULE_ACTION_TESTID);
   await expect(entry, `${SCHEDULE_ACTION_TESTID} must be offered on Traffic Management (pre-existing action)`).toBeVisible({ timeout: 10000 });
@@ -327,6 +348,35 @@ async function fetchViewRows(page, windowId, viewId) {
     if (!resp.ok) throw new Error(`fetch view rows failed: ${resp.status}`);
     return resp.json();
   }, { windowId, viewId });
+}
+
+/**
+ * Assert that one row the jump returned satisfies the jump's own restriction, in full.
+ *
+ * Asserts both halves at once for a row in the jump's DEFAULT (unfiltered-by-the-user) state: it must
+ * be unassigned (the window's IsAssigned default filter, applied because AD_Process.IsUseAutoFilters='Y')
+ * and in stock (the where-clause's board-visibility invariant). Checking both on every returned row means
+ * a regression that drops either one is caught by every test that inspects rows -- not only by the two
+ * mixed-tuple tests that seed the boundary directly.
+ *
+ * `IsAssigned` is a boolean in the view JSON, `QtyOnHand` a numeric string (verified against the
+ * running stack: `{"field":"IsAssigned","value":false}`, `{"field":"QtyOnHand","value":"1000"}`);
+ * both are present in fieldsByName even though QtyOnHand carries IsDisplayed='N' on this tab -- the
+ * same payload property waitForBoardRow() already relies on for M_Product_ID.
+ */
+function expectRowIsUnassignedAndStocked(targetRow, productId) {
+  expect(
+    String(targetRow.fieldsByName?.M_Product_ID?.value?.key),
+    'every row opened by the jump must carry the selected board row\'s product'
+  ).toBe(String(productId));
+  expect(
+    targetRow.fieldsByName?.IsAssigned?.value,
+    'the jump must OPEN on unassigned schedules only (the IsAssigned default filter)'
+  ).toBe(false);
+  expect(
+    Number(targetRow.fieldsByName?.QtyOnHand?.value),
+    'an unassigned schedule is on the board only when it has stock -- the jump must not return one without'
+  ).toBeGreaterThan(0);
 }
 
 /**
@@ -387,10 +437,11 @@ test.describe('Auftrags-Board -> Traffic Management jump', () => {
 1. Seed a sales-order line for a fresh product, with on-hand stock (needed so the still-unassigned
    schedule row clears the board's own \`isassigned='Y' OR qtyonhand>0\` filter) but no workplace.
 2. Select that Auftrags-Board row and run the jump.
-3. Traffic Management opens; every visible row carries that product, and the row count equals the
-   board row's OrderLineCount.
+3. Traffic Management opens; every visible row carries that product, is unassigned and in stock, and
+   the row count equals the board row's OrderLineCount (here the two coincide: the row's only schedule
+   is the unassigned one).
 
-Proves AC1 (the action is offered) and AC2 (single row -> exactly its schedules).
+Proves AC1 (the action is offered) and AC2 (single row -> exactly its schedules that still need one).
     `);
     test.setTimeout(120000);
 
@@ -432,50 +483,48 @@ Proves AC1 (the action is offered) and AC2 (single row -> exactly its schedules)
     await LoginPage.login(masterdata.login.user);
     await expectDashboardVisible(page);
 
-    const { viewId, rowId, row, pageNumber } = await waitForBoardRow(page, productId);
+    const { rowId, row } = await waitForBoardRow(page, productId);
     const expectedOrderLineCount = row.fieldsByName.OrderLineCount.value;
 
-    await selectBoardRow(page, viewId, rowId, { pageNumber });
+    await selectBoardRow(page, rowId);
     const dropdown = await openQuickActionsDropdown(page);
     const entry = dropdown.getByTestId(JUMP_ACTION_TESTID);
 
-    // --- EXPECTED RED: the migration that wires the jump has not been applied yet, so the Aktionen menu
-    // offers no jump entry at all. This is the assertion that must fail right now, for exactly this reason.
-    await expect(entry, `${JUMP_ACTION_TESTID} must be offered once the jump is wired`).toBeVisible({ timeout: 10000 });
+    await expect(entry, `${JUMP_ACTION_TESTID} must be offered for a valid single-row selection`).toBeVisible({ timeout: 10000 });
     await expect(entry, `${JUMP_ACTION_TESTID} must not be disabled for a valid single-row selection`).not.toHaveClass(/quick-actions-item-disabled/);
 
-    // --- Once the jump is wired, the rest of this test proves AC1/AC2 without further changes.
     const { windowId: targetWindowId, viewId: targetViewId } = await clickJumpAndCaptureTargetView(page, entry);
     expect(targetWindowId, 'the jump must open a window other than the board itself').not.toBe(String(ORDER_BOARD_WINDOW_ID));
 
     const targetView = await fetchViewRows(page, targetWindowId, targetViewId);
     expect(targetView.result.length, 'row count must equal the board row\'s OrderLineCount').toBe(expectedOrderLineCount);
     for (const targetRow of targetView.result) {
-      expect(
-        String(targetRow.fieldsByName?.M_Product_ID?.value?.key),
-        'every row opened by the jump must carry the selected board row\'s product'
-      ).toBe(String(productId));
+      expectRowIsUnassignedAndStocked(targetRow, productId);
     }
   });
 
-  test('fully-assigned board row: its rows stay visible after the jump (regression guard)', async ({ page }) => {
+  test('fully-assigned board row: none of its assigned schedules come through the jump', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00245: Traffic Management');
     allure.tag('F00245');
-    allure.story('Jump from a fully-assigned board row must not land on an empty grid');
+    allure.story('Jump from a fully-assigned board row returns nothing to schedule');
     allure.severity('critical');
     allure.description(`
 ### Scenario
 1. Seed a sales-order line assigned to a workplace, so its schedule is IsAssigned='Y' and QtyWaiting=0
    (the board's "In Kommissionierung" bucket).
 2. Select that board row and run the jump.
-3. Traffic Management opens WITH those rows visible -- not an empty grid, and not a grid whose only
-   content is hidden behind the "not assigned" default filter.
+3. Traffic Management opens -- cleanly, on the Traffic Management window, with no error -- and opens on
+   NONE of that row's schedules, because every one of them is already assigned and the overlay applies
+   the window's IsAssigned default filter (AD_Process.IsUseAutoFilters='Y').
 
-This is the exact failure the customer was shown by the predecessor delivery: the
-RelationTypeInOverlayProcess.setUseAutoFilters(true) default re-applied Traffic Management's own
-"Filter nach: Not Zugeordnet" filter on top of an already-assigned selection, hiding every row. Proves
-AC4, and is the regression guard for the AD_Process.IsUseAutoFilters='N' plumbing.
+Proves the "opens on unassigned only" half for the extreme case where the board row has nothing left to
+schedule -- and, just as importantly, that this case does NOT surface as an error: an empty overlay is
+the correct answer here, not a failure. The empty grid is not vacuous: the test first asserts that the
+board row genuinely covers at least one schedule (OrderLineCount > 0) and that every one of them is
+assigned (QtyWaiting = 0), so the emptiness is the filter at work, not a missing schedule or a broken
+jump. The operator can still see those schedules by clearing the filter -- that affordance is covered by
+the mixed-tuple-with-stock test, which has both an assigned and an unassigned row to tell apart.
     `);
     test.setTimeout(120000);
 
@@ -518,26 +567,34 @@ AC4, and is the regression guard for the AD_Process.IsUseAutoFilters='N' plumbin
     await expectDashboardVisible(page);
 
     const scheduleRow = await waitForScheduleCarrierResolved(page, productId);
-    await assignWorkplaceViaScheduleAction(page, scheduleRow.viewId, scheduleRow.rowId, workplaceName, { pageNumber: scheduleRow.pageNumber });
+    await assignWorkplaceViaScheduleAction(page, productId, scheduleRow.rowId, workplaceName);
 
-    const { viewId, rowId, row, pageNumber } = await waitForBoardRow(page, productId);
+    const { rowId, row } = await waitForBoardRow(page, productId);
     expect(row.fieldsByName.QtyWaiting.value, 'the seeded row must be entirely assigned (QtyWaiting=0)').toBe('0');
+    // Non-vacuity: the board row DOES cover at least one schedule (it is built from them), and every
+    // one of those is assigned -- so an empty jump result below can only be the restriction at work.
+    expect(
+      row.fieldsByName.OrderLineCount.value,
+      'the board row must genuinely cover at least one (assigned) schedule -- otherwise an empty jump result proves nothing'
+    ).toBeGreaterThan(0);
 
-    await selectBoardRow(page, viewId, rowId, { pageNumber });
+    await selectBoardRow(page, rowId);
     const dropdown = await openQuickActionsDropdown(page);
     const entry = dropdown.getByTestId(JUMP_ACTION_TESTID);
 
-    // --- EXPECTED RED: no jump entry yet.
-    await expect(entry, `${JUMP_ACTION_TESTID} must be offered once the jump is wired`).toBeVisible({ timeout: 10000 });
+    await expect(entry, `${JUMP_ACTION_TESTID} must be offered for a valid single-row selection`).toBeVisible({ timeout: 10000 });
     await expect(entry, `${JUMP_ACTION_TESTID} must not be disabled for a valid single-row selection`).not.toHaveClass(/quick-actions-item-disabled/);
 
-    // --- Once the jump is wired: the grid must NOT be empty despite every schedule being assigned.
-    const { windowId: targetWindowId, viewId: targetViewId } = await clickJumpAndCaptureTargetView(page, entry);
+    // The jump must still OPEN Traffic Management cleanly (no error toast, no 5xx) -- it simply has
+    // nothing to offer, because every schedule under this board row is already assigned.
+    const { windowId: targetWindowId, viewId: targetViewId } = await clickJumpAndExpectNoError(page, entry);
+    expect(targetWindowId, 'the jump must open the Traffic Management window').toBe(String(TRAFFIC_MANAGEMENT_WINDOW_ID));
+
     const targetView = await fetchViewRows(page, targetWindowId, targetViewId);
-    expect(targetView.result.length, 'the fully-assigned board row must not open an empty Traffic Management grid').toBeGreaterThan(0);
-    for (const targetRow of targetView.result) {
-      expect(String(targetRow.fieldsByName?.M_Product_ID?.value?.key)).toBe(String(productId));
-    }
+    expect(
+      targetView.result.length,
+      'an entirely-assigned board row has nothing left to schedule -- the jump must return no rows at all'
+    ).toBe(0);
   });
 
   test('two board rows selected: one grid holds the union, nothing from a third product', async ({ page }) => {
@@ -548,10 +605,11 @@ AC4, and is the regression guard for the AD_Process.IsUseAutoFilters='N' plumbin
     allure.severity('normal');
     allure.description(`
 ### Scenario
-1. Seed three products on one order, each getting its own board row (grouping is per-product).
+1. Seed three products on one order, each with on-hand stock and no workplace, so each gets its own
+   board row whose schedule is unassigned and therefore genuinely reachable through the jump.
 2. Select TWO of the three rows (ctrl-click) and run the jump.
-3. Expected: one Traffic Management grid holding the union of the two selected rows' schedules, and
-   nothing belonging to the third, unselected product.
+3. Expected: one Traffic Management grid holding the union of the two selected rows' schedules -- every
+   row unassigned and in stock -- and nothing belonging to the third, unselected product.
 
 Proves AC3 (RelationTypeInOverlayProcess.createCombinedFilterView's OR-union path).
     `);
@@ -563,14 +621,23 @@ Proves AC3 (RelationTypeInOverlayProcess.createCombinedFilterView's OR-union pat
         login: { user: { language: 'de_DE', firstname: 'orderboard', lastname: 'jump3' } },
         bpartners: { bp: { isVendor: false, isCustomer: true, isSoPriceList: true, name: 'OrderBoardJump-Multi-Partner' } },
         warehouses: { wh: {} },
-        workplaces: { wp1: { warehouse: 'wh' } },
         // See the "fully-assigned board row" test above for why a shipper with a local (no-gateway)
-        // carrier advise is required before any line can carry a workplace.
+        // carrier advise is required before ANY line appears in M_Picking_Job_Schedule_view at all
+        // (AD_SysConfig RequireCarrierProductSet='Y' on this stack).
         shippers: { ship1: { name: 'NoGwCarrier', isApiCarrierAdvise: true } },
         products: {
           pA: { name: 'OrderBoardJump-Multi-A', prices: [{ price: 10 }] },
           pB: { name: 'OrderBoardJump-Multi-B', prices: [{ price: 10 }] },
           pC: { name: 'OrderBoardJump-Multi-C', prices: [{ price: 10 }] },
+        },
+        // Real on-hand stock for all three products: an unassigned schedule is on the board -- and
+        // reachable through the jump -- only when qtyonhand>0. Product C is NOT selected for the jump
+        // below, but must be a genuine, visible board row for "nothing from a third product" to prove
+        // anything: an invisible row would satisfy that assertion without exercising the union filter.
+        handlingUnits: {
+          huA: { product: 'pA', warehouse: 'wh', qty: 50 },
+          huB: { product: 'pB', warehouse: 'wh', qty: 50 },
+          huC: { product: 'pC', warehouse: 'wh', qty: 50 },
         },
         salesOrders: {
           so3: {
@@ -578,11 +645,8 @@ Proves AC3 (RelationTypeInOverlayProcess.createCombinedFilterView's OR-union pat
             warehouse: 'wh',
             shipper: 'ship1',
             datePromised,
-            // No `workplace` here -- see the "fully-assigned board row" test for why the assignment is
-            // done afterwards via the real "Schedule" UI action instead. Product C is NOT selected for
-            // the jump below, but is assigned too: it must be a genuine, visible board row (assigned or
-            // stocked) for "nothing from a third product" to prove anything -- an invisible row would
-            // trivially satisfy that assertion without exercising the union filter at all.
+            // No workplace anywhere: all three schedules stay unassigned, which is exactly what the
+            // jump now resolves.
             lines: [
               { product: 'pA', qty: 3 },
               { product: 'pB', qty: 4 },
@@ -597,15 +661,15 @@ Proves AC3 (RelationTypeInOverlayProcess.createCombinedFilterView's OR-union pat
     const productIdA = masterdata.products.pA.id;
     const productIdB = masterdata.products.pB.id;
     const productIdC = masterdata.products.pC.id;
-    const workplaceName = masterdata.workplaces.wp1.name;
 
     await LoginPage.goto();
     await LoginPage.login(masterdata.login.user);
     await expectDashboardVisible(page);
 
+    // Each schedule only enters M_Picking_Job_Schedule_view once its carrier has been advised on the
+    // async workpackage -- see waitForScheduleCarrierResolved().
     for (const productId of [productIdA, productIdB, productIdC]) {
-      const scheduleRow = await waitForScheduleCarrierResolved(page, productId);
-      await assignWorkplaceViaScheduleAction(page, scheduleRow.viewId, scheduleRow.rowId, workplaceName, { pageNumber: scheduleRow.pageNumber });
+      await waitForScheduleCarrierResolved(page, productId);
     }
 
     const rowA = await waitForBoardRow(page, productIdA);
@@ -614,23 +678,24 @@ Proves AC3 (RelationTypeInOverlayProcess.createCombinedFilterView's OR-union pat
     // a third product" would be true only because there is no third row to leak in the first place.
     await waitForBoardRow(page, productIdC);
 
-    // Narrow to exactly rows A and B via a server-side filterOnlyIds view (see
-    // createFilteredBoardView()) so both are guaranteed to land on the SAME grid page (page 1 -- only
-    // two rows exist in this view), regardless of how many unrelated rows the unfiltered board view has
-    // accumulated across this stack's test history.
-    const filteredViewId = await createFilteredBoardView(page, [rowA.rowId, rowB.rowId]);
-    await selectTwoBoardRows(page, filteredViewId, rowA.rowId, rowB.rowId);
+    await selectTwoBoardRows(page, rowA.rowId, rowB.rowId);
     const dropdown = await openQuickActionsDropdown(page);
     const entry = dropdown.getByTestId(JUMP_ACTION_TESTID);
 
-    // --- EXPECTED RED: no jump entry yet.
-    await expect(entry, `${JUMP_ACTION_TESTID} must be offered once the jump is wired`).toBeVisible({ timeout: 10000 });
+    await expect(entry, `${JUMP_ACTION_TESTID} must be offered for a valid multi-row selection`).toBeVisible({ timeout: 10000 });
     await expect(entry, `${JUMP_ACTION_TESTID} must not be disabled for a valid multi-row selection`).not.toHaveClass(/quick-actions-item-disabled/);
 
-    // --- Once the jump is wired: one combined grid, union of A+B, nothing from C.
+    // One combined grid, union of A+B, nothing from C -- and every row unassigned and in stock.
     const { windowId: targetWindowId, viewId: targetViewId } = await clickJumpAndCaptureTargetView(page, entry);
     const targetView = await fetchViewRows(page, targetWindowId, targetViewId);
     expect(targetView.result.length, 'the combined grid must not be empty').toBeGreaterThan(0);
+    for (const targetRow of targetView.result) {
+      expect(targetRow.fieldsByName?.IsAssigned?.value, 'the jump must return ONLY unassigned schedules').toBe(false);
+      expect(
+        Number(targetRow.fieldsByName?.QtyOnHand?.value),
+        'an unassigned schedule is on the board only when it has stock -- the jump must not return one without'
+      ).toBeGreaterThan(0);
+    }
 
     const targetProductIds = new Set(targetView.result.map((r) => String(r.fieldsByName?.M_Product_ID?.value?.key)));
     expect(targetProductIds.has(String(productIdA)), 'the union must include product A').toBe(true);
@@ -646,17 +711,24 @@ Proves AC3 (RelationTypeInOverlayProcess.createCombinedFilterView's OR-union pat
     allure.severity('normal');
     allure.description(`
 ### Scenario
-1. Seed a fully-assigned board row and select it in the browser.
-2. WITHOUT reloading the page, create a DRAFT (not completed) shipment against the sales order's
-   schedule via the Backend API (chained onto the same masterdata context) -- a concurrent update
-   landing after the row was selected but before the jump is clicked. A draft shipment binds the
-   schedule's picked-quantity rows without completing the document, so the schedule stays open
-   (QtyToDeliver > 0) and keeps its place in Traffic Management -- unlike completing/fully shipping it,
-   which would legitimately (and correctly) remove it from Traffic Management's own grid, a different,
-   unrelated behaviour this test must not conflate with an error.
+1. Seed a board row whose schedule is unassigned and in stock (i.e. genuinely reachable through the
+   jump) and select it in the browser.
+2. WITHOUT reloading the page, create a SECOND sales order for the same product / partner / delivery
+   date via the Backend API (chained onto the same masterdata context) -- a concurrent update landing
+   after the row was selected but before the jump is clicked. Because the board groups by
+   (product, UOM, delivery date, country, client, org), that new order line falls under the very board
+   row that is already selected: its aggregate changes underneath the selection, while the originally
+   selected schedule stays untouched and still needs an assignment.
 3. Run the jump on that selection.
 4. Expected: the jump opens Traffic Management scoped to the row's product, with no error toast and no
-   5xx response anywhere in-flight, and the row is still there.
+   5xx response anywhere in-flight, and the originally selected schedule is still there.
+
+A draft (not completed) shipment was tried here first and is NOT usable: generating one drives the
+schedule's QtyToDeliver to 0 (verified on the running stack), and the view's unassigned branch exists
+only \`WHERE qtytoscheduleforpicking > 0\` -- so the row the test needs to still find would be gone for
+a reason that has nothing to do with the jump. That shape only ever worked while this test seeded an
+ASSIGNED row, whose branch of M_Picking_Job_Schedule_view joins M_Picking_Job_Schedule instead and does
+not depend on QtyToDeliver.
 
 ### Why this asserts success, not the original "stale selection -> readable error" idea
 \`M_Picking_OrderBoard_Overview_v\` is built directly on \`m_picking_job_schedule_view\` and groups by the
@@ -675,23 +747,27 @@ is (and remains) valid.
     test.setTimeout(120000);
 
     const datePromised = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const selectedQty = 6;      // the line that exists BEFORE the selection -- must survive the concurrent update
+    const concurrentQty = 2;    // the line the concurrent update adds under the same board row
     const masterdata = await Backend.createMasterdata({
       request: {
         login: { user: { language: 'de_DE', firstname: 'orderboard', lastname: 'jump4' } },
         bpartners: { bp: { isVendor: false, isCustomer: true, isSoPriceList: true, name: 'OrderBoardJump-ConcurrentUpdate-Partner' } },
         warehouses: { wh: {} },
-        workplaces: { wp1: { warehouse: 'wh' } },
         // See the "fully-assigned board row" test above for why a shipper with a local (no-gateway)
-        // carrier advise is required before any line can carry a workplace.
+        // carrier advise is required before the line appears in M_Picking_Job_Schedule_view at all.
         shippers: { ship1: { name: 'NoGwCarrier', isApiCarrierAdvise: true } },
         products: { p4: { name: 'OrderBoardJump-ConcurrentUpdate-Product', prices: [{ price: 10 }] } },
+        // On-hand stock so the still-unassigned schedule clears the board's own inclusion test and is
+        // therefore genuinely reachable through the jump.
+        handlingUnits: { hu4: { product: 'p4', warehouse: 'wh', qty: 50 } },
         salesOrders: {
           so4: {
             bpartner: 'bp',
             warehouse: 'wh',
             shipper: 'ship1',
             datePromised,
-            lines: [{ product: 'p4', qty: 6 }], // assigned afterwards via the "Schedule" UI action, not the masterdata shortcut
+            lines: [{ product: 'p4', qty: selectedQty }], // no workplace -> IsAssigned='N', which is what the jump resolves
           },
         },
       },
@@ -699,31 +775,38 @@ is (and remains) valid.
     allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
 
     const productId = masterdata.products.p4.id;
-    const workplaceName = masterdata.workplaces.wp1.name;
 
     await LoginPage.goto();
     await LoginPage.login(masterdata.login.user);
     await expectDashboardVisible(page);
 
-    const scheduleRow = await waitForScheduleCarrierResolved(page, productId);
-    await assignWorkplaceViaScheduleAction(page, scheduleRow.viewId, scheduleRow.rowId, workplaceName, { pageNumber: scheduleRow.pageNumber });
+    await waitForScheduleCarrierResolved(page, productId);
 
-    const { viewId, rowId, pageNumber } = await waitForBoardRow(page, productId);
-    await selectBoardRow(page, viewId, rowId, { pageNumber });
+    const { rowId } = await waitForBoardRow(page, productId);
+    await selectBoardRow(page, rowId);
     const dropdown = await openQuickActionsDropdown(page);
     const entry = dropdown.getByTestId(JUMP_ACTION_TESTID);
 
-    // Update the schedule WITHOUT navigating away, between selecting the row and clicking the jump --
-    // exactly the race a real user can hit. Chains onto the FIRST call's context
-    // (JsonCreateMasterdataRequest.context / MasterdataContext#putFromJson-#toJson round-trip) so
-    // `salesOrder: 'so4'` resolves -- an established, plain-JSON mechanism, though not previously
-    // exercised by any spec in this suite. `complete: false` leaves the shipment as DRAFT (not
-    // completed) so the schedule stays open and visible in Traffic Management -- see the description
-    // above for why completing it instead would be a different, unrelated (and correct) disappearance.
+    // Change the selected board row's own aggregate WITHOUT navigating away, between selecting the row
+    // and clicking the jump -- exactly the race a real user can hit. Chains onto the FIRST call's
+    // context (JsonCreateMasterdataRequest.context / MasterdataContext#putFromJson-#toJson round-trip)
+    // so `bpartner: 'bp'` / `warehouse: 'wh'` / `shipper: 'ship1'` / `product: 'p4'` resolve to the
+    // records already seeded -- an established, plain-JSON mechanism, though not previously exercised
+    // by any spec in this suite. Same product + partner + delivery date means the new line lands under
+    // the SAME board row that is already selected. See the description above for why a draft shipment
+    // (the shape this test used while it seeded an assigned row) cannot be used here.
     await Backend.createMasterdata({
       request: {
         context: masterdata.context,
-        shipments: { draftShip: { salesOrder: 'so4', complete: false } },
+        salesOrders: {
+          so4b: {
+            bpartner: 'bp',
+            warehouse: 'wh',
+            shipper: 'ship1',
+            datePromised,
+            lines: [{ product: 'p4', qty: concurrentQty }],
+          },
+        },
       },
     });
 
@@ -738,40 +821,47 @@ is (and remains) valid.
     const targetView = await fetchViewRows(page, targetWindowId, targetViewId);
     expect(targetView.result.length, 'the jump target grid must not be empty for a still-valid selection').toBeGreaterThan(0);
     for (const targetRow of targetView.result) {
-      expect(
-        String(targetRow.fieldsByName?.M_Product_ID?.value?.key),
-        'every row opened by the jump must carry the selected board row\'s product'
-      ).toBe(String(productId));
+      expectRowIsUnassignedAndStocked(targetRow, productId);
     }
+    // The originally selected schedule specifically -- not just "some row" -- must have survived the
+    // concurrent update. The second order's line may or may not have had its carrier advised by now
+    // (that runs on an async workpackage), so its presence is deliberately not asserted either way.
+    const returnedQtys = targetView.result.map((r) => Number(r.fieldsByName?.QtyOrdered?.value));
+    expect(returnedQtys, 'the schedule that was selected before the concurrent update must still be returned').toContain(selectedQty);
   });
 
-  test('mixed-tuple board row: an unassigned, unstocked sibling schedule must not leak through the jump', async ({ page }) => {
+  test('mixed-tuple board row: the jump opens on the unassigned schedule only, and the operator can clear that', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00245: Traffic Management');
     allure.tag('F00245');
-    allure.story('The jump excludes target rows the board itself would not include');
+    allure.story('The jump opens filtered to unassigned -- as a filter the operator can clear');
     allure.severity('critical');
     allure.description(`
 ### Scenario
 1. Seed ONE sales order with TWO lines for the SAME product/UOM/delivery-date/country tuple (so both
-   schedules fall under one Auftrags-Board row): one line gets assigned to a workplace, the other gets
-   NO workplace and NO on-hand stock.
-2. The unassigned, unstocked line fails the board's own \`isassigned='Y' OR qtyonhand>0\` inclusion
-   test, so it does not count towards the board row's OrderLineCount -- but it DOES share the exact
-   grouping tuple the jump's EXISTS back-join matches on.
+   schedules fall under one Auftrags-Board row), plus real on-hand stock for that product. One line is
+   assigned to a workplace via Traffic Management's own "Schedule" action; the other stays unassigned.
+2. Both schedules therefore pass the board's own \`isassigned='Y' OR qtyonhand>0\` inclusion test, so
+   the board row's OrderLineCount is 2 -- the board legitimately shows both.
 3. Select that board row and run the jump.
-4. Expected: the target grid holds EXACTLY the assigned line's schedule -- row count equal to the
-   board row's OrderLineCount (1), never 2 -- and the unassigned/unstocked sibling is absent.
+4. DEFAULT STATE: the overlay holds EXACTLY ONE row -- the UNASSIGNED line (QtyOrdered = the unassigned
+   line's qty, IsAssigned=false, no workplace) -- and shows the filter as ACTIVE, so the operator can
+   see that a restriction is in force.
+5. CONFIGURABILITY: clearing that filter in the overlay, the way an operator would (open the filter
+   button, pick the default filter, hit "clear filter"), brings the assigned sibling back -- two rows.
 
-### Why this is the defect this suite was missing
-The jump's WhereClause is an EXISTS back-join to \`M_Picking_OrderBoard_Overview_v\` on the grouping
-tuple, plus a trailing \`AND (IsAssigned='Y' OR QtyOnHand>0)\` on the TARGET row. The EXISTS alone only
-proves "a board aggregate row with this id and this tuple exists" -- it says nothing about whether the
-specific target row would itself have counted towards that aggregate. Without the trailing AND, a
-target row sharing the tuple but failing the board's own inclusion test is still returned, so the jump
-can list more schedules than the board row it was launched from claims to hold (OrderLineCount).
-None of the other five tests in this file seeds two schedules under one tuple with different
-IsAssigned/QtyOnHand outcomes, so none of them can catch a regression here.
+### Why this is the case that pins the behaviour down
+The jump exists so the operator lands on the schedules that still need a workplace; one that already has
+one is noise on arrival. But this is a first draft for customer feedback, so "only unassigned" must be
+the OPENING state, not a decision baked into the relation -- hence a default filter (the target window's
+own \`IsAssigned\` FilterDefaultValue='N', applied because AD_Process.IsUseAutoFilters='Y') rather than a
+where-clause term.
+
+Both halves need this one seed, and only this seed: it is the only place in this file where an assigned
+and an unassigned schedule share a single board row, so it is the only test that can tell "opens on the
+unassigned rows" apart from "returns whatever the board shows" -- the two answers differ here (1 row vs
+2) and nowhere else. That same gap is what makes step 5 meaningful: the row that reappears after
+clearing is precisely the one the default filter had hidden.
     `);
     test.setTimeout(120000);
 
@@ -792,10 +882,12 @@ IsAssigned/QtyOnHand outcomes, so none of them can catch a regression here.
         // ONE product for BOTH lines -- this is what makes them share the board's grouping tuple
         // (M_Product_ID, C_UOM_ID, DeliveryDate::date, C_Country_ID, AD_Client_ID, AD_Org_ID).
         products: { p6: { name: 'OrderBoardJump-MixedTuple-Product', prices: [{ price: 10 }] } },
-        // Deliberately NO handlingUnits here -- the unassigned line must have qtyonhand=0. Both lines
-        // are seeded WITHOUT a workplace (see the "fully-assigned board row" test above for why the
-        // workplace shortcut races the async carrier advise for a multi-line order); only the first
-        // line is assigned afterwards, via the real "Schedule" UI action.
+        // Real on-hand stock: it is what puts the UNASSIGNED line on the board (and hence in the jump).
+        // Stock is per product/warehouse, not per order line, so both lines share it.
+        handlingUnits: { hu6: { product: 'p6', warehouse: 'wh', qty: 50 } },
+        // Both lines are seeded WITHOUT a workplace (see the "fully-assigned board row" test above for
+        // why the workplace shortcut races the async carrier advise for a multi-line order); only the
+        // first line is assigned afterwards, via the real "Schedule" UI action.
         salesOrders: {
           so6: {
             bpartner: 'bp',
@@ -803,8 +895,8 @@ IsAssigned/QtyOnHand outcomes, so none of them can catch a regression here.
             shipper: 'ship1',
             datePromised,
             lines: [
-              { product: 'p6', qty: assignedQty },   // assigned afterwards -> IsAssigned='Y', counts on the board
-              { product: 'p6', qty: unassignedQty }, // stays unassigned, no stock -> invisible to the board
+              { product: 'p6', qty: assignedQty },   // assigned afterwards -> IsAssigned='Y', must NOT come through
+              { product: 'p6', qty: unassignedQty }, // stays unassigned, in stock -> the ONLY row the jump may return
             ],
           },
         },
@@ -820,21 +912,22 @@ IsAssigned/QtyOnHand outcomes, so none of them can catch a regression here.
     await expectDashboardVisible(page);
 
     // Resolve and assign ONLY the assignedQty line's schedule -- the unassignedQty sibling is left
-    // exactly as seeded (no workplace, no stock).
+    // exactly as seeded (no workplace).
     const assignedScheduleRow = await waitForScheduleCarrierResolvedByQty(page, productId, assignedQty);
-    await assignWorkplaceViaScheduleAction(
-      page, assignedScheduleRow.viewId, assignedScheduleRow.rowId, workplaceName, { pageNumber: assignedScheduleRow.pageNumber }
-    );
-    // Sanity: the unassigned sibling's own schedule must genuinely exist (carrier-resolved, so it is not
-    // simply "not created yet") -- otherwise "the sibling is absent from the jump" would be trivially true
-    // because there is no sibling to leak in the first place.
+    await assignWorkplaceViaScheduleAction(page, productId, assignedScheduleRow.rowId, workplaceName);
+    // The unassigned sibling must genuinely exist and be carrier-resolved (it is the row the jump is
+    // required to return, so its absence would make the assertions below meaningless).
     await waitForScheduleCarrierResolvedByQty(page, productId, unassignedQty);
 
-    const { viewId, rowId, row, pageNumber } = await waitForBoardRow(page, productId);
-    const expectedOrderLineCount = row.fieldsByName.OrderLineCount.value;
-    expect(expectedOrderLineCount, 'only the assigned line must count towards the board row\'s OrderLineCount').toBe(1);
+    const { rowId, row } = await waitForBoardRow(page, productId);
+    // The board itself shows BOTH schedules -- this is what makes the jump's narrower result meaningful
+    // rather than a coincidence of the seeding.
+    expect(
+      row.fieldsByName.OrderLineCount.value,
+      'both the assigned and the unassigned-but-stocked line must count towards the board row\'s OrderLineCount'
+    ).toBe(2);
 
-    await selectBoardRow(page, viewId, rowId, { pageNumber });
+    await selectBoardRow(page, rowId);
     const dropdown = await openQuickActionsDropdown(page);
     const entry = dropdown.getByTestId(JUMP_ACTION_TESTID);
 
@@ -842,28 +935,172 @@ IsAssigned/QtyOnHand outcomes, so none of them can catch a regression here.
     await expect(entry, `${JUMP_ACTION_TESTID} must not be disabled for a valid single-row selection`).not.toHaveClass(/quick-actions-item-disabled/);
 
     const { windowId: targetWindowId, viewId: targetViewId } = await clickJumpAndCaptureTargetView(page, entry);
-    expect(targetWindowId, 'the jump must open a window other than the board itself').not.toBe(String(ORDER_BOARD_WINDOW_ID));
+    expect(targetWindowId, 'the jump must open the Traffic Management window').toBe(String(TRAFFIC_MANAGEMENT_WINDOW_ID));
 
     const targetView = await fetchViewRows(page, targetWindowId, targetViewId);
     expect(
       targetView.result.length,
-      'the jump must return exactly the board row\'s OrderLineCount -- not the unassigned, unstocked sibling too'
-    ).toBe(expectedOrderLineCount);
+      'the jump must OPEN on the unassigned line only -- one row, not the board row\'s two'
+    ).toBe(1);
 
     const [onlyRow] = targetView.result;
-    expect(String(onlyRow.fieldsByName?.M_Product_ID?.value?.key), 'the single returned row must carry the seeded product').toBe(String(productId));
+    expectRowIsUnassignedAndStocked(onlyRow, productId);
     expect(
       Number(onlyRow.fieldsByName?.QtyOrdered?.value),
-      'the single returned row must be the ASSIGNED line, not the unassigned/unstocked sibling'
-    ).toBe(assignedQty);
-    expect(onlyRow.fieldsByName?.C_Workplace_ID?.value?.key, 'the single returned row must carry the assigned workplace').toBeTruthy();
+      'the row the jump opens on must be the UNASSIGNED line, not the assigned sibling'
+    ).toBe(unassignedQty);
+    expect(
+      onlyRow.fieldsByName?.C_Workplace_ID?.value?.key,
+      'the row the jump opens on must carry no workplace -- that is what "unassigned" means here'
+    ).toBeFalsy();
+
+    // --- CONFIGURABILITY: the restriction is a filter the operator can see and clear, not SQL. ---
+    // Everything below is driven through the overlay's own UI, scoped to the modal so nothing can be
+    // read off the board grid still rendered behind it (Modal.js: `panel-modal-content`).
+    const overlay = page.locator('.panel-modal-content');
+    const overlayRows = overlay.locator('tbody tr[data-testid^="table-row-"]');
+    await expect(overlayRows, 'the overlay must render the one unassigned row the jump opened on').toHaveCount(1);
+
+    // The filter must be VISIBLY in force -- FiltersIncluded.js marks the filter button `btn-active`
+    // when one of its included filters is applied. Without AD_Process.IsUseAutoFilters='Y' the overlay
+    // applies no default filter at all, so this button is never active and the operator is given no
+    // hint that anything is being hidden.
+    const filterButton = overlay.locator('.filters-not-frequent button.btn-filter');
+    await expect(
+      filterButton,
+      'the overlay must show the IsAssigned default filter as active -- the operator has to see the restriction to be able to lift it'
+    ).toHaveClass(/btn-active/, { timeout: 15000 });
+
+    // Clear it exactly the way an operator would: open the filter, then hit its "clear filter" control
+    // (FiltersItem.js `.filter-clear`, rendered only while the filter IS active -- so this click is
+    // itself a second, independent proof that the default filter was applied). Both are class-based
+    // selectors -- no localized caption is matched.
+    //
+    // The click lands straight on the filter's parameter panel, with no intermediate filter-picking
+    // menu: FiltersIncluded.toggleDropdown() pre-selects the filter to open whenever one is already
+    // active -- and, failing that, whenever the group holds exactly one filter, which is the case here
+    // (Traffic Management's included-filter group contains only `default`).
+    await filterButton.click();
+    await overlay.locator('.filter-clear').click();
+
+    // With the filter gone, the assigned sibling comes back: the where-clause alone admits both rows.
+    await expect(
+      overlayRows,
+      'clearing the IsAssigned filter must bring the assigned sibling back -- the restriction is a removable default, not a hard rule'
+    ).toHaveCount(2, { timeout: 20000 });
+  });
+
+  test('mixed-tuple board row without stock: the unstocked, unassigned sibling never comes through the jump', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00245: Traffic Management');
+    allure.tag('F00245');
+    allure.story('The jump never returns a schedule the board itself does not show');
+    allure.severity('critical');
+    allure.description(`
+### Scenario
+1. Seed ONE sales order with TWO lines for the SAME product/UOM/delivery-date/country tuple and NO
+   on-hand stock: one line is assigned to a workplace, the other stays unassigned.
+2. The board admits only the assigned line (\`isassigned='Y' OR qtyonhand>0\`), so OrderLineCount is 1;
+   the unassigned, unstocked line is invisible on the board -- yet it DOES share the exact grouping
+   tuple the jump's EXISTS back-join matches on.
+3. Select that board row and run the jump.
+4. Expected: the unassigned, unstocked line is NOWHERE in the result. It is excluded by the relation's
+   own where-clause, which is the HARD half of the jump's restriction and is not affected by this
+   change.
+
+### Why this exclusion needs its own test -- and why it is deliberately filter-agnostic
+The jump's WhereClause is an EXISTS back-join to \`M_Picking_OrderBoard_Overview_v\` on the grouping
+tuple, plus \`AND (IsAssigned='Y' OR QtyOnHand>0)\` on the TARGET row. The EXISTS alone only proves
+"a board aggregate row with this id and this tuple exists" -- it says nothing about whether the specific
+target row would itself have counted towards that aggregate. Drop that trailing term and this unstocked
+sibling is returned by the jump even though the board does not show it. Only this test seeds an
+unassigned schedule with zero stock, so only this test can catch that.
+
+The assertion is therefore about the SIBLING'S ABSENCE, not about the grid's size. That is on purpose:
+the where-clause half is unchanged by the IsUseAutoFilters change, so this test must be -- and stays --
+green both before and after it, which is exactly what pins the two halves apart. (The IsAssigned default
+filter does independently hide the assigned line, so the grid does end up empty once that filter is
+applied; asserting the count here would fold the soft half back into this test and lose that separation.
+The soft half has its own coverage: the "fully-assigned board row" and mixed-tuple-with-stock tests.)
+
+The absence is not vacuous: the test first asserts that BOTH schedules genuinely exist (each
+carrier-resolved and reachable in Traffic Management's own view before the assignment), that the board
+row covers exactly one of them, and that the jump still opens Traffic Management cleanly.
+    `);
+    test.setTimeout(120000);
+
+    const datePromised = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const assignedQty = 7;
+    const unassignedQty = 4;
+    const masterdata = await Backend.createMasterdata({
+      request: {
+        login: { user: { language: 'de_DE', firstname: 'orderboard', lastname: 'jump7' } },
+        bpartners: { bp: { isVendor: false, isCustomer: true, isSoPriceList: true, name: 'OrderBoardJump-MixedTupleNoStock-Partner' } },
+        warehouses: { wh: {} },
+        workplaces: { wp1: { warehouse: 'wh' } },
+        shippers: { ship1: { name: 'NoGwCarrier', isApiCarrierAdvise: true } },
+        products: { p7: { name: 'OrderBoardJump-MixedTupleNoStock-Product', prices: [{ price: 10 }] } },
+        // Deliberately NO handlingUnits -- the unassigned line must have qtyonhand=0, which is what
+        // keeps it off the board and, therefore, out of the jump.
+        salesOrders: {
+          so7: {
+            bpartner: 'bp',
+            warehouse: 'wh',
+            shipper: 'ship1',
+            datePromised,
+            lines: [
+              { product: 'p7', qty: assignedQty },   // assigned afterwards -> the only line the board shows
+              { product: 'p7', qty: unassignedQty }, // unassigned AND unstocked -> not on the board, and never in the jump
+            ],
+          },
+        },
+      },
+    });
+    allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+
+    const productId = masterdata.products.p7.id;
+    const workplaceName = masterdata.workplaces.wp1.name;
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await expectDashboardVisible(page);
+
+    const assignedScheduleRow = await waitForScheduleCarrierResolvedByQty(page, productId, assignedQty);
+    await assignWorkplaceViaScheduleAction(page, productId, assignedScheduleRow.rowId, workplaceName);
+    // Sanity: the unassigned sibling's own schedule must genuinely exist (carrier-resolved, so it is not
+    // simply "not created yet") -- otherwise "the sibling is absent from the jump" would be trivially
+    // true because there is no sibling to leak in the first place.
+    await waitForScheduleCarrierResolvedByQty(page, productId, unassignedQty);
+
+    const { rowId, row } = await waitForBoardRow(page, productId);
+    expect(
+      row.fieldsByName.OrderLineCount.value,
+      'only the assigned line must count towards the board row\'s OrderLineCount -- the unstocked sibling is not on the board'
+    ).toBe(1);
+
+    await selectBoardRow(page, rowId);
+    const dropdown = await openQuickActionsDropdown(page);
+    const entry = dropdown.getByTestId(JUMP_ACTION_TESTID);
+
+    await expect(entry, `${JUMP_ACTION_TESTID} must be offered for a valid single-row selection`).toBeVisible({ timeout: 10000 });
+    await expect(entry, `${JUMP_ACTION_TESTID} must not be disabled for a valid single-row selection`).not.toHaveClass(/quick-actions-item-disabled/);
+
+    const { windowId: targetWindowId, viewId: targetViewId } = await clickJumpAndExpectNoError(page, entry);
+    expect(targetWindowId, 'the jump must open the Traffic Management window').toBe(String(TRAFFIC_MANAGEMENT_WINDOW_ID));
+
+    const targetView = await fetchViewRows(page, targetWindowId, targetViewId);
+    const returnedQtys = targetView.result.map((r) => Number(r.fieldsByName?.QtyOrdered?.value));
+    expect(
+      returnedQtys,
+      'the unassigned line has no stock, so the board does not show it -- the jump\'s where-clause must not return it either'
+    ).not.toContain(unassignedQty);
   });
 
   test('Traffic Management opened from the menu still applies its default not-assigned filter', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00245: Traffic Management');
     allure.tag('F00245');
-    allure.story('Opening Traffic Management normally is unaffected by the jump\'s IsUseAutoFilters override');
+    allure.story('The window\'s own default not-assigned filter is what the jump now leans on');
     allure.severity('critical');
     allure.description(`
 ### Scenario
@@ -872,9 +1109,11 @@ view-creation response still carries the "not assigned" default filter (AD_Colum
 FilterDefaultValue='N') -- verified live against this window: creating a documentView for window 541929
 returns \`filters: [{filterId:"default", parameters:[{parameterName:"IsAssigned", value:false}]}]\`.
 
-This test must PASS from the start: it exercises the window's OWN default-filter plumbing, not the jump
-action a follow-up migration adds, and it guards the IsUseAutoFilters routing against over-reach into
-ordinary window navigation. Proves AC5.
+This filter is what the jump's whole "opens on unassigned" behaviour rests on: with
+AD_Process.IsUseAutoFilters='Y' the overlay applies this very default, so if the filter were ever
+dropped from the window the jump would silently start showing everything. The check is deliberately
+made through ORDINARY navigation (no jump involved), so it keeps guarding the filter's existence
+independently of how the overlay is wired -- and it stays green across the IsUseAutoFilters change.
     `);
     test.setTimeout(60000);
 

--- a/e2e/frontend-webui/tests/spec/order-board-jump-to-traffic-management.spec.js
+++ b/e2e/frontend-webui/tests/spec/order-board-jump-to-traffic-management.spec.js
@@ -981,13 +981,41 @@ clearing is precisely the one the default filter had hidden.
     // active -- and, failing that, whenever the group holds exactly one filter, which is the case here
     // (Traffic Management's included-filter group contains only `default`).
     await filterButton.click();
+
+    // Clearing the filter makes the frontend re-fetch the overlay's grid; catch that GET so the rows it
+    // returns can be inspected by field. The rendered grid cannot answer this on its own -- C_Workplace_ID
+    // carries IsDisplayed='N' on this tab (AD_Field, verified against the running stack), so it is in the
+    // view JSON but never in the DOM. Same intercept shape as clickJumpAndCaptureTargetView().
+    const clearedViewResponsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'GET' &&
+        new RegExp(`/documentView/${TRAFFIC_MANAGEMENT_WINDOW_ID}/[^/?]+\\?firstRow=`).test(response.url()),
+      { timeout: 30000 }
+    );
     await overlay.locator('.filter-clear').click();
+    const clearedViewId = decodeURIComponent(
+      (await clearedViewResponsePromise).url().match(/\/documentView\/\d+\/([^/?]+)\?firstRow=/)[1]
+    );
 
     // With the filter gone, the assigned sibling comes back: the where-clause alone admits both rows.
     await expect(
       overlayRows,
       'clearing the IsAssigned filter must bring the assigned sibling back -- the restriction is a removable default, not a hard rule'
     ).toHaveCount(2, { timeout: 20000 });
+
+    // ...and the row that came back must be the ASSIGNED sibling specifically -- a bare count of 2 would
+    // also be satisfied by some unrelated row leaking in, which is exactly what the count cannot tell apart.
+    const clearedView = await fetchViewRows(page, TRAFFIC_MANAGEMENT_WINDOW_ID, clearedViewId);
+    const reappearedRow = clearedView.result.find((r) => Number(r.fieldsByName?.QtyOrdered?.value) === assignedQty);
+    expect(reappearedRow, 'the row that reappears after clearing must be the assigned line').toBeTruthy();
+    expect(
+      reappearedRow.fieldsByName?.IsAssigned?.value,
+      'the row that reappears must be the one the default filter had been hiding -- i.e. an ASSIGNED one'
+    ).toBe(true);
+    expect(
+      reappearedRow.fieldsByName?.C_Workplace_ID?.value?.key,
+      'the reappeared assigned row must carry the workplace it was assigned to'
+    ).toBeTruthy();
   });
 
   test('mixed-tuple board row without stock: the unstocked, unassigned sibling never comes through the jump', async ({ page }) => {
@@ -1016,14 +1044,21 @@ target row would itself have counted towards that aggregate. Drop that trailing 
 sibling is returned by the jump even though the board does not show it. Only this test seeds an
 unassigned schedule with zero stock, so only this test can catch that.
 
-The assertion is therefore about the SIBLING'S ABSENCE, not about the grid's size. That is on purpose:
-the where-clause half is unchanged by the IsUseAutoFilters change, so this test must be -- and stays --
-green both before and after it, which is exactly what pins the two halves apart. (The IsAssigned default
-filter does independently hide the assigned line, so the grid does end up empty once that filter is
-applied; asserting the count here would fold the soft half back into this test and lose that separation.
-The soft half has its own coverage: the "fully-assigned board row" and mixed-tuple-with-stock tests.)
+The primary assertion is therefore about the SIBLING'S ABSENCE, not about an exact grid size. That is on
+purpose: the where-clause half is unchanged by the IsUseAutoFilters change, so this test must be -- and
+stays -- green both before and after it, which is exactly what pins the two halves apart. Pinning the
+count to an exact number would fold the soft half back in and lose that separation (the IsAssigned
+default filter independently hides the assigned line, so the grid holds 1 row before the change and 0
+after). The soft half has its own coverage: the "fully-assigned board row" and mixed-tuple-with-stock
+tests.
 
-The absence is not vacuous: the test first asserts that BOTH schedules genuinely exist (each
+It is backed by an UPPER BOUND that survives that same ambiguity: the jump may never return more rows
+than the board row itself covers (OrderLineCount = 1 here). That bound holds on both sides of the change
+while still failing loudly -- at 2 rows -- if the where-clause's trailing term were dropped and the
+unstocked sibling reappeared. Without it the containment check alone would be close to vacuous in the
+post-change state, where the array it inspects is empty.
+
+Neither assertion is vacuous: the test first asserts that BOTH schedules genuinely exist (each
 carrier-resolved and reachable in Traffic Management's own view before the assignment), that the board
 row covers exactly one of them, and that the jump still opens Traffic Management cleanly.
     `);
@@ -1073,8 +1108,9 @@ row covers exactly one of them, and that the jump still opens Traffic Management
     await waitForScheduleCarrierResolvedByQty(page, productId, unassignedQty);
 
     const { rowId, row } = await waitForBoardRow(page, productId);
+    const expectedOrderLineCount = row.fieldsByName.OrderLineCount.value;
     expect(
-      row.fieldsByName.OrderLineCount.value,
+      expectedOrderLineCount,
       'only the assigned line must count towards the board row\'s OrderLineCount -- the unstocked sibling is not on the board'
     ).toBe(1);
 
@@ -1094,6 +1130,15 @@ row covers exactly one of them, and that the jump still opens Traffic Management
       returnedQtys,
       'the unassigned line has no stock, so the board does not show it -- the jump\'s where-clause must not return it either'
     ).not.toContain(unassignedQty);
+    // Upper bound, deliberately not an exact count -- see the description for why this test stays
+    // agnostic about the IsAssigned default filter. The jump can never show more schedules than the
+    // board row it was launched from claims to hold, so a leaked unstocked sibling fails here too, on
+    // the count, and not only on the containment check above (which inspects an empty array once the
+    // default filter has also removed the assigned line).
+    expect(
+      targetView.result.length,
+      'the jump must never return more rows than the board row covers (OrderLineCount)'
+    ).toBeLessThanOrEqual(expectedOrderLineCount);
   });
 
   test('Traffic Management opened from the menu still applies its default not-assigned filter', async ({ page }) => {


### PR DESCRIPTION
## What

**First draft for the customer feedback round**, not a final behaviour.

The jump from an Auftrags-Board Übersicht row into Traffic Management currently lists every schedule the relation resolves. What the customer asked for is to land on the ones that **still need a workplace**.

This PR sets **`AD_Process.IsUseAutoFilters='Y'`** on the jump process (`AD_Process` 585657, value `M_Picking_OrderBoard_Overview_v_to_TrafficManagement`) — one AD value, shipped as a new migration.

| | before | after |
|---|---|---|
| `AD_Process.IsUseAutoFilters` | `'N'` | `'Y'` |
| relation target where-clause (`AD_Ref_Table` for `AD_Reference` 542136) | `EXISTS (… M_Picking_OrderBoard_Overview_v …) AND (M_Picking_Job_Schedule_view.IsAssigned = ''Y'' OR M_Picking_Job_Schedule_view.QtyOnHand > 0)` | **unchanged** |

Migration: `backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5822540_sys_OrderBoard_to_TrafficManagement_IsUseAutoFilters.sql`

`5822100` is already applied and is left exactly as it is; its comments describing the previous `IsUseAutoFilters='N'` behaviour are superseded by the new script, not edited.

## Why a default filter and not a where-clause term

`M_Picking_Job_Schedule_view.IsAssigned` carries `FilterDefaultValue='N'`, and it is that window's **only** auto-filter — verified on the local stack, it is the sole column of the view with a non-null `FilterDefaultValue`. With `IsUseAutoFilters='Y'` the overlay applies that default, so the jump opens on `IsAssigned='N'` intersected with the where-clause's board-visibility test — i.e. the unassigned, in-stock schedules.

Because the restriction arrives as a **filter value** rather than as SQL, it is rendered in the overlay's filter bar: the operator can see that something is being hidden, and can clear or change it to bring the already-assigned schedules back into view. A where-clause term would produce the same opening rows with no way to look past them. For a draft that goes in front of the customer, being able to look past it is the point — the feedback round can then decide whether it should harden.

**On the local stack there are 29 unassigned schedule rows, of which only 15 have stock** (measured before this session's test seeding: `SELECT isassigned, count(*), count(*) FILTER (WHERE qtyonhand>0) FROM m_picking_job_schedule_view GROUP BY isassigned` → `N: 29 / 15`, `Y: 79 / 0`). Those 15 are what the jump now opens on. The other 14 stay out because of the **where-clause**, which is deliberately untouched: it is the board-visibility invariant added by https://github.com/metasfresh/metasfresh/commit/02a72a57f113d02d07e87dfcaf2c70257ca57542 — the board admits a row when `IsAssigned='Y' OR QtyOnHand>0`, so an unassigned row is on the board only when it has stock, and returning an unstocked one would list a schedule the board does not show. That half is a hard rule, not a user preference, and stays in SQL.

So the change draws a deliberate line between the two halves:

- **hard, in the where-clause** — never show a schedule the board itself does not show. Not clearable.
- **soft, as a default filter** — open on the ones still waiting for a workplace. Clearable.

## TDD — RED before, GREEN after

Both runs used the **identical final spec**, against the local `deep_tundra_release_alt` stack (DB `localhost:22532`, app `:28282`, webapi `:28080`, frontend `:33000`); the only thing that changed between them is `AD_Process.IsUseAutoFilters`.

**RED** — flag at `'N'`, caches reset (run below is the re-confirmation against the final, strengthened spec):

```
  ✓  1 … single waiting board row: the jump lists exactly that row's schedules (14.2s)
  ✘  2 … fully-assigned board row: none of its assigned schedules come through the jump (17.5s)
  ✓  3 … two board rows selected: one grid holds the union, nothing from a third product (9.9s)
  ✓  4 … selection still valid after a concurrent update (no reload): the jump opens cleanly, no Oops/500 (14.6s)
  ✘  5 … mixed-tuple board row: the jump opens on the unassigned schedule only, and the operator can clear that (18.1s)
  ✓  6 … mixed-tuple board row without stock: the unstocked, unassigned sibling never comes through the jump (16.4s)
  ✓  7 … Traffic Management opened from the menu still applies its default not-assigned filter (1.4s)
    Error: an entirely-assigned board row has nothing left to schedule -- the jump must return no rows at all
    Expected: 0
    Received: 1
    Error: the jump must OPEN on the unassigned line only -- one row, not the board row's two
    Expected: 1
    Received: 2
  2 failed
  5 passed (1.6m)
```

**GREEN** — flag at `'Y'` as the migration sets it (originally applied via the migration CLI: `Applied 7 scripts`, including `5822540_sys_OrderBoard_to_TrafficManagement_IsUseAutoFilters.sql`), caches reset:

```
  ✓  1 … single waiting board row: the jump lists exactly that row's schedules (14.4s)
  ✓  2 … fully-assigned board row: none of its assigned schedules come through the jump (17.5s)
  ✓  3 … two board rows selected: one grid holds the union, nothing from a third product (7.5s)
  ✓  4 … selection still valid after a concurrent update (no reload): the jump opens cleanly, no Oops/500 (17.3s)
  ✓  5 … mixed-tuple board row: the jump opens on the unassigned schedule only, and the operator can clear that (26.7s)
  ✓  6 … mixed-tuple board row without stock: the unstocked, unassigned sibling never comes through the jump (17.5s)
  ✓  7 … Traffic Management opened from the menu still applies its default not-assigned filter (1.4s)
  7 passed (1.7m)
```

Note test **6** is green in both runs, by design: it covers the where-clause half, which this change does not touch. That is what keeps the two halves separable in the suite.

## Spec changes — coverage grows, it does not shrink

The spec's expectations previously encoded the superseded "assigned rows appear" rule. Updating them is the sanctioned requirement change; each edit is stated below with what it now covers.

| test | before | after |
|---|---|---|
| single waiting board row | every returned row carries the product | + every returned row is **unassigned and in stock** (shared `expectRowIsUnassignedAndStocked`) |
| fully-assigned board row | grid must be **non-empty** | grid must be **empty**, the overlay must still open on the Traffic Management window with **no error toast and no 5xx**, and non-vacuity is asserted first (board row covers ≥1 schedule, all assigned) |
| two rows selected (union) | seeded three assigned rows; asserted union membership | seeded three **unassigned, in-stock** rows so the union is reachable at all; same membership assertions **plus** unassigned/in-stock on every row |
| concurrent update | seeded an assigned row; asserted grid non-empty | seeded an unassigned in-stock row; same non-empty assertion **plus** unassigned/in-stock per row **plus** a new assertion that the **specific** schedule selected before the update is still returned |
| mixed-tuple (in stock) | *(this seed did not exist)* | **new core case**: one board row covering an assigned **and** an unassigned in-stock schedule → the jump opens on the unassigned one **alone** (1 row, not the board row's 2), and then **clearing the filter through the overlay UI brings the assigned sibling back** — 2 rows, and the row that reappears is asserted to be that sibling (`IsAssigned=true`, carrying its `C_Workplace_ID`) |
| mixed-tuple (no stock) | asserted the grid holds exactly the **assigned** line | asserts the **unstocked unassigned sibling is absent** — the load-bearing check, and the only assertion in the file that catches a leak past the where-clause. Deliberately no *exact* count, which isolates the unchanged where-clause half and keeps this test green on both sides of the change. A separate upper bound (`rows <= OrderLineCount`) guards a different bug class, duplication / join fan-out |
| menu navigation | unchanged | unchanged (still guards the window's own default filter, which the jump now leans on) |

Nothing was deleted: the file went from 6 tests to 7, and every previously-asserted fact either survives or is replaced by a strictly narrower one.

The configurability half is driven entirely through the overlay's own UI, with class-based selectors only (no localized captions): the filter button must render as `btn-active`, then `.filter-clear` — which `FiltersItem` renders **only while the filter is active**, so clicking it is itself a second, independent proof that the default filter was applied. The cleared grid's re-fetch is then intercepted so the reappeared row can be checked by field: `C_Workplace_ID` is `IsDisplayed='N'` on that tab, so it is in the view JSON but never in the DOM.

## A claim in this PR that I checked instead of assuming

The first version of that upper bound came with a comment saying it would fail "at 2 rows" if the where-clause's trailing board-visibility term were dropped. That was reasoning carried over from the pre-change state, and it is wrong for the state this PR leaves behind.

Verified by simulating the regression on a running stack — removing the trailing term from `AD_Ref_Table.WhereClause` (`AD_Reference` 542136), resetting caches, re-running the test:

```
    Error: the unassigned line has no stock, so the board does not show it -- the jump's where-clause must not return it either
    expect(received).not.toContain(expected) // indexOf
    Expected value: not 4
    Received array:     [4]
```

The leak surfaces as **exactly one** row, because the `IsAssigned` auto-filter strips the assigned line in the same fetch — so the containment check fires and the bound (`1 <= 1`) does not. The where-clause was then restored and confirmed byte-identical to its backup.

The test still catches the regression; only the comment was wrong. It now says the containment check is what does the work, and warns against reading the bound as making it redundant.

## Also in this PR — a real spec defect

Row selection used to navigate the window's **unfiltered** grid and compute which page the row had landed on. That broke as soon as the board exceeded the 7 pages its pagination helper handled (`goToGridPage` timed out mid-run). Selection is now always made in a view scoped to the row(s) in question — `filterOnlyIds` for the board, and a product filter for Traffic Management, whose composed row key (`<M_ShipmentSchedule_ID>$<M_Picking_Job_Schedule_ID>`) `filterOnlyIds` cannot address (it deserializes to `Integer`; passing one back yields HTTP 400). Grid paging is gone from the spec entirely.

## Not done here

- No merge — human-only.
- Internal tracker updates are handled separately.
