### PR TITLE
mobile E2E: port the GetQuantityDialog detach-race guard to task_force_hotfix

### DIFF
--- a/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
@@ -146,8 +146,16 @@ export const GetQuantityDialog = {
 //
 
 const expectMissingOrDisabled = async (locator) => {
+    // Element should either not exist (dialog already closed) or be disabled (dialog closing).
+    // Race condition: count() > 0 may be true, but by the time toBeDisabled() runs the dialog
+    // may have unmounted. In that case, re-check count — if 0, element is gone (OK).
     if (await locator.count() > 0) {
-        await expect(locator).toBeDisabled();
+        try {
+            await expect(locator).toBeDisabled();
+        } catch (e) {
+            if (await locator.count() === 0) return;
+            throw e;
+        }
     }
 };
 


### PR DESCRIPTION
Test-harness only, no production code.

`task_force_hotfix` still carries the original unguarded `expectMissingOrDisabled` helper in `e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js`: when the quantity dialog unmounts between `count()` and `toBeDisabled()`, the assertion fails with `element(s) not found` (`cancel-button` / `done-button`). On https://github.com/metasfresh/metasfresh/pull/25830 the `mobile test` job hit this seam on three consecutive attempts, two specs each (`distribution/job_dropAllButton`, `distribution/scan_HU_barcodes`, `distribution/navigateToJobsListAfterPickFromComplete`, `picking/productBasedPicking/standard`).

This ports the guarded helper byte-identically from `new_dawn_uat` (try/catch, re-check `count()` after a failed `toBeDisabled()`), the same port already merged for other hotfix lines in https://github.com/metasfresh/metasfresh/pull/25305 and https://github.com/metasfresh/metasfresh/pull/25495.
