### PR TITLE
merge/galaxy_hero_hotfix-to-galaxy_hero_release

### DIFF
--- a/backend/de.metas.serviceprovider/src/test/java/de/metas/serviceprovider/issue/IssueServiceTest.java
+++ b/backend/de.metas.serviceprovider/src/test/java/de/metas/serviceprovider/issue/IssueServiceTest.java
@@ -53,14 +53,19 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class IssueServiceTest
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
-	private final IssueRepository issueRepository = new IssueRepository(queryBL, ModelCacheInvalidationService.newInstanceForUnitTesting());
-	private final TimeBookingRepository timeBookingRepository = new TimeBookingRepository(queryBL);
-	private final IssueService issueService = new IssueService(issueRepository, timeBookingRepository);
+	private IssueRepository issueRepository;
+	private TimeBookingRepository timeBookingRepository;
+	private IssueService issueService;
 
 	@BeforeEach
 	public void init()
 	{
 		AdempiereTestHelper.get().init();
+
+		// construct after init(): newInstanceForUnitTesting() requires JUnit test mode to be enabled
+		issueRepository = new IssueRepository(queryBL, ModelCacheInvalidationService.newInstanceForUnitTesting());
+		timeBookingRepository = new TimeBookingRepository(queryBL);
+		issueService = new IssueService(issueRepository, timeBookingRepository);
 	}
 
 	/**

--- a/backend/de.metas.serviceprovider/src/test/java/de/metas/serviceprovider/timebooking/importer/failed/FailedTimeBookingRepositoryTest.java
+++ b/backend/de.metas.serviceprovider/src/test/java/de/metas/serviceprovider/timebooking/importer/failed/FailedTimeBookingRepositoryTest.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class FailedTimeBookingRepositoryTest
 {
-	private final FailedTimeBookingRepository failedTimeBookingRepository = FailedTimeBookingRepository.newInstanceForUnitTesting();
+	private FailedTimeBookingRepository failedTimeBookingRepository;
 
 	private ExternalSystem MOCK_EXTERNAL_SYSTEM_EVERHOUR = null;
 	private ExternalSystem MOCK_EXTERNAL_SYSTEM_GITHUB = null;
@@ -50,6 +50,9 @@ public class FailedTimeBookingRepositoryTest
 	public void init()
 	{
 		AdempiereTestHelper.get().init();
+
+		// construct after init(): newInstanceForUnitTesting() requires JUnit test mode to be enabled
+		failedTimeBookingRepository = FailedTimeBookingRepository.newInstanceForUnitTesting();
 
 		MOCK_EXTERNAL_SYSTEM_EVERHOUR = ExternalSystemTestHelper.createExternalSystemIfNotExists(ExternalSystemType.Everhour);
 		MOCK_EXTERNAL_SYSTEM_GITHUB = ExternalSystemTestHelper.createExternalSystemIfNotExists(ExternalSystemType.Github);

--- a/docker-builds/Dockerfile.backend
+++ b/docker-builds/Dockerfile.backend
@@ -14,7 +14,7 @@ COPY backend .
 RUN find . -type f ! -name "pom.xml" -exec rm -r {} \;
 
 
-FROM maven:3.8.4-jdk-8 AS build
+FROM maven:3.8.8-eclipse-temurin-8 AS build
 
 WORKDIR /backend
 

--- a/docker-builds/Dockerfile.common
+++ b/docker-builds/Dockerfile.common
@@ -1,4 +1,4 @@
-FROM maven:3.8.4-jdk-8
+FROM maven:3.8.8-eclipse-temurin-8
 
 WORKDIR /parent
 COPY misc/parent-pom .

--- a/docker-builds/Dockerfile.cucumber
+++ b/docker-builds/Dockerfile.cucumber
@@ -2,7 +2,7 @@ ARG REFNAME=local
 ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
-FROM maven:3.8.4-jdk-8
+FROM maven:3.8.8-eclipse-temurin-8
 
 RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
 ENV LANG=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 LC_MESSAGES=de_DE.UTF-8

--- a/docker-builds/Dockerfile.junit
+++ b/docker-builds/Dockerfile.junit
@@ -3,7 +3,7 @@ ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-common:$REFNAME AS common
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
-FROM maven:3.8.4-jdk-8 AS junit
+FROM maven:3.8.8-eclipse-temurin-8 AS junit
 
 ARG SKIP_MIGRATION_SCRIPTS_TEST=false
 

--- a/docker-builds/Dockerfile.migration-cli
+++ b/docker-builds/Dockerfile.migration-cli
@@ -5,7 +5,7 @@
 # Build context requires:
 #   - git.properties file (created from init job outputs)
 
-FROM maven:3.8.4-jdk-8
+FROM maven:3.8.8-eclipse-temurin-8
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Merge-through of `galaxy_hero_hotfix` into `galaxy_hero_release`.

Carries the JDK-8 Maven base-image bump already merged on `galaxy_hero_hotfix` — `FROM maven:3.8.4-jdk-8` (Debian 11 bullseye, LTS ended 2026-08-31, `apt-get install` 404s) → `FROM maven:3.8.8-eclipse-temurin-8` (Ubuntu 22.04 jammy) in the `docker-builds/` Dockerfiles — plus everything else pending on `galaxy_hero_hotfix`.

Created manually (same branch naming as the auto-port workflow) because auto-port only fires on a green `cicd` run of the source branch.
