### PR TITLE
HttpCallSchedulerTest — wait for the async failure instead of asserting isCompletedExceptionally() synchronously

### DIFF
--- a/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
+++ b/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
@@ -7,9 +7,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class HttpCallSchedulerTest
 {
@@ -113,10 +115,18 @@ class HttpCallSchedulerTest
 			throw new RuntimeException("test error");
 		}));
 
-		// Should complete exceptionally
-		assertThat(failingFuture).isCompletedExceptionally();
+		// Should complete exceptionally.
+		// The supplier throws on the scheduler's pool thread, so completion happens
+		// asynchronously. Block until the future settles (up to 5s) instead of checking
+		// isCompletedExceptionally() synchronously: that check was racy and failed
+		// intermittently on CPU-contended CI runners where the pool thread had not yet
+		// run the throwing supplier at the instant the assertion was evaluated.
+		assertThatThrownBy(() -> failingFuture.get(5, TimeUnit.SECONDS))
+				.isInstanceOf(ExecutionException.class)
+				.hasCauseInstanceOf(RuntimeException.class);
 
-		// Wait a bit for scheduler to settle
+		// Wait a bit for scheduler to settle (let the pool thread finish run() and
+		// complete executorFuture, so the next schedule() re-submits run() for the queue)
 		Thread.sleep(500);
 
 		// Second request should still succeed


### PR DESCRIPTION
Test-only de-flake port (cherry-pick of https://github.com/metasfresh/metasfresh/pull/25306, commit https://github.com/metasfresh/metasfresh/commit/7533555e254729dcb114d2a18f64d7268d56309c).

## Problem

`de.metas.util.web.audit.HttpCallSchedulerTest.exceptionInRequestDoesNotBreakScheduler` asserts `isCompletedExceptionally()` synchronously right after `schedule()`, but the throwing supplier runs asynchronously on the scheduler's pool thread. On loaded CI runners the check evaluates before the pool thread has completed the future → `test (java)` red at `HttpCallSchedulerTest.java:117`. Since the JDK-8 base-image bump this red is consistent on this branch (3/3 re-runs), as it was on the other old lines.

## Fix

Wait for the failure deterministically and assert its cause:

```java
assertThatThrownBy(() -> failingFuture.get(5, TimeUnit.SECONDS))
    .isInstanceOf(ExecutionException.class)
    .hasCauseInstanceOf(RuntimeException.class);
```

Same change as already on `deep_tundra_release`, `soft_panda_hotfix`, `intensive_care_hotfix`, `middle_ages_release` and `new_dawn_uat`. The resulting test file is byte-identical to the one on `soft_panda_hotfix`. No production code touched.

## Verification

CI `test (java)` on this PR (locally verified on `middle_ages_release`: `HttpCallSchedulerTest` 4/4 green after the change).
