### PR TITLE
Manufacturing — component issue must credit P_Asset with a negative Fact_Acct qty

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
@@ -131,12 +131,25 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
 
     # Component issue: DR P_WIP_Acct / CR P_Asset_Acct (inventory down, WIP up).
     # Material receipt of finished good: DR P_Asset_Acct / CR P_WIP_Acct (inventory up, WIP down).
+    # Qty runs in the same direction as the amount on each leg: the debited account gains the quantity, the
+    # credited one loses it. The inventory valuation (Lagerwert) report sums Fact_Acct.qty per account, so a
+    # POSITIVE qty on the credit to P_Asset_Acct would add the issued component back onto the stock it left.
     And Fact_Acct records are matching
-      | Record_ID            | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr |
-      | issueCostCollector   | P_WIP_Acct            | compProd     | 10        | 0         |
-      | issueCostCollector   | P_Asset_Acct          | compProd     | 0         | 10        |
-      | receiptCostCollector | P_Asset_Acct          | finProd      | 10        | 0         |
-      | receiptCostCollector | P_WIP_Acct            | finProd      | 0         | 10        |
+      | Record_ID            | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr | Qty    |
+      | issueCostCollector   | P_WIP_Acct            | compProd     | 10        | 0         | 1 PCE  |
+      | issueCostCollector   | P_Asset_Acct          | compProd     | 0         | 10        | -1 PCE |
+      | receiptCostCollector | P_Asset_Acct          | finProd      | 10        | 0         | 1 PCE  |
+      | receiptCostCollector | P_WIP_Acct            | finProd      | 0         | 10        | -1 PCE |
+
+    # Lagerwert, the report those qty signs feed: the component is down to 99 of its seeded 100 PCE, the
+    # finished good up to 11 of its seeded 10, each still at its unchanged 10 CHF/PCE. Both products are
+    # stocked and issued in the same UOM, so each lands on a single report row - which is what makes a
+    # wrong-signed issue qty invisible here: it is added to the stock row instead of subtracted from it,
+    # leaving the ledger amount right and only the quantity and cost price wrong (101 PCE at 990/101).
+    And expect inventory valuation report
+      | Date       | M_Product_ID | M_Warehouse_ID | Qty | Acct_CostPrice | Acct_ExpectedAmt | InventoryValueAcctAmt |
+      | 2024-03-27 | compProd     | warehouseStd   | 99  | 10.0000        | 990.00           | 990.00                |
+      | 2024-03-27 | finProd      | warehouseStd   | 11  | 10.0000        | 110.00           | 110.00                |
 
   @from:cucumber
   @Id:S26253_TC1
@@ -418,11 +431,11 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
 
     # issued 340 - received 300 = a 40 CHF WIP residual for the Distribute action to discharge.
     And Fact_Acct records are matching
-      | Record_ID            | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr |
-      | issueCostCollector   | P_WIP_Acct            | compProd     | 340       | 0         |
-      | issueCostCollector   | P_Asset_Acct          | compProd     | 0         | 340       |
-      | receiptCostCollector | P_Asset_Acct          | finProd      | 300       | 0         |
-      | receiptCostCollector | P_WIP_Acct            | finProd      | 0         | 300       |
+      | Record_ID            | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr | Qty     |
+      | issueCostCollector   | P_WIP_Acct            | compProd     | 340       | 0         | 10 PCE  |
+      | issueCostCollector   | P_Asset_Acct          | compProd     | 0         | 340       | -10 PCE |
+      | receiptCostCollector | P_Asset_Acct          | finProd      | 300       | 0         | 10 PCE  |
+      | receiptCostCollector | P_WIP_Acct            | finProd      | 0         | 300       | -10 PCE |
 
     # Sell 10 of the 18 PCE on hand, leaving the 8 PCE onto which the residual gets capitalized.
     And metasfresh contains M_PricingSystems
@@ -459,10 +472,12 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
       | acctSchema      | finProd      | AveragePO        | 30 CHF           | 8 PCE      |
 
-    # Lagerwert before discharging: the 8 PCE still on hand, booked on P_Asset_Acct at 30 CHF/PCE.
+    # Lagerwert before discharging: the 8 PCE still on hand, booked on P_Asset_Acct at 30 CHF/PCE, and the
+    # component down to 90 of its seeded 100 PCE - 1000 CHF seeded minus the 340 issued, so 660 over 90 PCE.
     And expect inventory valuation report
       | Date       | M_Product_ID | M_Warehouse_ID | Qty | Acct_CostPrice | Acct_ExpectedAmt | InventoryValueAcctAmt |
       | 2024-03-27 | finProd      | warehouseStd   | 8   | 30.0000        | 240.00           | 240.00                |
