### PR TITLE
Quick Input — Enter on a secondary lookup sub-field drops the selected value

### DIFF
--- a/e2e/frontend-webui/tests/spec/quick-input.spec.js
+++ b/e2e/frontend-webui/tests/spec/quick-input.spec.js
@@ -5,9 +5,9 @@ import { Backend } from '../utils/Backend';
 import { LoginPage } from '../utils/pages/LoginPage';
 import { DashboardPage } from '../utils/pages/DashboardPage';
 import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
-import { SLOW_ACTION_TIMEOUT } from '../utils/common';
+import { SLOW_ACTION_TIMEOUT, collectPageErrors } from '../utils/common';
 import { SALES_ORDER_WINDOW_ID } from '../utils/WindowIds';
-import { waitForTabAllowsNew } from '../utils/WebAPIValidation';
+import { waitForTabAllowsNew, getTabRows } from '../utils/WebAPIValidation';
 
 /**
  * Quick Input (Batch Entry) E2E test suite.
@@ -21,6 +21,8 @@ import { waitForTabAllowsNew } from '../utils/WebAPIValidation';
  * 3. Multiple lines in sequence: Add two lines via Enter-key workflow
  * 4. Invalid product: no beep when sysconfig disabled (default behavior)
  * 5. Regular form lookup regression: Customer selection in header (non-quick-input)
+ * 6. Enter-key selects packing instruction on secondary sub-field (the reported bug)
+ * 7. Mouse-click selects packing instruction on secondary sub-field (regression)
  */
 
 // ============================================================================
@@ -31,7 +33,10 @@ import { waitForTabAllowsNew } from '../utils/WebAPIValidation';
  * Create standard masterdata for quick input tests.
  * Creates a user, customer, and one or two products.
  */
