### PR TITLE
merge/swift_eagle_hotfix-to-swift_eagle_release

### DIFF
--- a/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
+++ b/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
@@ -7,9 +7,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class HttpCallSchedulerTest
 {
@@ -113,10 +115,18 @@ class HttpCallSchedulerTest
 			throw new RuntimeException("test error");
 		}));
 
-		// Should complete exceptionally
-		assertThat(failingFuture).isCompletedExceptionally();
+		// Should complete exceptionally.
+		// The supplier throws on the scheduler's pool thread, so completion happens
+		// asynchronously. Block until the future settles (up to 5s) instead of checking
+		// isCompletedExceptionally() synchronously: that check was racy and failed
+		// intermittently on CPU-contended CI runners where the pool thread had not yet
+		// run the throwing supplier at the instant the assertion was evaluated.
+		assertThatThrownBy(() -> failingFuture.get(5, TimeUnit.SECONDS))
+				.isInstanceOf(ExecutionException.class)
+				.hasCauseInstanceOf(RuntimeException.class);
 
-		// Wait a bit for scheduler to settle
+		// Wait a bit for scheduler to settle (let the pool thread finish run() and
+		// complete executorFuture, so the next schedule() re-submits run() for the queue)
 		Thread.sleep(500);
 
 		// Second request should still succeed


### PR DESCRIPTION
Merge-through of `swift_eagle_hotfix` into `swift_eagle_release`.

Carries the test-only `HttpCallSchedulerTest` de-flake already merged on `swift_eagle_hotfix` (cherry-pick of https://github.com/metasfresh/metasfresh/pull/25306: the racy synchronous `isCompletedExceptionally()` assertion replaced by an awaited completion; the same fix that made `test (java)` green on the `_hotfix` line) — plus everything else pending on `swift_eagle_hotfix`.

Created manually (same branch naming as the auto-port workflow) because auto-port only fires on a green `cicd` run of the source branch.