+      | 2024-03-27 | compProd     | warehouseStd   | 90  | 7.3333         | 660.00           | 660.00                |
 
     And the manufacturing order identified by ppOrder is distributed
 
@@ -567,11 +582,11 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
 
     # issued 250 - received 200 = a 50 CHF WIP residual for the Distribute action to discharge.
     And Fact_Acct records are matching
-      | Record_ID            | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr |
-      | issueCostCollector   | P_WIP_Acct            | compProd     | 250       | 0         |
-      | issueCostCollector   | P_Asset_Acct          | compProd     | 0         | 250       |
-      | receiptCostCollector | P_Asset_Acct          | finProd      | 200       | 0         |
-      | receiptCostCollector | P_WIP_Acct            | finProd      | 0         | 200       |
+      | Record_ID            | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr | Qty     |
+      | issueCostCollector   | P_WIP_Acct            | compProd     | 250       | 0         | 10 PCE  |
+      | issueCostCollector   | P_Asset_Acct          | compProd     | 0         | 250       | -10 PCE |
+      | receiptCostCollector | P_Asset_Acct          | finProd      | 200       | 0         | 10 PCE  |
+      | receiptCostCollector | P_WIP_Acct            | finProd      | 0         | 200       | -10 PCE |
 
     # Sell 10 of the 16 PCE on hand, leaving the 6 PCE onto which the residual gets capitalized.
     And metasfresh contains M_PricingSystems
@@ -608,10 +623,12 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty |
       | acctSchema      | finProd      | MovingAverageInvoice | 20 CHF           | 6 PCE      |
 
-    # Lagerwert before discharging: the 6 PCE still on hand, booked on P_Asset_Acct at 20 CHF/PCE.
+    # Lagerwert before discharging: the 6 PCE still on hand, booked on P_Asset_Acct at 20 CHF/PCE, and the
+    # component down to 90 of its seeded 100 PCE - 1000 CHF seeded minus the 250 issued, so 750 over 90 PCE.
     And expect inventory valuation report
       | Date       | M_Product_ID | M_Warehouse_ID | Qty | Acct_CostPrice | Acct_ExpectedAmt | InventoryValueAcctAmt |
       | 2024-03-27 | finProd      | warehouseStd   | 6   | 20.0000        | 120.00           | 120.00                |
+      | 2024-03-27 | compProd     | warehouseStd   | 90  | 8.3333         | 750.00           | 750.00                |
 
     And the manufacturing order identified by ppOrder is distributed
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
@@ -741,7 +741,8 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
     # point of discharging the residual is that the warehouse must be worth this same 60 again afterwards -
     # manufacturing moves value between products, it does not create any.
     # cwComp is asserted only here. Once issued it returns TWO report rows - the PCE stock and the KGM issue -
-    # because the report groups by the UOM on each posting, and the step takes one row per product.
+    # because the report groups by the UOM on each posting, and the step REQUIRES exactly one row per
+    # product - it fails on more, it does not pick one.
     And expect inventory valuation report
       | Date       | M_Product_ID | M_Warehouse_ID | Qty | Acct_CostPrice | Acct_ExpectedAmt | InventoryValueAcctAmt |
       | 2024-03-27 | cwComp       | warehouseStd   | 1   | 7.0000         | 7.00             | 7.00                  |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
@@ -131,9 +131,7 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
 
     # Component issue: DR P_WIP_Acct / CR P_Asset_Acct (inventory down, WIP up).
     # Material receipt of finished good: DR P_Asset_Acct / CR P_WIP_Acct (inventory up, WIP down).
-    # Qty runs in the same direction as the amount on each leg: the debited account gains the quantity, the
-    # credited one loses it. The inventory valuation (Lagerwert) report sums Fact_Acct.qty per account, so a
-    # POSITIVE qty on the credit to P_Asset_Acct would add the issued component back onto the stock it left.
+    # Qty runs with the amount on each leg: the debited account gains it, the credited one loses it.
     And Fact_Acct records are matching
       | Record_ID            | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr | Qty    |
       | issueCostCollector   | P_WIP_Acct            | compProd     | 10        | 0         | 1 PCE  |