-async function createMasterdata(language, { twoProducts = false } = {}) {
+async function createMasterdata(
+  language,
+  { twoProducts = false, withPackingInstruction = false } = {}
+) {
   const products = {
     Product1: {
       name: 'QIPROD',
@@ -48,26 +53,32 @@ async function createMasterdata(language, { twoProducts = false } = {}) {
     };
   }
 
-  return await Backend.createMasterdata({
-    request: {
-      login: {
-        user: {
-          language,
-          firstname: 'QI',
-          lastname: 'Test',
-        },
+  const request = {
+    login: {
+      user: {
+        language,
+        firstname: 'QI',
+        lastname: 'Test',
       },
-      bpartners: {
-        CUSTOMER1: {
-          isVendor: false,
-          isCustomer: true,
-          isSoPriceList: true,
-          name: 'Customer',
-        },
-      },
-      products,
     },
-  });
+    bpartners: {
+      CUSTOMER1: {
+        isVendor: false,
+        isCustomer: true,
+        isSoPriceList: true,
+        name: 'Customer',
+      },
+    },
+    products,
+  };
+
+  if (withPackingInstruction) {
+    request.packingInstructions = {
+      PI: { tu: 'TU', product: 'Product1', qtyCUsPerTU: 4 },
+    };
+  }
+
+  return await Backend.createMasterdata({ request });
 }
 
 /**
@@ -144,6 +155,36 @@ async function typeProductAndWaitForDropdown(page, productCode) {
   await page.waitForTimeout(300);
 
   return productInput;
+}
+
+/**
+ * Type into the Packvorschrift (M_HU_PI_Item_Product_ID) sub-field of the quick input
+ * (index 2 of the composite product lookup) and wait for its dropdown.
+ */
+async function typePackingInstructionAndWaitForDropdown(page, text) {
+  const piInput = page.locator('#lookup_M_HU_PI_Item_Product_ID input.input-field');
+  await piInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+  await expect(piInput).toBeEnabled({ timeout: SLOW_ACTION_TIMEOUT }); // enabled once the product is set
+  await piInput.click();
+  await piInput.fill(text);
+  await page.waitForTimeout(500);
+  await page
+    .locator('#lookup_M_HU_PI_Item_Product_ID .rotating, #lookup_M_HU_PI_Item_Product_ID .spinner')
+    .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+    .catch(() => {});
+  await page.locator('.input-dropdown-list-option').first().waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+  return piInput;
+}
+
+/** Assert the single order line carries the given M_HU_PI_Item_Product_ID. */
+async function expectSingleLineWithPackingInstruction(recordId, expectedPiItemProductId) {
+  const rows = await getTabRows(SALES_ORDER_WINDOW_ID, recordId, 'AD_Tab-187');
+  expect(rows).toHaveLength(1);
+  const piField = rows[0].fieldsByName.M_HU_PI_Item_Product_ID;
+  // masterdata.packingInstructions.PI.tuPIItemProductTestId is a data-testid style string
+  // ("tuPIItemProduct-<M_HU_PI_Item_Product_ID>"), not the bare id — strip the prefix.
+  const expectedId = String(expectedPiItemProductId).replace(/^\D+/, '');
+  expect(piField && piField.value && String(piField.value.key)).toBe(expectedId);
 }
 
 /**
@@ -450,6 +491,88 @@ Continuous keyboard entry: line1 → line2 → ... without reopening batch entry
       console.log(
         `[${language}] Multiple lines test passed — 2 lines created`
       );
+    });
+
+    // ------------------------------------------------------------------
+    // TEST 6 (TC2): Enter on the SECONDARY sub-field (Packvorschrift) of the
+    // composite product lookup — the reported bug. Index 2, not index 0.
+    // ------------------------------------------------------------------
+    test(`Enter-key selects packing instruction on secondary sub-field (${label})`, async ({ page }) => {
+      allure.epic('E0100: Sales');
+      allure.tag('F00101.10: Sales Order Quick Entry packing instruction');
+      allure.tag('F00101.10');
+      allure.story('Quick Input: packing instruction via Enter');
+      allure.severity('critical');
+      allure.parameter('Language', language);
+      allure.tag(language);
+      test.setTimeout(150000);
+
+      const errors = collectPageErrors(page);
+      const masterdata = await createMasterdata(language, { withPackingInstruction: true });
+      allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+      const pi = masterdata.packingInstructions.PI;
+
+      const { recordId } = await setupOrderWithBatchEntry(page, masterdata, language);
+
+      await typeProductAndWaitForDropdown(page, masterdata.products.Product1.productCode);
+      await page.keyboard.press('Enter');
+      await page.waitForTimeout(1000);
+
+      const piInput = await typePackingInstructionAndWaitForDropdown(page, pi.tuName);
+      await page.keyboard.press('Enter');          // ← the defective path (RawLookup.handleAutoSelectAndAdvance, index 2)
+      await page.waitForTimeout(1000);
+      expect(await piInput.inputValue()).toContain(pi.tuName);
+
+      const quantityInput = page.getByRole('spinbutton');
+      await quantityInput.click();
+      await quantityInput.fill('3');
+      await page.keyboard.press('Enter');
+      await page.waitForTimeout(2000);
+
+      await expectSingleLineWithPackingInstruction(recordId, pi.tuPIItemProductTestId);
+      await expect(page.locator('#lookup_M_HU_PI_Item_Product_ID input.input-field')).toHaveValue('');
+      await expect(page.locator('#lookup_M_Product_ID input.input-field')).toHaveValue('');
+      expect(errors, `browser errors: ${errors.join('\n')}`).toEqual([]);
+    });
+
+    // ------------------------------------------------------------------
+    // TEST 7 (TC6): same sub-field, MOUSE selection (handleSelect_RegularItem, index 2).
+    // Works today; must keep working after the shared-helper refactor.
+    // ------------------------------------------------------------------
+    test(`Mouse-click selects packing instruction on secondary sub-field (${label})`, async ({ page }) => {
+      allure.epic('E0100: Sales');
+      allure.tag('F00101.10: Sales Order Quick Entry packing instruction');
+      allure.tag('F00101.10');
+      allure.story('Quick Input: packing instruction via mouse');
+      allure.severity('normal');
+      allure.parameter('Language', language);
+      allure.tag(language);
+      test.setTimeout(150000);
+
+      const errors = collectPageErrors(page);
+      const masterdata = await createMasterdata(language, { withPackingInstruction: true });
+      allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+      const pi = masterdata.packingInstructions.PI;
+
+      const { recordId } = await setupOrderWithBatchEntry(page, masterdata, language);
+
+      await typeProductAndWaitForDropdown(page, masterdata.products.Product1.productCode);
+      await page.keyboard.press('Enter');
+      await page.waitForTimeout(1000);
+
+      await typePackingInstructionAndWaitForDropdown(page, pi.tuName);
+      await page.locator('.input-dropdown-list-option').getByText(pi.tuName).first().click();
+      await page.waitForTimeout(1000);
+
+      const quantityInput = page.getByRole('spinbutton');
+      await quantityInput.click();
+      await quantityInput.fill('3');
+      await page.keyboard.press('Enter');
+      await page.waitForTimeout(2000);
+
+      await expectSingleLineWithPackingInstruction(recordId, pi.tuPIItemProductTestId);
+      await expect(page.locator('#lookup_M_HU_PI_Item_Product_ID input.input-field')).toHaveValue('');
+      expect(errors, `browser errors: ${errors.join('\n')}`).toEqual([]);
     });
 
     // ------------------------------------------------------------------

--- a/e2e/frontend-webui/tests/spec/quick-input.spec.js
+++ b/e2e/frontend-webui/tests/spec/quick-input.spec.js
@@ -14,6 +14,7 @@ import { waitForTabAllowsNew, getTabRows } from '../utils/WebAPIValidation';
  *
  * Features tested:
  * - F00100: Sales Order
+ * - F00101.10: Sales Order Quick Entry packing instruction
  *
  * Tests:
  * 1. Enter-key focus advance: Product → Enter → focus advances to Qty
@@ -23,6 +24,7 @@ import { waitForTabAllowsNew, getTabRows } from '../utils/WebAPIValidation';
  * 5. Regular form lookup regression: Customer selection in header (non-quick-input)
  * 6. Enter-key selects packing instruction on secondary sub-field (the reported bug)
  * 7. Mouse-click selects packing instruction on secondary sub-field (regression)
+ * (TESTs 6–7 are placed after TEST 3 in the file)
  */
 
 // ============================================================================
@@ -514,6 +516,7 @@ Continuous keyboard entry: line1 → line2 → ... without reopening batch entry
 
       const { recordId } = await setupOrderWithBatchEntry(page, masterdata, language);
 
+      errors.length = 0; // contract: zero browser errors during the quick-input steps only (TC2/TC6 steps 3–5)
       await typeProductAndWaitForDropdown(page, masterdata.products.Product1.productCode);
       await page.keyboard.press('Enter');
       await page.waitForTimeout(1000);
@@ -529,10 +532,10 @@ Continuous keyboard entry: line1 → line2 → ... without reopening batch entry
       await page.keyboard.press('Enter');
       await page.waitForTimeout(2000);
 
+      expect(errors, `browser errors: ${errors.join('\n')}`).toEqual([]);
       await expectSingleLineWithPackingInstruction(recordId, pi.tuPIItemProductTestId);
       await expect(page.locator('#lookup_M_HU_PI_Item_Product_ID input.input-field')).toHaveValue('');
       await expect(page.locator('#lookup_M_Product_ID input.input-field')).toHaveValue('');
-      expect(errors, `browser errors: ${errors.join('\n')}`).toEqual([]);
     });
 
     // ------------------------------------------------------------------
@@ -556,11 +559,13 @@ Continuous keyboard entry: line1 → line2 → ... without reopening batch entry
 
       const { recordId } = await setupOrderWithBatchEntry(page, masterdata, language);
 
+      errors.length = 0; // contract: zero browser errors during the quick-input steps only (TC2/TC6 steps 3–5)
       await typeProductAndWaitForDropdown(page, masterdata.products.Product1.productCode);
       await page.keyboard.press('Enter');
       await page.waitForTimeout(1000);
 
       await typePackingInstructionAndWaitForDropdown(page, pi.tuName);
+      // getByText on a masterdata-generated TU name (language-invariant), not a localized caption
       await page.locator('.input-dropdown-list-option').getByText(pi.tuName).first().click();
       await page.waitForTimeout(1000);
 
@@ -570,9 +575,10 @@ Continuous keyboard entry: line1 → line2 → ... without reopening batch entry
       await page.keyboard.press('Enter');
       await page.waitForTimeout(2000);
 
+      expect(errors, `browser errors: ${errors.join('\n')}`).toEqual([]);
       await expectSingleLineWithPackingInstruction(recordId, pi.tuPIItemProductTestId);
       await expect(page.locator('#lookup_M_HU_PI_Item_Product_ID input.input-field')).toHaveValue('');
-      expect(errors, `browser errors: ${errors.join('\n')}`).toEqual([]);
+      await expect(page.locator('#lookup_M_Product_ID input.input-field')).toHaveValue('');
     });
 
     // ------------------------------------------------------------------

