### PR TITLE
Cucumber: de-flake productMaturing by running CreateMaturingCandidates synchronously (port)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/process/AD_Process_Run_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/process/AD_Process_Run_StepDef.java
@@ -1,0 +1,97 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.process;
+
+import de.metas.process.AdProcessId;
+import de.metas.process.IADProcessDAO;
+import de.metas.process.ProcessInfo;
+import de.metas.security.IRoleDAO;
+import de.metas.security.Role;
+import de.metas.security.RoleId;
+import de.metas.user.UserId;
+import de.metas.util.Services;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.service.ClientId;
+import org.compiere.util.Env;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Generic step definition that runs any {@code AD_Process} by its {@code Value}, the same way the
+ * {@code Scheduler} runs it: under the test's client context and the {@code WebUI} role (the default
+ * cucumber System client/role context would match no business records). Works for SQL processes
+ * (e.g. {@code de.metas.process.ExecuteUpdateSQL}) as well as Java processes that take no parameters.
+ *
+ * <p>Rationale for direct invocation: in production this process is triggered by an {@code AD_Scheduler}
+ * at a configurable interval. Invoking it directly via {@code ProcessInfo.executeSync()} keeps the test
+ * deterministic — no dependency on scheduler timing or async queues.
+ */
+@RequiredArgsConstructor
+public class AD_Process_Run_StepDef
+{
+	@NonNull private final IADProcessDAO adProcessDAO = Services.get(IADProcessDAO.class);
+	@NonNull private final IRoleDAO roleDAO = Services.get(IRoleDAO.class);
+
+	/**
+	 * Runs the {@code AD_Process} identified by its {@code Value}, synchronously, and fails the step if the
+	 * process reports an error. The process is executed under the logged-in client and the {@code WebUI}
+	 * role, mirroring how the {@code AD_Scheduler} invokes it.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * When the AD_Process with value 'My_AD_Process_Value' is run
+	 * </pre>
+	 *
+	 * @param processValue the {@code AD_Process.Value}
+	 */
+	@When("the AD_Process with value {string} is run")
+	public void run_ad_process_by_value(@NonNull final String processValue)
+	{
+		final AdProcessId processId = adProcessDAO.retrieveProcessIdByValue(processValue);
+		assertThat(processId).as("AD_Process with Value=%s must exist", processValue).isNotNull();
+
+		final ClientId clientId = Env.getClientId();
+		final UserId loggedUserId = Env.getLoggedUserId();
+		final RoleId roleId = roleDAO.getUserRoles(loggedUserId)
+				.stream()
+				.filter(r -> "WebUI".equals(r.getName()))
+				.map(Role::getId)
+				.findFirst()
+				.orElseThrow(() -> new AdempiereException("WebUI role not found for user " + loggedUserId));
+
+		ProcessInfo.builder()
+				.setAD_Process_ID(processId.getRepoId())
+				.setClientId(clientId)
+				.setRoleId(roleId)
+				.setCreateTemporaryCtx()
+				.buildAndPrepareExecution()
+				.switchContextWhenRunning()
+				.executeSync()
+				.getResult()
+				.propagateErrorIfAny();
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
@@ -78,7 +78,7 @@ Feature: Maturing scenarios
 
     And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -86,6 +86,11 @@ Feature: Maturing scenarios
 
     And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
+    # Intentionally NOT converted to the generic "AD_Process ... is run" step (unlike
+    # CreateMaturingCandidates above):
+    # - A synchronous run only enqueues its selection.
+    # - Its close chain needs the scheduler's own async RUN_ONCE dispatch to flip IsClosed.
+    # - Run synchronously, the candidate stays unclosed. Do not convert this line.
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_AlreadyMaturedForOrdering' is ran once
 
     And after not more than 60s, PP_Order_Candidates are found
@@ -151,7 +156,7 @@ Feature: Maturing scenarios
 
     And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -163,7 +168,7 @@ Feature: Maturing scenarios
 
     And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -206,7 +211,7 @@ Feature: Maturing scenarios
 
     And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -218,6 +223,6 @@ Feature: Maturing scenarios
 
     And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     Then after not more than 60s, no PP_Order_Candidates are found for Issue_HU_ID: 'rawgood_hu_30'


### PR DESCRIPTION
Test-only port to `soft_panda_hotfix` of the maturing de-flake that already landed on `new_dawn_uat` (https://github.com/metasfresh/metasfresh/pull/25175) and `deep_tundra_release` (https://github.com/metasfresh/metasfresh/pull/25475).

## Why

The three `productMaturing.feature` scenarios fail intermittently on this branch (`after not more than 60s, PP_Order_Candidates are found` times out — the maturing candidate is never created). Root cause (see the two PRs above): triggering `CreateMaturingCandidates` through the async `AD_Scheduler … is ran once` (RUN_ONCE) path races with an already-closed TrxRun transaction on the scheduler thread. Flaky-registry cases 15 / 16 / 26; latest recurrence on this branch's base build 5.175-soft-panda-hotfix.43099.

## What

- `AD_Process_Run_StepDef` — the generic synchronous `the AD_Process with value '<value>' is run` step (`ProcessInfo.executeSync()` under the user's WebUI role), ported from https://github.com/metasfresh/metasfresh/pull/24601. Only this file of that PR is needed here.
- `productMaturing.feature` — cherry-pick of https://github.com/metasfresh/metasfresh/commit/f4ca93b4d3077ac2d369ccc67f60a427c741ab72: five `CreateMaturingCandidates` scheduler triggers become the synchronous step; the `AlreadyMaturedForOrdering` trigger intentionally stays on the scheduler path (its close chain needs the async dispatch). Applied cleanly; the resulting step counts (1 `is ran once` / 5 sync runs) match `new_dawn_uat`.

No production code touched.