### PR TITLE
merge/modus_operandi_hotfix-to-modus_operandi_release

### DIFF
--- a/docker-builds/Dockerfile.backend
+++ b/docker-builds/Dockerfile.backend
@@ -14,7 +14,7 @@ COPY backend .
 RUN find . -type f ! -name "pom.xml" -exec rm -r {} \;
 
 
-FROM maven:3.8.4-jdk-8 AS build
+FROM maven:3.8.8-eclipse-temurin-8 AS build
 
 WORKDIR /backend
 

--- a/docker-builds/Dockerfile.common
+++ b/docker-builds/Dockerfile.common
@@ -1,4 +1,4 @@
-FROM maven:3.8.4-jdk-8
+FROM maven:3.8.8-eclipse-temurin-8
 
 WORKDIR /parent
 COPY misc/parent-pom .

--- a/docker-builds/Dockerfile.cucumber
+++ b/docker-builds/Dockerfile.cucumber
@@ -2,7 +2,7 @@ ARG REFNAME=local
 ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
-FROM maven:3.8.4-jdk-8
+FROM maven:3.8.8-eclipse-temurin-8
 
 RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
 ENV LANG=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 LC_MESSAGES=de_DE.UTF-8

--- a/docker-builds/Dockerfile.junit
+++ b/docker-builds/Dockerfile.junit
@@ -3,7 +3,7 @@ ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-common:$REFNAME AS common
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
-FROM maven:3.8.4-jdk-8 AS junit
+FROM maven:3.8.8-eclipse-temurin-8 AS junit
 
 ARG SKIP_MIGRATION_SCRIPTS_TEST=false
 


### PR DESCRIPTION
Merge-through of `modus_operandi_hotfix` into `modus_operandi_release`.

Carries the JDK-8 Maven base-image bump already merged on `modus_operandi_hotfix` — `FROM maven:3.8.4-jdk-8` (Debian 11 bullseye, LTS ended 2026-08-31, `apt-get install` 404s) → `FROM maven:3.8.8-eclipse-temurin-8` (Ubuntu 22.04 jammy) in the `docker-builds/` Dockerfiles — plus everything else pending on `modus_operandi_hotfix`.

Created manually (same branch naming as the auto-port workflow) because auto-port only fires on a green `cicd` run of the source branch.