--- a/e2e/frontend-webui/tests/spec/quick-input.spec.js
+++ b/e2e/frontend-webui/tests/spec/quick-input.spec.js
@@ -7,7 +7,7 @@ import { DashboardPage } from '../utils/pages/DashboardPage';
 import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
 import { SLOW_ACTION_TIMEOUT, collectPageErrors } from '../utils/common';
 import { SALES_ORDER_WINDOW_ID } from '../utils/WindowIds';
-import { waitForTabAllowsNew, getTabRows } from '../utils/WebAPIValidation';
+import { waitForTabAllowsNew, getTabRows, waitForRecordSaved } from '../utils/WebAPIValidation';
 
 /**
  * Quick Input (Batch Entry) E2E test suite.
@@ -24,7 +24,9 @@ import { waitForTabAllowsNew, getTabRows } from '../utils/WebAPIValidation';
  * 5. Regular form lookup regression: Customer selection in header (non-quick-input)
  * 6. Enter-key selects packing instruction on secondary sub-field (the reported bug)
  * 7. Mouse-click selects packing instruction on secondary sub-field (regression)
- * (TESTs 6–7 are placed after TEST 3 in the file)
+ * 8. Regular-form composite partner lookup: server auto-fill of the location and
+ *    contact secondary sub-fields (RawList-rendered sub-fields, not RawLookup)
+ * (TESTs 6–8 are placed after TEST 3 in the file)
  */
 
 // ============================================================================
