### PR TITLE
Fix minor typos in comments and messages

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/adempiere/service/impl/ColumnBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/adempiere/service/impl/ColumnBL.java
@@ -82,8 +82,8 @@ public class ColumnBL implements IColumnBL
 	@Override
 	public Optional<String> getTableIdColumnName(final String tableName, final String recordIdColumnName)
 	{
-		Check.assumeNotEmpty(tableName, "Paramter 'tableName' is empty; recordColumnName={}", tableName, recordIdColumnName);
-		Check.assumeNotEmpty(recordIdColumnName, "Paramter 'recordColumnName' is empty; tableName={}", recordIdColumnName, tableName);
+		Check.assumeNotEmpty(tableName, "Parameter 'tableName' is empty; recordColumnName={}", tableName, recordIdColumnName);
+		Check.assumeNotEmpty(recordIdColumnName, "Parameter 'recordColumnName' is empty; tableName={}", recordIdColumnName, tableName);
 
 		final String prefix = extractPrefixFromRecordColumn(recordIdColumnName);
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/user/User.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/user/User.java
@@ -112,7 +112,7 @@ public class User
 
 		Check.assume(
 				userLanguage == null || userLanguage.equals(language),
-				"If a userLanguage parameter is specified, it needs to be equal to the language paramter; this={}",
+				"If a userLanguage parameter is specified, it needs to be equal to the language parameter; this={}",
 				language);
 	}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/executor/IMigrationExecutor.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/executor/IMigrationExecutor.java
@@ -98,7 +98,7 @@ public interface IMigrationExecutor
 	String getStatusDescription();
 
 	/**
-	 * Get the exceptions that occured during the execution of the current migration.
+	 * Get the exceptions that occurred during the execution of the current migration.
 	 * 
 	 * @return {@link List}&lt;{@link Exception}&gt; exceptions
 	 */

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/IWorkPackageQueue.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/IWorkPackageQueue.java
@@ -125,7 +125,7 @@ public interface IWorkPackageQueue
 	/**
 	 * Indicates that all queue elements have been added to the given <code>workPackge</code>.
 	 *
-	 * @param callback callback to be called after workpackage gets processed (sucessful or not).
+	 * @param callback callback to be called after workpackage gets processed (successful or not).
 	 */
 	void markReadyForProcessing(I_C_Queue_WorkPackage workPackage, IQueueProcessorListener callback);
 

--- a/backend/de.metas.dlm/base/src/main/java/de/metas/dlm/partitioner/IIterateResult.java
+++ b/backend/de.metas.dlm/base/src/main/java/de/metas/dlm/partitioner/IIterateResult.java
@@ -32,7 +32,7 @@ import de.metas.dlm.partitioner.IIterateResultHandler.AddResult;
  */
 
 /**
- * Implementors are passed as paramter to {@link IRecordCrawlerService#crawl(de.metas.dlm.partitioner.config.PartitionConfig, IContextAware, IIterateResult)}.
+ * Implementors are passed as parameter to {@link IRecordCrawlerService#crawl(de.metas.dlm.partitioner.config.PartitionConfig, IContextAware, IIterateResult)}.
  * <p>
  * The crawler uses it both to add the records it found and to get the next record to load the incoming and outgoing references for.
  *

--- a/backend/de.metas.dlm/base/src/main/java/de/metas/dlm/partitioner/config/PartitionerConfigLine.java
+++ b/backend/de.metas.dlm/base/src/main/java/de/metas/dlm/partitioner/config/PartitionerConfigLine.java
@@ -55,7 +55,7 @@ public class PartitionerConfigLine
 
 	private PartitionerConfigLine(final PartitionConfig parent, final String tableName)
 	{
-		Check.assumeNotNull(parent, "Paramter 'parent is not null");
+		Check.assumeNotNull(parent, "Parameter 'parent is not null");
 		Check.assumeNotEmpty(tableName, "Parameter 'tableName' is not empty");
 
 		this.parent = parent;

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/trace/HuTraceQueryCreator.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/trace/HuTraceQueryCreator.java
@@ -402,7 +402,7 @@ final class HuTraceQueryCreator
 
 	private static int extractInt(@NonNull final DocumentFilterParam parameter)
 	{
-		final Object value = Check.assumeNotNull(parameter.getValue(), "Given paramter may not have a null value; parameter={}", parameter);
+		final Object value = Check.assumeNotNull(parameter.getValue(), "Given parameter may not have a null value; parameter={}", parameter);
 
 		if (value instanceof LookupValue)
 		{
@@ -421,7 +421,7 @@ final class HuTraceQueryCreator
 
 	private static String extractString(@NonNull final DocumentFilterParam parameter)
 	{
-		final Object value = Check.assumeNotNull(parameter.getValue(), "Given paramter may not have a null value; parameter={}", parameter);
+		final Object value = Check.assumeNotNull(parameter.getValue(), "Given parameter may not have a null value; parameter={}", parameter);
 
 		if (value instanceof LookupValue)
 		{

--- a/backend/de.metas.util/src/main/java/de/metas/util/StringUtils.java
+++ b/backend/de.metas.util/src/main/java/de/metas/util/StringUtils.java
@@ -221,7 +221,7 @@ public final class StringUtils
 				result = string.substring(0, maxLength);
 				break;
 			default:
-				Check.errorIf(true, "Unexpected parameter TruncateAt={}; lenght={}; string={}", side, maxLength, string);
+				Check.errorIf(true, "Unexpected parameter TruncateAt={}; length={}; string={}", side, maxLength, string);
 				result = ""; // won't be reached;
 		}
 


### PR DESCRIPTION
Fixes the typos reported in #25728:

- `occured` -> `occurred` (javadoc)
- `paramter` -> `parameter` (assert messages & javadoc)
- `lenght` -> `length` (error message)
- `sucessful` -> `successful` (javadoc)

Only comments and user-facing assert/log message strings are touched, no behavior change.