### PR TITLE
CI images: move the JDK-8 Maven stages off Debian 11 (EOL) to maven:3.8.8-eclipse-temurin-8 (port)

### DIFF
--- a/backend/de.metas.serviceprovider/src/test/java/de/metas/serviceprovider/issue/IssueServiceTest.java
+++ b/backend/de.metas.serviceprovider/src/test/java/de/metas/serviceprovider/issue/IssueServiceTest.java
@@ -53,14 +53,19 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class IssueServiceTest
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
-	private final IssueRepository issueRepository = new IssueRepository(queryBL, ModelCacheInvalidationService.newInstanceForUnitTesting());
-	private final TimeBookingRepository timeBookingRepository = new TimeBookingRepository(queryBL);
-	private final IssueService issueService = new IssueService(issueRepository, timeBookingRepository);
+	private IssueRepository issueRepository;
+	private TimeBookingRepository timeBookingRepository;
+	private IssueService issueService;
 
 	@BeforeEach
 	public void init()
 	{
 		AdempiereTestHelper.get().init();
+
+		// construct after init(): newInstanceForUnitTesting() requires JUnit test mode to be enabled
+		issueRepository = new IssueRepository(queryBL, ModelCacheInvalidationService.newInstanceForUnitTesting());
+		timeBookingRepository = new TimeBookingRepository(queryBL);
+		issueService = new IssueService(issueRepository, timeBookingRepository);
 	}
 
 	/**

--- a/backend/de.metas.serviceprovider/src/test/java/de/metas/serviceprovider/timebooking/importer/failed/FailedTimeBookingRepositoryTest.java
+++ b/backend/de.metas.serviceprovider/src/test/java/de/metas/serviceprovider/timebooking/importer/failed/FailedTimeBookingRepositoryTest.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class FailedTimeBookingRepositoryTest
 {
-	private final FailedTimeBookingRepository failedTimeBookingRepository = FailedTimeBookingRepository.newInstanceForUnitTesting();
+	private FailedTimeBookingRepository failedTimeBookingRepository;
 
 	private ExternalSystem MOCK_EXTERNAL_SYSTEM_EVERHOUR = null;
 	private ExternalSystem MOCK_EXTERNAL_SYSTEM_GITHUB = null;
@@ -50,6 +50,9 @@ public class FailedTimeBookingRepositoryTest
 	public void init()
 	{
 		AdempiereTestHelper.get().init();
+
+		// construct after init(): newInstanceForUnitTesting() requires JUnit test mode to be enabled
+		failedTimeBookingRepository = FailedTimeBookingRepository.newInstanceForUnitTesting();
 
 		MOCK_EXTERNAL_SYSTEM_EVERHOUR = ExternalSystemTestHelper.createExternalSystemIfNotExists(ExternalSystemType.Everhour);
 		MOCK_EXTERNAL_SYSTEM_GITHUB = ExternalSystemTestHelper.createExternalSystemIfNotExists(ExternalSystemType.Github);

--- a/docker-builds/Dockerfile.backend
+++ b/docker-builds/Dockerfile.backend
@@ -14,7 +14,7 @@ COPY backend .
 RUN find . -type f ! -name "pom.xml" -exec rm -r {} \;
 
 
-FROM maven:3.8.4-jdk-8 AS build
+FROM maven:3.8.8-eclipse-temurin-8 AS build
 
 WORKDIR /backend
 

--- a/docker-builds/Dockerfile.common
+++ b/docker-builds/Dockerfile.common
@@ -1,4 +1,4 @@
-FROM maven:3.8.4-jdk-8
+FROM maven:3.8.8-eclipse-temurin-8
 
 WORKDIR /parent
 COPY misc/parent-pom .

--- a/docker-builds/Dockerfile.cucumber
+++ b/docker-builds/Dockerfile.cucumber
@@ -2,7 +2,7 @@ ARG REFNAME=local
 ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
-FROM maven:3.8.4-jdk-8
+FROM maven:3.8.8-eclipse-temurin-8
 
 RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
 ENV LANG=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 LC_MESSAGES=de_DE.UTF-8

--- a/docker-builds/Dockerfile.junit
+++ b/docker-builds/Dockerfile.junit
@@ -3,7 +3,7 @@ ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-common:$REFNAME AS common
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
-FROM maven:3.8.4-jdk-8 AS junit
+FROM maven:3.8.8-eclipse-temurin-8 AS junit
 
 ARG SKIP_MIGRATION_SCRIPTS_TEST=false
 

--- a/docker-builds/Dockerfile.migration-cli
+++ b/docker-builds/Dockerfile.migration-cli
@@ -5,7 +5,7 @@
 # Build context requires:
 #   - git.properties file (created from init job outputs)
 
-FROM maven:3.8.4-jdk-8
+FROM maven:3.8.8-eclipse-temurin-8
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Port of https://github.com/metasfresh/metasfresh/pull/25730 (`deep_tundra_release`; same change already on `intensive_care_hotfix` via https://github.com/metasfresh/metasfresh/pull/25731 and `soft_panda_hotfix` via https://github.com/metasfresh/metasfresh/pull/25732).

## Problem

`build (cucumber)` and `test (java)` fail in the first `RUN` of `Dockerfile.cucumber` / `Dockerfile.junit`:

```
Err:2 http://security.debian.org/debian-security bullseye-security/main amd64 locales all 2.31-13+deb11u14
  404  Not Found
```

Those images build `FROM maven:3.8.4-jdk-8`, which is **Debian 11 (bullseye) — LTS ended 2026-08-31** (https://wiki.debian.org/LTS). Building on an EOL suite is the root cause; re-running does not help.

## Fix

`FROM maven:3.8.4-jdk-8` → `FROM maven:3.8.8-eclipse-temurin-8` in `Dockerfile.common`, `Dockerfile.backend` (build stage), `Dockerfile.cucumber`, `Dockerfile.junit` and — where the branch has it — `Dockerfile.migration-cli`; they move together because they share the `/root/.m2` populated by the earlier stages. Target (verified with `docker run`): Ubuntu 22.04 jammy (standard support until 2027-04-01), Apache Maven 3.8.8 (same minor), Temurin 1.8.0_392; `locales` and `mmv` resolvable; no Dockerfile or script hardcodes a JDK path.

## Verification

This PR's CI: `build-commons → backend → build (cucumber) / test (java) / migration-cli` rebuild from scratch on the new base. The same five-line change is already green-built on `deep_tundra_release`, `intensive_care_hotfix` and `soft_panda_hotfix`.