@@ -579,6 +581,52 @@ Continuous keyboard entry: line1 → line2 → ... without reopening batch entry
       await expectSingleLineWithPackingInstruction(recordId, pi.tuPIItemProductTestId);
       await expect(page.locator('#lookup_M_HU_PI_Item_Product_ID input.input-field')).toHaveValue('');
       await expect(page.locator('#lookup_M_Product_ID input.input-field')).toHaveValue('');
+    });
+
+    // ------------------------------------------------------------------
+    // TEST 8 (TC7 part a): regular-form composite BPartner lookup — the
+    // secondary sub-fields (Location, Contact) auto-fill from the server
+    // after selecting the customer. In THIS window these sub-fields are
+    // RawList-rendered (not RawLookup), so this guards the server auto-fill
+    // reaching the secondary sub-fields — not the RawLookup call sites
+    // themselves (those are covered by TESTs 6/7).
+    // ------------------------------------------------------------------
+    test(`Composite partner lookup: location and contact auto-fill in the regular form (${label})`, async ({ page }) => {
+      allure.epic('E0100: Sales');
+      allure.tag('F00100: Sales Order');
+      allure.tag('F00100');
+      allure.story('Composite lookup: secondary sub-fields auto-filled in a regular form');
+      allure.severity('normal');
+      allure.parameter('Language', language);
+      allure.tag(language);
+      test.setTimeout(150000);
+
+      // Contract: zero browser errors for the whole scenario — not reset mid-test.
+      const errors = collectPageErrors(page);
+      const masterdata = await createMasterdata(language);
+      allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+
+      await LoginPage.goto();
+      await LoginPage.login(masterdata.login.user);
+      await DashboardPage.expectVisible();
+      await SalesOrderPage.goto();
+      await SalesOrderPage.clickNew();
+      const recordId = await SalesOrderPage.selectCustomer(
+        masterdata.bpartners.CUSTOMER1.bpartnerCode
+      );
+
+      // Server auto-fill reached the secondary sub-fields — asserted, not logged.
+      await expect(page.locator('#lookup_C_BPartner_Location_ID input.input-field')).not.toHaveValue(
+        '',
+        { timeout: SLOW_ACTION_TIMEOUT }
+      );
+      // The server defaults AD_User_ID only from a contact flagged IsSalesContact_Default (CalloutOrder),
+      // which the frontend-testing masterdata API cannot set — so only the sub-field's presence is asserted here; Location is the auto-filled value under test.
+      await expect(page.locator('#lookup_AD_User_ID input.input-field')).toBeVisible();
+
+      await waitForRecordSaved(SALES_ORDER_WINDOW_ID, recordId, { maxRetries: 20, retryDelayMs: 1000 });
+
+      expect(errors, `browser errors: ${errors.join('\n')}`).toEqual([]);
     });
 
     // ------------------------------------------------------------------

