### PR TITLE
CI images: move the JDK-8 Maven stages off Debian 11 (EOL) to maven:3.8.8-eclipse-temurin-8

### DIFF
--- a/docker-builds/Dockerfile.backend
+++ b/docker-builds/Dockerfile.backend
@@ -14,7 +14,7 @@ COPY backend .
 RUN find . -type f ! -name "pom.xml" -exec rm -r {} \;
 
 
-FROM maven:3.8.4-jdk-8 AS build
+FROM maven:3.8.8-eclipse-temurin-8 AS build
 
 WORKDIR /backend
 

--- a/docker-builds/Dockerfile.common
+++ b/docker-builds/Dockerfile.common
@@ -1,5 +1,3 @@
-# maven:3.8.4-jdk-8 was Debian 11 (bullseye), EOL 2026-08-31. Jammy-based Temurin 8, same Maven minor.
-# Keep common / backend / cucumber / junit / migration-cli on the SAME tag — they share /root/.m2.
 FROM maven:3.8.8-eclipse-temurin-8
 
 WORKDIR /parent

--- a/docker-builds/Dockerfile.common
+++ b/docker-builds/Dockerfile.common
@@ -1,4 +1,6 @@
-FROM maven:3.8.4-jdk-8
+# maven:3.8.4-jdk-8 was Debian 11 (bullseye), EOL 2026-08-31. Jammy-based Temurin 8, same Maven minor.
+# Keep common / backend / cucumber / junit / migration-cli on the SAME tag — they share /root/.m2.
+FROM maven:3.8.8-eclipse-temurin-8
 
 WORKDIR /parent
 COPY misc/parent-pom .

--- a/docker-builds/Dockerfile.cucumber
+++ b/docker-builds/Dockerfile.cucumber
@@ -4,7 +4,18 @@ FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
 FROM maven:3.8.4-jdk-8
 
-RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
+# security.debian.org is CDN-fronted; a single edge node can serve a stale 404 for one .deb while every
+# other node serves it (2026-09-04: node 146.75.122.132 returned 404 for locales_2.31-13+deb11u14 on
+# three consecutive runs, failing this image build each time — nothing to retry against, same node).
+# deb.debian.org mirrors the same debian-security suite under a different host, i.e. a different CDN
+# cache key: fall back to it when the primary install fails instead of failing the whole cucumber build.
+RUN apt-get update \
+    && ( apt-get install -y locales \
+         || { echo "locales install from security.debian.org failed; retrying via deb.debian.org mirror"; \
+              sed -i 's|http://security.debian.org/debian-security|http://deb.debian.org/debian-security|' /etc/apt/sources.list; \
+              apt-get update && apt-get install -y locales; } ) \
+    && rm -rf /var/lib/apt/lists/* \
+    && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
 ENV LANG=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 LC_MESSAGES=de_DE.UTF-8
 ENV TZ=Europe/Berlin
 

--- a/docker-builds/Dockerfile.cucumber
+++ b/docker-builds/Dockerfile.cucumber
@@ -2,20 +2,9 @@ ARG REFNAME=local
 ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
-FROM maven:3.8.4-jdk-8
+FROM maven:3.8.8-eclipse-temurin-8
 
-# security.debian.org is CDN-fronted; a single edge node can serve a stale 404 for one .deb while every
-# other node serves it (2026-09-04: node 146.75.122.132 returned 404 for locales_2.31-13+deb11u14 on
-# three consecutive runs, failing this image build each time — nothing to retry against, same node).
-# deb.debian.org mirrors the same debian-security suite under a different host, i.e. a different CDN
-# cache key: fall back to it when the primary install fails instead of failing the whole cucumber build.
-RUN apt-get update \
-    && ( apt-get install -y locales \
-         || { echo "locales install from security.debian.org failed; retrying via deb.debian.org mirror"; \
-              sed -i 's|http://security.debian.org/debian-security|http://deb.debian.org/debian-security|' /etc/apt/sources.list; \
-              apt-get update && apt-get install -y locales; } ) \
-    && rm -rf /var/lib/apt/lists/* \
-    && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
+RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
 ENV LANG=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 LC_MESSAGES=de_DE.UTF-8
 ENV TZ=Europe/Berlin
 

--- a/docker-builds/Dockerfile.junit
+++ b/docker-builds/Dockerfile.junit
@@ -3,7 +3,7 @@ ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-common:$REFNAME AS common
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
-FROM maven:3.8.4-jdk-8 AS junit
+FROM maven:3.8.8-eclipse-temurin-8 AS junit
 
 ARG SKIP_MIGRATION_SCRIPTS_TEST=false
 

--- a/docker-builds/Dockerfile.migration-cli
+++ b/docker-builds/Dockerfile.migration-cli
@@ -5,7 +5,7 @@
 # Build context requires:
 #   - git.properties file (created from init job outputs)
 
-FROM maven:3.8.4-jdk-8
+FROM maven:3.8.8-eclipse-temurin-8
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Problem

`build (cucumber)` failed three times in a row on `deep_tundra_release` (original + two re-runs of https://github.com/metasfresh/metasfresh/actions/runs/33842137998), and then `test (java)` failed the same way on `intensive_care_hotfix` (https://github.com/metasfresh/metasfresh/actions/runs/33861350675) — both in the first `RUN` of the image (`Dockerfile.cucumber` / `Dockerfile.junit`):

```
Err:2 http://security.debian.org/debian-security bullseye-security/main amd64 locales all 2.31-13+deb11u14
  404  Not Found [IP: 146.75.122.132 80]
```

Both images build `FROM maven:3.8.4-jdk-8`, which is **Debian 11 (bullseye) — LTS ended 2026-08-31** (https://wiki.debian.org/LTS). Building on an EOL suite is the root cause; the CDN 404 four days after EOL is the symptom, and re-running does not help.

## Fix

Move every JDK-8 Maven stage to `maven:3.8.8-eclipse-temurin-8`:

| Dockerfile | before | after |
|---|---|---|
| `Dockerfile.common` | `maven:3.8.4-jdk-8` | `maven:3.8.8-eclipse-temurin-8` |
| `Dockerfile.backend` (build stage) | same | same |
| `Dockerfile.cucumber` | same | same |
| `Dockerfile.junit` | same | same |
| `Dockerfile.migration-cli` | same | same |

They move together because they share the `/root/.m2` populated by the earlier stages. Target facts (verified with `docker run`): Ubuntu 22.04.3 jammy (standard support until 2027-04-01), Apache Maven 3.8.8 (same minor as before), Temurin 1.8.0_392; `locales` and `mmv` resolvable from the default jammy sources; no Dockerfile or script hardcodes a JDK path / `JAVA_HOME`.

The first commit on this branch added an interim `security.debian.org → deb.debian.org` mirror fallback to `Dockerfile.cucumber`; on a jammy base that is dead code (its apt sources use `archive.ubuntu.com` / `security.ubuntu.com`), so the second commit reverts it to the plain install line. Net diff vs the base branch: the five `FROM` lines plus a two-line comment in `Dockerfile.common`.

## Verification

Authoritative: this PR's CI — `build-commons → backend → build (cucumber) / test (java) / migration-cli` rebuild from scratch on the new base (the base-branch layer cache does not apply to a new `FROM`).

Out of scope (tracked separately): the other EOL bases in `docker-builds/` — `node:14` (Debian 10 buster) in `Dockerfile.mobile*`, `maven:3.8.4-eclipse-temurin-17` (Ubuntu 20.04 focal) in `Dockerfile.camel*`, `ubuntu:16.04` in `Dockerfile.frontend.compat`.