@@ -141,11 +139,10 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
       | receiptCostCollector | P_Asset_Acct          | finProd      | 10        | 0         | 1 PCE  |
       | receiptCostCollector | P_WIP_Acct            | finProd      | 0         | 10        | -1 PCE |
 
-    # Lagerwert, the report those qty signs feed: the component is down to 99 of its seeded 100 PCE, the
-    # finished good up to 11 of its seeded 10, each still at its unchanged 10 CHF/PCE. Both products are
-    # stocked and issued in the same UOM, so each lands on a single report row - which is what makes a
-    # wrong-signed issue qty invisible here: it is added to the stock row instead of subtracted from it,
-    # leaving the ledger amount right and only the quantity and cost price wrong (101 PCE at 990/101).
+    # Lagerwert, the report those qty signs feed: the component down to 99 of its seeded 100 PCE, the finished
+    # good up to 11 of its seeded 10, each at its unchanged 10 CHF/PCE. Both are stocked and issued in the same
+    # UOM, so each lands on one row - a wrong-signed issue qty is added there instead of subtracted (101 PCE at
+    # 990/101), leaving the ledger amount right and only the quantity and cost price wrong.
     And expect inventory valuation report
       | Date       | M_Product_ID | M_Warehouse_ID | Qty | Acct_CostPrice | Acct_ExpectedAmt | InventoryValueAcctAmt |
       | 2024-03-27 | compProd     | warehouseStd   | 99  | 10.0000        | 990.00           | 990.00                |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
@@ -390,9 +390,6 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
 
     # Baseline Lagerwert, before anything is manufactured. The ledger holds what the seeding inventories
     # actually posted - compProd at the Background's 10 CHF, not the 34 its current cost was later set to.
-    # The component is asserted ONLY here: after the issue the report's Qty counts the issued quantity with
-    # the wrong sign (100 + 10 issued reads as 110, not 90), so its Acct_CostPrice is wrong too while the
-    # amount stays right. Asserting that would bake the defect in - it is being fixed separately.
     And expect inventory valuation report
       | Date       | M_Product_ID | M_Warehouse_ID | Qty | Acct_CostPrice | Acct_ExpectedAmt | InventoryValueAcctAmt |
       | 2024-03-27 | compProd     | warehouseStd   | 100 | 10.0000        | 1000.00          | 1000.00               |
@@ -743,6 +740,8 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
     # Baseline Lagerwert, before anything is manufactured: 7 + 53 = 60 CHF across both products. The whole
     # point of discharging the residual is that the warehouse must be worth this same 60 again afterwards -
     # manufacturing moves value between products, it does not create any.
+    # cwComp is asserted only here. Once issued it returns TWO report rows - the PCE stock and the KGM issue -
+    # because the report groups by the UOM on each posting, and the step takes one row per product.
     And expect inventory valuation report
       | Date       | M_Product_ID | M_Warehouse_ID | Qty | Acct_CostPrice | Acct_ExpectedAmt | InventoryValueAcctAmt |
       | 2024-03-27 | cwComp       | warehouseStd   | 1   | 7.0000         | 7.00             | 7.00                  |

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/manufacturing/acct/Doc_PPCostCollector.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/manufacturing/acct/Doc_PPCostCollector.java
@@ -315,11 +315,13 @@ public class Doc_PPCostCollector extends Doc<DocLine_CostCollector>
 
 			final CostAmount costs = costResult.getCostAmountForCostElement(element).getMainAmt();
 			// A ComponentIssue line carries a negated qty (DocLine_CostCollector.setQty(movementQty, isSOTrx=true)),
-			// so getCreateCosts returns a negative cost. Posting it uncompensated would invert the direction
-			// (DR-WIP negative / CR-Asset negative). Compensate the sign here — mirroring createFacts_Variance —
-			// so a component issue posts DR P_WIP_Acct (positive) / CR P_Asset_Acct (positive): inventory down, WIP up.
+			// so getCreateCosts returns a negative COST — negate it back to post DR P_WIP_Acct / CR P_Asset_Acct
+			// (inventory down, WIP up). Do NOT negate the qty as well: createFactLines already puts +qty on the
+			// debit leg and -qty on the credit leg, so the positive issued qty is what leaves P_Asset_Acct with
+			// -qty. Negating it too gave the credited P_Asset_Acct a POSITIVE qty, which report_InventoryValue
+			// (Lagerwert) sums back into the very stock the component had just left.
 			// alsoAddZeroLine=true: a component issue always books, even a zero-cost/zero-qty line