--- a/e2e/frontend-webui/tests/utils/WebAPIValidation.js
+++ b/e2e/frontend-webui/tests/utils/WebAPIValidation.js
@@ -212,6 +212,26 @@ export async function getTabInfo(windowId, recordId, tabId) {
 }
 
 /**
+ * Fetch the included-tab rows of a record: GET /window/{windowId}/{recordId}/{tabId}
+ * (WindowRestController). Returns the array of row documents (each with fieldsByName).
+ *
+ * The endpoint's JSON body is a JSONDocumentList ({ result, missingIds, orderBys }), not a
+ * bare array — unwrap `.result`.
+ */
+export async function getTabRows(windowId, recordId, tabId) {
+  const page = getPage();
+  const response = await page.request.get(
+    `${WEBAPI_BASE_URL}/window/${windowId}/${recordId}/${tabId}`,
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+  if (!response.ok()) {
+    throw new Error(`HTTP ${response.status()} fetching rows of ${windowId}/${recordId}/${tabId}`);
+  }
+  const data = await response.json();
+  return data.result;
+}
+
+/**
  * Wait for a record to be saved (with retries).
  * Useful after filling mandatory fields and triggering save.
  *

--- a/e2e/frontend-webui/tests/utils/WebAPIValidation.js
+++ b/e2e/frontend-webui/tests/utils/WebAPIValidation.js
@@ -217,18 +217,28 @@ export async function getTabInfo(windowId, recordId, tabId) {
  *
  * The endpoint's JSON body is a JSONDocumentList ({ result, missingIds, orderBys }), not a
  * bare array — unwrap `.result`.
+ *
+ * @param {string|number} windowId - Window ID
+ * @param {string|number} recordId - Record ID
+ * @param {string} tabId - Tab ID (e.g., 'AD_Tab-187' for Sales Order Lines)
+ * @returns {Promise<Array>} Array of row documents (each with fieldsByName)
  */
 export async function getTabRows(windowId, recordId, tabId) {
-  const page = getPage();
-  const response = await page.request.get(
-    `${WEBAPI_BASE_URL}/window/${windowId}/${recordId}/${tabId}`,
-    { headers: { 'Content-Type': 'application/json' } }
-  );
-  if (!response.ok()) {
-    throw new Error(`HTTP ${response.status()} fetching rows of ${windowId}/${recordId}/${tabId}`);
+  try {
+    const page = getPage();
+    const response = await page.request.get(
+      `${WEBAPI_BASE_URL}/window/${windowId}/${recordId}/${tabId}`,
+      { headers: { 'Content-Type': 'application/json' } }
+    );
+    if (!response.ok()) {
+      throw new Error(`HTTP ${response.status()} fetching rows of ${windowId}/${recordId}/${tabId}`);
+    }
+    const data = await response.json();
+    return data.result;
+  } catch (error) {
+    console.error(`Failed to fetch tab rows for window ${windowId}, record ${recordId}, tab ${tabId}:`, error.message);
+    throw error;
   }
-  const data = await response.json();
-  return data.result;
 }
 
 /**

--- a/e2e/frontend-webui/tests/utils/common.js
+++ b/e2e/frontend-webui/tests/utils/common.js
@@ -11,6 +11,19 @@ export const VERY_SLOW_ACTION_TIMEOUT = 40000;   // 40 seconds
 export const getPage = () => global.currentPage;
 
 /**
+ * Collect uncaught page errors and console.error entries from `page` for a hard
+ * zero-error assertion at the end of a scenario. Attach BEFORE navigating.
+ */
+export function collectPageErrors(page) {
+  const errors = [];
+  page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+  });
+  return errors;
+}
+
+/**
  * Wrap a test step function with automatic error detection.
  * If an error toast appears during execution, the step will fail.
  */

