### PR TITLE
serviceprovider tests — construct repositories after JUnit test mode is enabled

### DIFF
--- a/backend/de.metas.serviceprovider/src/test/java/de/metas/serviceprovider/issue/IssueServiceTest.java
+++ b/backend/de.metas.serviceprovider/src/test/java/de/metas/serviceprovider/issue/IssueServiceTest.java
@@ -53,14 +53,19 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class IssueServiceTest
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
-	private final IssueRepository issueRepository = new IssueRepository(queryBL, ModelCacheInvalidationService.newInstanceForUnitTesting());
-	private final TimeBookingRepository timeBookingRepository = new TimeBookingRepository(queryBL);
-	private final IssueService issueService = new IssueService(issueRepository, timeBookingRepository);
+	private IssueRepository issueRepository;
+	private TimeBookingRepository timeBookingRepository;
+	private IssueService issueService;
 
 	@BeforeEach
 	public void init()
 	{
 		AdempiereTestHelper.get().init();
+
+		// construct after init(): newInstanceForUnitTesting() requires JUnit test mode to be enabled
+		issueRepository = new IssueRepository(queryBL, ModelCacheInvalidationService.newInstanceForUnitTesting());
+		timeBookingRepository = new TimeBookingRepository(queryBL);
+		issueService = new IssueService(issueRepository, timeBookingRepository);
 	}
 
 	/**

--- a/backend/de.metas.serviceprovider/src/test/java/de/metas/serviceprovider/timebooking/importer/failed/FailedTimeBookingRepositoryTest.java
+++ b/backend/de.metas.serviceprovider/src/test/java/de/metas/serviceprovider/timebooking/importer/failed/FailedTimeBookingRepositoryTest.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class FailedTimeBookingRepositoryTest
 {
-	private final FailedTimeBookingRepository failedTimeBookingRepository = FailedTimeBookingRepository.newInstanceForUnitTesting();
+	private FailedTimeBookingRepository failedTimeBookingRepository;
 
 	private ExternalSystem MOCK_EXTERNAL_SYSTEM_EVERHOUR = null;
 	private ExternalSystem MOCK_EXTERNAL_SYSTEM_GITHUB = null;
@@ -50,6 +50,9 @@ public class FailedTimeBookingRepositoryTest
 	public void init()
 	{
 		AdempiereTestHelper.get().init();
+
+		// construct after init(): newInstanceForUnitTesting() requires JUnit test mode to be enabled
+		failedTimeBookingRepository = FailedTimeBookingRepository.newInstanceForUnitTesting();
 
 		MOCK_EXTERNAL_SYSTEM_EVERHOUR = ExternalSystemTestHelper.createExternalSystemIfNotExists(ExternalSystemType.Everhour);
 		MOCK_EXTERNAL_SYSTEM_GITHUB = ExternalSystemTestHelper.createExternalSystemIfNotExists(ExternalSystemType.Github);


### PR DESCRIPTION
Test-only fix in `backend/de.metas.serviceprovider`.

## Problem

`IssueServiceTest` and `FailedTimeBookingRepositoryTest` construct their repositories via `ModelCacheInvalidationService.newInstanceForUnitTesting()` / `FailedTimeBookingRepository.newInstanceForUnitTesting()` in **field initializers**, i.e. before the `@BeforeEach` `AdempiereTestHelper.get().init()` has enabled JUnit test mode. That only passes when another test class in the same surefire JVM enabled test mode first. With a different class order the constructor fails:

```
[ERROR] IssueServiceTest.<init>:56 » IllegalState JUnit test mode shall be enabled
```

Reproduced locally on `new_dawn_uat` by running the class alone (`mvn -Dtest=IssueServiceTest test` → RED). The new `maven:3.8.8-eclipse-temurin-8` base image (https://github.com/metasfresh/metasfresh/pull/25730) changes the surefire class order and exposed this on older branches (https://github.com/metasfresh/metasfresh/pull/25746, https://github.com/metasfresh/metasfresh/pull/25747); on `new_dawn_uat` the defect is latent.

## Fix

Construct the repositories inside `init()` after `AdempiereTestHelper.get().init()` — the same fix https://github.com/metasfresh/metasfresh/commit/0d559977ec80d28b747df56bffaf314bd7d11b21 already applied to `GithubImporterServiceTest`. No production code touched.

## Verification

Local, `new_dawn_uat`-based branch, 2026-09-04: `mvn -o -Dtest=IssueServiceTest,FailedTimeBookingRepositoryTest test` in `backend/de.metas.serviceprovider` → `IssueServiceTest` 1/1, `FailedTimeBookingRepositoryTest` 3/3, 0 errors (RED before the change, GREEN after). CI `test (java)` on this PR.