-			final Fact fact = createFactLines(as, element, debit, credit, costs.negate(), qtyIssued.negate(), true);
+			final Fact fact = createFactLines(as, element, debit, credit, costs.negate(), qtyIssued, true);
 			if (fact != null)
 			{
 				facts.add(fact);

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/manufacturing/acct/Doc_PPCostCollector.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/manufacturing/acct/Doc_PPCostCollector.java
@@ -314,12 +314,10 @@ public class Doc_PPCostCollector extends Doc<DocLine_CostCollector>
 			}
 
 			final CostAmount costs = costResult.getCostAmountForCostElement(element).getMainAmt();
-			// A ComponentIssue line carries a negated qty (DocLine_CostCollector.setQty(movementQty, isSOTrx=true)),
-			// so getCreateCosts returns a negative COST — negate it back to post DR P_WIP_Acct / CR P_Asset_Acct
-			// (inventory down, WIP up). Do NOT negate the qty as well: createFactLines already puts +qty on the
-			// debit leg and -qty on the credit leg, so the positive issued qty is what leaves P_Asset_Acct with
-			// -qty. Negating it too gave the credited P_Asset_Acct a POSITIVE qty, which report_InventoryValue
-			// (Lagerwert) sums back into the very stock the component had just left.
+			// The doc line carries a negated qty (DocLine_CostCollector.setQty(movementQty, isSOTrx=true)), so
+			// getCreateCosts returns a negative COST — negate it back. Do NOT negate the qty too: createFactLines
+			// puts +qty on the debit leg and -qty on the credit leg, so the positive issued qty is what leaves
+			// P_Asset_Acct with the -qty that report_InventoryValue sums as stock going out.
 			// alsoAddZeroLine=true: a component issue always books, even a zero-cost/zero-qty line
 			final Fact fact = createFactLines(as, element, debit, credit, costs.negate(), qtyIssued, true);
 			if (fact != null)


### PR DESCRIPTION
## Problem

A manufacturing **component issue** writes its `Fact_Acct.Qty` with the wrong sign: the leg that **credits**
`P_Asset_Acct` carries a **positive** quantity, and the leg that debits `P_WIP_Acct` a negative one.

The inventory valuation report ("Lagerwert", `de_metas_acct.report_InventoryValue`) aggregates
`COALESCE(SUM(fa.qty), 0)` per account, so it **adds** every issued component back onto the stock it just
left. Measured on the existing cucumber scenario `@Id:S30811_TC4` before the fix — component seeded at
100 PCE / 1000 CHF, 10 PCE issued at 25 CHF:

| | Qty | Acct_CostPrice | Acct_ExpectedAmt | Acct_ErrorAmt | InventoryValueAcctAmt |
|---|---|---|---|---|---|
| reported | 110 | 6.8182 | 750.00 | 0.00 | 750 |
| correct | 90 | 8.3333 | 750.00 | 0.00 | 750 |

The ledger **amount** is right; only the **quantity** and the **cost price derived from it** are wrong. And
because `Acct_ExpectedAmt` is `Acct_CostPrice x Qty`, the two errors cancel and `Acct_ErrorAmt` stays `0.00`
— the report raises no flag at all. This has been silently corrupting quantity and cost price on every
manufacturing component issue.

## Root cause

`Doc_PPCostCollector.createFactLines` gives the **debit** leg `setQty(qty)` and the **credit** leg
`setQty(qty.negate())`: the debited account gains the quantity, the credited one loses it. That is the
convention every other document type follows — `Doc_InOut.createFacts_SalesShipmentLine`
(DR `P_COGS` `+qty` / CR `P_Asset` `-qty`) and `Doc_Inventory.createFactsForInventoryLine`
(`P_Asset` qty sign-aligned with `setAmtSourceDrOrCr`).

`createFacts_ComponentIssue` broke it. A `ComponentIssue` doc line carries a negated qty
(`DocLine_CostCollector.setQty(movementQty, isSOTrx=true)`), so `getCreateCosts` returns a negative **cost**.
Commit https://github.com/metasfresh/metasfresh/commit/f1a344082b2 (2026-06-23) compensated for that by negating **both** the cost and the qty:

```java
createFactLines(as, element, debit, credit, costs.negate(), qtyIssued.negate(), true);
```

The **cost** negation was the fix that commit intended and is correct. Negating the **qty** as well was
collateral: `qtyIssued` (`PP_Cost_Collector.MovementQty`) is already positive, so the extra negation put
`+qtyIssued` on the credited `P_Asset_Acct`. Its cucumber scenario asserted only `AmtAcctDr`/`AmtAcctCr`,
never `Qty`, so the regression shipped invisible.

## Which layer is wrong — the posting, not the report

`report_InventoryValue`'s signed `SUM(fa.qty)` is correct and is already load-bearing on a green assertion:
`@Id:S30811_TC3` asserts the report shows the finished good at **Qty 8** after 8 seeded + 10 manufactured
- 10 shipped. That is only reachable if the shipment's `P_Asset` credit contributes **-10** and the report
sums signed. Compensating in the report would break every shipment, inventory and movement posting.
`ComponentIssue` is the lone outlier, so the fix belongs there.

## Fix

Stop negating the quantity; keep negating the cost.

```java
createFactLines(as, element, debit, credit, costs.negate(), qtyIssued, true);
```

A component issue now posts DR `P_WIP_Acct` `+qty` / CR `P_Asset_Acct` `-qty`. The change is sign-symmetric:
for a negative `MovementQty` (a component return) `P_Asset_Acct` correctly gains quantity. `P_FloorStock_Acct`
issues follow the same path. Material-receipt, variance, activity-control, by/co-product and
cost-difference-distribution postings are untouched.

## Blast radius

**General, not a catch-weight corner case.** The defect is unconditional in `createFacts_ComponentIssue`,
so it affects every manufacturing component issue. Two shapes:

- **Same UOM** (component stocked and issued in the same unit) — the stock and issue postings merge into one
  report row, so the wrong sign is **added** to the on-hand quantity: 110 instead of 90 above. `Acct_ErrorAmt`
  is `0.00`, so nothing flags it. This is the common case and the silent one.
- **Catch weight** (e.g. stocked in PCE, BOM line in KGM) — the postings land in different UOM groups, so the
  issue gets its own row with a **negative** cost price. There `Costing_ErrorAmt` does surface a discrepancy
  where the true one is zero.

Beyond the Lagerwert report, the same `Fact_Acct.qty` feeds
`de_metas_acct.m_inventoryline_update_qtycount_from_fact_acct`, which reconciles physical inventory against
accounting stock.

## Existing data — this fix is forward-only

Only newly posted cost collectors are corrected. `Fact_Acct` rows already written keep the wrong `Qty` sign
and will keep skewing the report for past periods. The affected window is bounded: before https://github.com/metasfresh/metasfresh/commit/f1a344082b2
(2026-06-23, reverted in https://github.com/metasfresh/metasfresh/commit/7b28242a47a and restored in https://github.com/metasfresh/metasfresh/commit/aabf9b98f07 on 2026-07-02) the qty was correct and the
*amount* was inverted instead, so only postings made by a release carrying that commit are affected.

Correcting history would need either a re-post of the affected `PP_Cost_Collector` documents or a data
migration flipping `Qty` on their `P_Asset_Acct`/`P_WIP_Acct`/`P_FloorStock_Acct` fact lines. **Flagging, not
writing one** — whether it is wanted, and over which period, is a decision for the issue owner.

## Rollout impact

Manufacturing cost collectors are in active use on this branch line, so wrong-signed rows are being
written for every component issue on the instances it serves. Whether the inventory valuation report is
actually consulted on them is not established from the code, which bears on how urgent the rollout is.

## Test

`backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature`

- Added the `Qty` column to the `Fact_Acct records are matching` tables of the component-issue scenario and of
  `@Id:S30811_TC3` / `@Id:S30811_TC4` — this pins the root cause at the posting.
- Added the component's post-issue row to the Lagerwert assertions of all three — this pins the user-visible
  consequence. The finished-good rows those scenarios already asserted are unchanged and still pass.

RED before the fix: exactly those 3 scenarios failed, each on the component-issue qty sign; the other 4
scenarios in the file passed. GREEN after: all 7 pass. `de.metas.manufacturing` unit tests: 122 pass.