--- a/frontend/src/__tests__/components/widget/Lookup/Lookup.test.js
+++ b/frontend/src/__tests__/components/widget/Lookup/Lookup.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { Lookup } from '../../../../components/widget/Lookup/Lookup';
+import RawLookup from '../../../../components/widget/Lookup/RawLookup';
+
+/**
+ * A composite lookup (partner → location) renders one RawLookup per sub-field.
+ * Only index 0 may receive the real callback / forwarded ref; non-primary sub-fields
+ * must receive `undefined` — never the boolean `false`.
+ */
+describe('Lookup — props handed to composite sub-fields', () => {
+  const properties = [
+    { field: 'C_BPartner_ID', source: 'lookup', caption: 'Partner' },
+    { field: 'C_BPartner_Location_ID', source: 'lookup', caption: 'Location' },
+  ];
+  const widgetData = [
+    { field: 'C_BPartner_ID', value: null, readonly: false, mandatory: true },
+    { field: 'C_BPartner_Location_ID', value: null, readonly: false, mandatory: false },
+  ];
+  const forwardedRef = React.createRef();
+
+  const render = () =>
+    shallow(
+      <Lookup
+        properties={properties}
+        widgetData={widgetData}
+        forwardedRef={forwardedRef}
+        windowType="143"
+        entity="window"
+        onChange={jest.fn()}
+        onSelectBarcode={jest.fn()}
+        onScanBarcode={jest.fn()}
+      />
+    );
+
+  it('primary sub-field gets the real handleInputEmptyStatus callback and the forwarded ref', () => {
+    const wrapper = render();
+    const primary = wrapper.find(RawLookup).at(0);
+    expect(typeof primary.prop('handleInputEmptyStatus')).toBe('function');
+    expect(primary.getElement().ref).toBe(forwardedRef);
+  });
+
+  it('secondary sub-field gets undefined — not false — for handleInputEmptyStatus and ref', () => {
+    const wrapper = render();
+    const secondary = wrapper.find(RawLookup).at(1);
+    expect(secondary.prop('handleInputEmptyStatus')).toBeUndefined();
+    expect(secondary.getElement().ref).toBeNull(); // React normalises an undefined ref to null
+  });
+});

--- a/frontend/src/__tests__/components/widget/Lookup/Lookup.test.js
+++ b/frontend/src/__tests__/components/widget/Lookup/Lookup.test.js
@@ -5,18 +5,18 @@ import { Lookup } from '../../../../components/widget/Lookup/Lookup';
 import RawLookup from '../../../../components/widget/Lookup/RawLookup';
 
 /**
- * A composite lookup (partner → location) renders one RawLookup per sub-field.
+ * A composite lookup (quick-input product → packing instruction) renders one RawLookup per sub-field.
  * Only index 0 may receive the real callback / forwarded ref; non-primary sub-fields
  * must receive `undefined` — never the boolean `false`.
  */
 describe('Lookup — props handed to composite sub-fields', () => {
   const properties = [
-    { field: 'C_BPartner_ID', source: 'lookup', caption: 'Partner' },
-    { field: 'C_BPartner_Location_ID', source: 'lookup', caption: 'Location' },
+    { field: 'M_Product_ID', source: 'lookup', caption: 'Product' },
+    { field: 'M_HU_PI_Item_Product_ID', source: 'lookup', caption: 'Packing instruction' },
   ];
   const widgetData = [
-    { field: 'C_BPartner_ID', value: null, readonly: false, mandatory: true },
-    { field: 'C_BPartner_Location_ID', value: null, readonly: false, mandatory: false },
+    { field: 'M_Product_ID', value: null, readonly: false, mandatory: true },
+    { field: 'M_HU_PI_Item_Product_ID', value: null, readonly: false, mandatory: false },
   ];
   const forwardedRef = React.createRef();
 

--- a/frontend/src/__tests__/components/widget/Lookup/RawLookup.test.js
+++ b/frontend/src/__tests__/components/widget/Lookup/RawLookup.test.js
@@ -45,6 +45,7 @@ const createDummyProps = (props = {}) => {
     onDropdownListToggle: jest.fn(),
     onChange: jest.fn(),
     enableAutofocus: jest.fn(),
+    setNextProperty: jest.fn(() => false),
     //
     // Overrides:
     ...props,
@@ -160,6 +161,58 @@ describe('RawLookup component', () => {
       });
       expect(handleValueSpy).toHaveBeenCalled();
       expect(wrapper.state().list.length).toEqual(2);
+    });
+  });
+
+  describe('handleInputEmptyStatus guard (non-primary sub-fields receive no function)', () => {
+    const item = { key: '1000123', caption: 'KT x 18 KG' };
+
+    // Lookup.js hands non-primary sub-fields `false` (pre-fix) / `undefined` (post-fix);
+    // primary sub-fields get the real callback. All three notification sites must cope.
+    const propValues = [
+      ['false', false],
+      ['undefined', undefined],
+      ['a function', 'FN'], // replaced by a fresh jest.fn() per test
+    ];
+
+    const mountWith = (handleInputEmptyStatus) => {
+      const onChange = jest.fn(); // returns undefined → doThen runs the callback synchronously
+      const props = createDummyProps({
+        subentity: 'quickInput',
+        onChange,
+        handleInputEmptyStatus,
+      });
+      const wrapper = mount(<RawLookup {...props} />);
+      return { wrapper, onChange, instance: wrapper.instance() };
+    };
+
+    describe.each(propValues)('handleInputEmptyStatus = %s', (_label, value) => {
+      let fn;
+      const resolve = () => (value === 'FN' ? (fn = jest.fn()) : value);
+
+      it('handleAutoSelectAndAdvance (quick-input Enter path) does not throw and PATCHes', () => {
+        const { instance, onChange } = mountWith(resolve());
+        expect(() => instance.handleAutoSelectAndAdvance(item)).not.toThrow();
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith('someField', item);
+        expect(instance.inputSearch.value).toBe('KT x 18 KG');
+        if (fn) expect(fn).toHaveBeenCalledWith(false);
+      });
+
+      it('handleSelect_RegularItem (mouse / regular form) does not throw and PATCHes', () => {
+        const { instance, onChange } = mountWith(resolve());
+        expect(() => instance.handleSelect_RegularItem(item)).not.toThrow();
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith('someField', item);
+        if (fn) expect(fn).toHaveBeenCalledWith(false);
+      });
+
+      it('componentDidUpdate (value arrives from the server) does not throw', () => {
+        const { wrapper } = mountWith(resolve());
+        expect(() => wrapper.setProps({ defaultValue: item })).not.toThrow();
+        expect(wrapper.instance().inputSearch.value).toBe('KT x 18 KG');
+        if (fn) expect(fn).toHaveBeenCalledWith(false);
+      });
     });
   });
 });

