### PR TITLE
CI images: move the JDK-8 Maven stages off Debian 11 (EOL) to maven:3.8.8-eclipse-temurin-8 (port)

### DIFF
--- a/docker-builds/Dockerfile.backend
+++ b/docker-builds/Dockerfile.backend
@@ -9,7 +9,7 @@ COPY backend .
 RUN find . -type f ! -name "pom.xml" -exec rm -r {} \;
 
 
-FROM maven:3.8.4-jdk-8 as build
+FROM maven:3.8.8-eclipse-temurin-8 as build
 
 WORKDIR /backend
 

--- a/docker-builds/Dockerfile.common
+++ b/docker-builds/Dockerfile.common
@@ -1,4 +1,4 @@
-FROM maven:3.8.4-jdk-8
+FROM maven:3.8.8-eclipse-temurin-8
 
 WORKDIR /parent
 COPY misc/parent-pom .

--- a/docker-builds/Dockerfile.cucumber
+++ b/docker-builds/Dockerfile.cucumber
@@ -2,7 +2,7 @@ ARG REFNAME=local
 ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME as backend
 
-FROM maven:3.8.4-jdk-8
+FROM maven:3.8.8-eclipse-temurin-8
 
 RUN apt-get update && apt-get install -y locales postgresql-client && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
 ENV LANG=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 LC_MESSAGES=de_DE.UTF-8

--- a/docker-builds/Dockerfile.junit
+++ b/docker-builds/Dockerfile.junit
@@ -3,7 +3,7 @@ ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-common:$REFNAME as common
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME as backend
 
-FROM maven:3.8.4-jdk-8 as junit
+FROM maven:3.8.8-eclipse-temurin-8 as junit
 
 ARG SKIP_MIGRATION_SCRIPTS_TEST=false
 


### PR DESCRIPTION
Port of https://github.com/metasfresh/metasfresh/pull/25730 (`deep_tundra_release`; same change already on `intensive_care_hotfix` via https://github.com/metasfresh/metasfresh/pull/25731 and `soft_panda_hotfix` via https://github.com/metasfresh/metasfresh/pull/25732).

## Problem

`build (cucumber)` and `test (java)` fail in the first `RUN` of `Dockerfile.cucumber` / `Dockerfile.junit`:

```
Err:2 http://security.debian.org/debian-security bullseye-security/main amd64 locales all 2.31-13+deb11u14
  404  Not Found
```

Those images build `FROM maven:3.8.4-jdk-8`, which is **Debian 11 (bullseye) — LTS ended 2026-08-31** (https://wiki.debian.org/LTS). Building on an EOL suite is the root cause; re-running does not help.

## Fix

`FROM maven:3.8.4-jdk-8` → `FROM maven:3.8.8-eclipse-temurin-8` in `Dockerfile.common`, `Dockerfile.backend` (build stage), `Dockerfile.cucumber`, `Dockerfile.junit` and — where the branch has it — `Dockerfile.migration-cli`; they move together because they share the `/root/.m2` populated by the earlier stages. Target (verified with `docker run`): Ubuntu 22.04 jammy (standard support until 2027-04-01), Apache Maven 3.8.8 (same minor), Temurin 1.8.0_392; `locales` and `mmv` resolvable; no Dockerfile or script hardcodes a JDK path.

## Verification

This PR's CI: `build-commons → backend → build (cucumber) / test (java) / migration-cli` rebuild from scratch on the new base. The same five-line change is already green-built on `deep_tundra_release`, `intensive_care_hotfix` and `soft_panda_hotfix`.
