### PR TITLE
Fix typos in comments/javadoc

### DIFF
--- a/backend/de.metas.util/src/main/java/org/adempiere/util/lang/IReference.java
+++ b/backend/de.metas.util/src/main/java/org/adempiere/util/lang/IReference.java
@@ -29,7 +29,7 @@ package org.adempiere.util.lang;
  * This is the base interface for all reference aware classes and interfaces like:
  * <ul>
  * <li> {@link IMutable} which defines a mutable reference
- * <li> {@link LazyInitializer} which is an abtract class. It's value is initalized on first call of {@link #getValue()}.
+ * <li> {@link LazyInitializer} which is an abtract class. It's value is initialized on first call of {@link #getValue()}.
  * <li>etc
  * </ul>
  * 

--- a/misc/de-metas-common/de-metas-common-util/src/main/java/de/metas/common/util/Check.java
+++ b/misc/de-metas-common/de-metas-common-util/src/main/java/de/metas/common/util/Check.java
@@ -853,7 +853,7 @@ public final class Check
 			}
 			catch (final Exception e)
 			{
-				// In case message formating failed, we have a fallback format to use
+				// In case message formatting failed, we have a fallback format to use
 				messageFormated = new StringBuilder()
 						.append(message)
 						.append(" (").append(Arrays.toString(params)).append(")")

--- a/misc/de-metas-common/de-metas-common-util/src/main/java/de/metas/common/util/StringUtils.java
+++ b/misc/de-metas-common/de-metas-common-util/src/main/java/de/metas/common/util/StringUtils.java
@@ -320,7 +320,7 @@ public final class StringUtils
 			}
 			catch (final Exception e)
 			{
-				// In case message formating failed, we have a fallback format to use
+				// In case message formatting failed, we have a fallback format to use
 				messageFormated = new StringBuilder()
 						.append(message)
 						.append(" (").append(Arrays.toString(params)).append(")")


### PR DESCRIPTION
Fix minor typos in comments/javadoc/log messages. No functional change.