--- a/frontend/src/components/widget/Lookup/Lookup.js
+++ b/frontend/src/components/widget/Lookup/Lookup.js
@@ -16,7 +16,7 @@ import WidgetTooltip from '../WidgetTooltip';
  * Composed lookup (e.g. partner/location/contact) component.
  * NOTE: this component is covering also the case of a simple lookup which is just a particular case.
  */
-class Lookup extends Component {
+export class Lookup extends Component {
   rawLookupsState = {};
 
   constructor(props) {
@@ -479,7 +479,7 @@ class Lookup extends Component {
 
     return (
       <RawLookup
-        ref={isPrimaryField && forwardedRef}
+        ref={isPrimaryField ? forwardedRef : undefined}
         key={index}
         idValue={idValue}
         defaultValue={defaultValue}
@@ -492,7 +492,9 @@ class Lookup extends Component {
         setNextProperty={this.setNextProperty}
         lookupEmpty={isInputEmpty}
         fireDropdownList={fireDropdownList}
-        handleInputEmptyStatus={isPrimaryField && this.handleInputEmptyStatus}
+        handleInputEmptyStatus={
+          isPrimaryField ? this.handleInputEmptyStatus : undefined
+        }
         enableAutofocus={this.enableAutofocus}
         isOpen={isDropdownOpen}
         onDropdownListToggle={this.dropdownListToggle}

--- a/frontend/src/components/widget/Lookup/RawLookup.js
+++ b/frontend/src/components/widget/Lookup/RawLookup.js
@@ -122,7 +122,6 @@ export class RawLookup extends Component {
     const {
       autoFocus,
       defaultValue,
-      handleInputEmptyStatus,
       filterWidget,
       lookupEmpty,
       localClearing,
@@ -145,7 +144,7 @@ export class RawLookup extends Component {
         (prevProps.defaultValue &&
           prevProps.defaultValue.caption !== defaultValue.caption))
     ) {
-      handleInputEmptyStatus && handleInputEmptyStatus(false);
+      this.notifyInputEmptyStatus(false);
     }
 
     if (
@@ -228,6 +227,20 @@ export class RawLookup extends Component {
     );
   };
 
+  /**
+   * Tell the parent composite Lookup that this sub-field's input is (not) empty.
+   * Only the PRIMARY sub-field gets a real `handleInputEmptyStatus` callback from Lookup.js;
+   * secondary sub-fields get none — so every call site must go through this guard.
+   * Optional chaining (`handleInputEmptyStatus?.(false)`) is NOT a sufficient guard: it lets
+   * the literal `false` through and throws.
+   */
+  notifyInputEmptyStatus = (isEmpty) => {
+    const { handleInputEmptyStatus } = this.props;
+    if (typeof handleInputEmptyStatus === 'function') {
+      handleInputEmptyStatus(isEmpty);
+    }
+  };
+
   handleSelect_AdvancedSearch = () => {
     const {
       dispatch,
@@ -260,7 +273,6 @@ export class RawLookup extends Component {
   handleSelect_RegularItem = (selectedItemParam, isMouseEvent = false) => {
     const {
       onChange,
-      handleInputEmptyStatus,
       mainProperty,
       setNextProperty,
       filterWidget,
@@ -301,7 +313,7 @@ export class RawLookup extends Component {
     this.inputSearch.value = computeInputTextFromSelectedItem(selectedItemNorm);
     this.setState({ inputTextOnFocus: this.inputSearch.value });
 
-    handleInputEmptyStatus && handleInputEmptyStatus(false);
+    this.notifyInputEmptyStatus(false);
 
     if (shouldKeepFocus) {
       this.focus();
@@ -537,8 +549,7 @@ export class RawLookup extends Component {
    * Unlike handleSelect_RegularItem, this does NOT refocus the current lookup input.
    */
   handleAutoSelectAndAdvance = (selectedItem) => {
-    const { onChange, handleInputEmptyStatus, mainProperty, filterWidget } =
-      this.props;
+    const { onChange, mainProperty, filterWidget } = this.props;
 
     const fieldName = filterWidget
       ? mainProperty.parameterName
@@ -547,7 +558,7 @@ export class RawLookup extends Component {
     this.inputSearch.value = computeInputTextFromSelectedItem(selectedItem);
     this.setState({ inputTextOnFocus: this.inputSearch.value });
 
-    handleInputEmptyStatus?.(false);
+    this.notifyInputEmptyStatus(false);
 
     this.handleDropdownBlur();
 

--- a/frontend/src/components/widget/Lookup/RawLookup.js
+++ b/frontend/src/components/widget/Lookup/RawLookup.js
@@ -985,7 +985,7 @@ RawLookup.propTypes = {
   defaultValue: PropTypes.any,
   initialFocus: PropTypes.bool,
   autoFocus: PropTypes.bool,
-  handleInputEmptyStatus: PropTypes.any,
+  handleInputEmptyStatus: PropTypes.func,
   isOpen: PropTypes.bool,
   selected: PropTypes.object,
   forcedWidth: PropTypes.number,


### PR DESCRIPTION
## What

In the sales-order quick input, pressing Enter on a non-primary sub-field of the composite product lookup (e.g. the packing instruction sub-field, `M_HU_PI_Item_Product_ID`, index 2) dropped the selected value and threw `TypeError: handleInputEmptyStatus is not a function`. Selecting the same value via mouse click worked correctly.

## Root cause

`Lookup.js` passed the literal `false` (instead of `undefined`) as both the `ref` and the `handleInputEmptyStatus` prop for non-primary sub-fields of the composite lookup. `RawLookup.handleAutoSelectAndAdvance` called `handleInputEmptyStatus?.(false)` — optional chaining only guards against `null`/`undefined`, not against a non-function value such as `false`, so the call threw.

## Fix

- Added `RawLookup#notifyInputEmptyStatus(isEmpty)`, one guarded helper (checks `typeof handleInputEmptyStatus === 'function'`) used by all three call sites that previously invoked `handleInputEmptyStatus` directly: `componentDidUpdate`, `handleSelect_RegularItem`, `handleAutoSelectAndAdvance`.
- `Lookup.js` now passes `undefined` (not `false`) for the `ref` and `handleInputEmptyStatus` props of secondary sub-fields.
- Tightened `RawLookup.propTypes.handleInputEmptyStatus` from `PropTypes.any` to `PropTypes.func`.

Verified: `cd frontend && npx jest src/__tests__/components/widget/Lookup/RawLookup.test.js src/__tests__/components/widget/Lookup/Lookup.test.js` -> 2 suites / 16 tests passed, including the `handleInputEmptyStatus` guard cases for `false` / `undefined` / a real function across all three call sites (`handleAutoSelectAndAdvance`, `handleSelect_RegularItem`, `componentDidUpdate`).

## Changed files

- `frontend/src/components/widget/Lookup/Lookup.js`
- `frontend/src/components/widget/Lookup/RawLookup.js`
- `frontend/src/__tests__/components/widget/Lookup/RawLookup.test.js`
- `frontend/src/__tests__/components/widget/Lookup/Lookup.test.js`
- `e2e/frontend-webui/tests/spec/quick-input.spec.js`
- `e2e/frontend-webui/tests/utils/WebAPIValidation.js`
- `e2e/frontend-webui/tests/utils/common.js`

