### PR TITLE
Manufacturing cost monitor: closeable-selection guard, post-action refresh, zoom to the manufacturing order, and view-selection rebuild

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/I_PP_Order.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/I_PP_Order.java
@@ -1099,6 +1099,36 @@ public interface I_PP_Order
 	String COLUMNNAME_Line = "Line";
 
 	/**
+	 * Set Manufacturing Order.
+	 * Opens the manufacturing order in the Manufacturing Order window.
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true
+	 * @deprecated Please don't use it because this is a virtual column
+	 */
+	@Deprecated
+	void setLink_PP_Order_ID (int Link_PP_Order_ID);
+
+	/**
+	 * Get Manufacturing Order.
+	 * Opens the manufacturing order in the Manufacturing Order window.
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true
+	 */
+	int getLink_PP_Order_ID();
+
+	@Nullable org.eevolution.model.I_PP_Order getLink_PP_Order();
+
+	@Deprecated
+	void setLink_PP_Order(@Nullable org.eevolution.model.I_PP_Order Link_PP_Order);
+
+	ModelColumn<I_PP_Order, org.eevolution.model.I_PP_Order> COLUMN_Link_PP_Order_ID = new ModelColumn<>(I_PP_Order.class, "Link_PP_Order_ID", org.eevolution.model.I_PP_Order.class);
+	String COLUMNNAME_Link_PP_Order_ID = "Link_PP_Order_ID";
+
+	/**
 	 * Set Lot No..
 	 *
 	 * <br>Type: String

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/X_PP_Order.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/X_PP_Order.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 public class X_PP_Order extends org.compiere.model.PO implements I_PP_Order, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 2126020309L;
+	private static final long serialVersionUID = 1476785033L;
 
     /** Standard Constructor */
     public X_PP_Order (final Properties ctx, final int PP_Order_ID, @Nullable final String trxName)
@@ -820,6 +820,29 @@ public class X_PP_Order extends org.compiere.model.PO implements I_PP_Order, org
 	public int getLine() 
 	{
 		return get_ValueAsInt(COLUMNNAME_Line);
+	}
+
+	@Override
+	public org.eevolution.model.I_PP_Order getLink_PP_Order()
+	{
+		return get_ValueAsPO(COLUMNNAME_Link_PP_Order_ID, org.eevolution.model.I_PP_Order.class);
+	}
+
+	@Override
+	public void setLink_PP_Order(final org.eevolution.model.I_PP_Order Link_PP_Order)
+	{
+		set_ValueFromPO(COLUMNNAME_Link_PP_Order_ID, org.eevolution.model.I_PP_Order.class, Link_PP_Order);
+	}
+
+	@Override
+	public void setLink_PP_Order_ID (final int Link_PP_Order_ID)
+	{
+		throw new IllegalArgumentException ("Link_PP_Order_ID is virtual column");	}
+
+	@Override
+	public int getLink_PP_Order_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_Link_PP_Order_ID);
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
@@ -166,6 +166,9 @@ public class ProcessExecutionResult
 	 * Tells that the view's row selection has to be rebuilt, not merely re-read (the process changed
 	 * whether its records still belong to the view). Throws unless the view materializes a selection,
 	 * i.e. set it only on a process that runs on an AD-window view.
+	 * <p>
+	 * The Swing client reads only {@link #refreshAllAfterExecution}, and its fallback re-reads the row
+	 * without re-running the tab query — so a process reachable from Swing too must set both.
 	 */
 	@Setter @Getter private boolean recreateViewSelectionAfterExecution = false;
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
@@ -160,17 +160,27 @@ public class ProcessExecutionResult
 	/**
 	 * Tells if the whole window tab shall be refreshed after process execution (applies only when the process was started from a user window)
 	 */
-	@Setter @Getter private boolean refreshAllAfterExecution = false;
+	@Setter private boolean refreshAllAfterExecution = false;
 
 	/**
 	 * Tells that the view's row selection has to be rebuilt, not merely re-read (the process changed
-	 * whether its records still belong to the view). Throws unless the view materializes a selection,
-	 * i.e. set it only on a process that runs on an AD-window view.
+	 * whether its records still belong to the view). The stronger form of {@link #refreshAllAfterExecution}:
+	 * a process asks for this one alone, and {@link #isRefreshAllAfterExecution()} answers true as well,
+	 * so a client that knows only the coarser flag (the Swing one) still refreshes.
 	 * <p>
-	 * The Swing client reads only {@link #refreshAllAfterExecution}, and its fallback re-reads the row
-	 * without re-running the tab query — so a process reachable from Swing too must set both.
+	 * Only a view that materializes a selection implements the rebuild, so set this only on a process that
+	 * runs on an AD-window view; elsewhere it throws after the process has already committed.
 	 */
 	@Setter @Getter private boolean recreateViewSelectionAfterExecution = false;
+
+	/**
+	 * True when anything at all has to be refreshed — including the stronger
+	 * {@link #recreateViewSelectionAfterExecution}, which subsumes it.
+	 */
+	public boolean isRefreshAllAfterExecution()
+	{
+		return refreshAllAfterExecution || recreateViewSelectionAfterExecution;
+	}
 
 	@Setter @Getter @JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private TableRecordReference recordToRefreshAfterExecution = null;

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
@@ -162,6 +162,14 @@ public class ProcessExecutionResult
 	 */
 	@Setter @Getter private boolean refreshAllAfterExecution = false;
 
+	/**
+	 * Tells that the view's row selection has to be built again, not merely re-read, because the process
+	 * changed whether its records still belong to the view at all. Off unless a process asks for it.
+	 * Only a view that materializes a selection implements this; on any other one it throws after the
+	 * process has already committed, so set it only on a process that runs on an AD-window view.
+	 */
+	@Setter @Getter private boolean recreateViewSelectionAfterExecution = false;
+
 	@Setter @Getter @JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private TableRecordReference recordToRefreshAfterExecution = null;
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
@@ -163,10 +163,9 @@ public class ProcessExecutionResult
 	@Setter @Getter private boolean refreshAllAfterExecution = false;
 
 	/**
-	 * Tells that the view's row selection has to be built again, not merely re-read, because the process
-	 * changed whether its records still belong to the view at all. Off unless a process asks for it.
-	 * Only a view that materializes a selection implements this; on any other one it throws after the
-	 * process has already committed, so set it only on a process that runs on an AD-window view.
+	 * Tells that the view's row selection has to be rebuilt, not merely re-read (the process changed
+	 * whether its records still belong to the view). Throws unless the view materializes a selection,
+	 * i.e. set it only on a process that runs on an AD-window view.
 	 */
 	@Setter @Getter private boolean recreateViewSelectionAfterExecution = false;
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
@@ -826,6 +826,7 @@ public class ProcessExecutionResult
 		reportData = otherResult.reportData;
 
 		refreshAllAfterExecution = otherResult.refreshAllAfterExecution;
+		recreateViewSelectionAfterExecution = otherResult.recreateViewSelectionAfterExecution;
 
 		recordToSelectAfterExecution = otherResult.recordToSelectAfterExecution;
 		recordsToOpen = otherResult.recordsToOpen;

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/process/ProcessExecutionResultTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/process/ProcessExecutionResultTest.java
@@ -75,6 +75,7 @@ public class ProcessExecutionResultTest
 	{
 		final ProcessExecutionResult result = ProcessExecutionResult.newInstanceForADPInstanceId(PInstanceId.ofRepoId(12345));
 		result.setRecordToSelectAfterExecution(createDummyTableRecordReference());
+		result.setRecreateViewSelectionAfterExecution(true);
 		result.markAsError("error summary1");
 		result.setReportData(new ByteArrayResource(new byte[] { 1, 2, 3 }), "report.pdf", "application/pdf");
 		//
@@ -129,6 +130,7 @@ public class ProcessExecutionResultTest
 		Assertions.assertEquals(result.isErrorWasReportedToUser(), resultFromJson.isErrorWasReportedToUser());
 		Assertions.assertEquals(result.isShowProcessLogs(), resultFromJson.isShowProcessLogs());
 		Assertions.assertEquals(result.isRefreshAllAfterExecution(), resultFromJson.isRefreshAllAfterExecution());
+		Assertions.assertEquals(result.isRecreateViewSelectionAfterExecution(), resultFromJson.isRecreateViewSelectionAfterExecution());
 		//
 		Assertions.assertEquals(result.getReportData(), resultFromJson.getReportData());
 		Assertions.assertEquals(result.getReportFilename(), resultFromJson.getReportFilename());

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/process/ProcessExecutionResultTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/process/ProcessExecutionResultTest.java
@@ -15,6 +15,8 @@ import org.compiere.util.Env;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.springframework.core.io.ByteArrayResource;
 
 import java.io.IOException;
@@ -147,6 +149,18 @@ public class ProcessExecutionResultTest
 		// Assert.assertEquals(result.get, resultFromJson.get);
 
 		assertEqualsAsJson(result, resultFromJson);
+	}
+
+	/** Rebuilding the selection is the stronger request, so it must also answer the plain refresh-all question. */
+	@Test
+	public void recreatingTheSelectionImpliesRefreshAll()
+	{
+		final ProcessExecutionResult result = ProcessExecutionResult.newInstanceForADPInstanceId(PInstanceId.ofRepoId(1));
+		assertThat(result.isRefreshAllAfterExecution()).isFalse();
+
+		result.setRecreateViewSelectionAfterExecution(true);
+
+		assertThat(result.isRefreshAllAfterExecution()).isTrue();
 	}
 
 	@Test

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823260_sys_gh30811_AD_Message_PP_Order_CloseSelection_NoCompletedOrder.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823260_sys_gh30811_AD_Message_PP_Order_CloseSelection_NoCompletedOrder.sql
@@ -1,32 +1,26 @@
--- Reason shown instead of the "close selection" action when the selection holds nothing closeable.
--- Without it the action stays offered on, say, a selection of already-closed orders and fails at
--- execution time with a bare "@NoSelection@", which reads as a malfunction rather than a refusal.
---
--- MsgType 'E' WITH an ErrorCode, matching AD_Message 545829 of the same delivery.
+-- Reason shown instead of the "close selection" action when nothing in the selection is closeable;
+-- without it the action fails at execution with a bare "@NoSelection@", i.e. reads as a malfunction.
+-- MsgType 'E' with an ErrorCode, same shape as AD_Message 545829.
 
--- 1. the message (base text = German)
 INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
 VALUES (0,545832/*From ID Server*/,0,TO_TIMESTAMP('2026-09-09 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',
         'Keiner der ausgewählten Fertigungsaufträge ist fertiggestellt. Geschlossen werden können nur fertiggestellte Aufträge.',
         'E',TO_TIMESTAMP('2026-09-09 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,'org.eevolution.process.PP_Order_CloseSelection.NoCompletedOrderInSelection');
 
--- 2. the short ErrorCode (the full key lives in Value)
 UPDATE AD_Message SET ErrorCode='PPOrderNoCompletedOrderInSelection',
        Updated=TO_TIMESTAMP('2026-09-09 09:00:00.500000','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100
 WHERE AD_Message_ID=545832;
 
--- 3. seed AD_Message_Trl for ALL active system languages with the base (DE) text, IsTranslated='N'
 INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
 SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
 FROM AD_Language l, AD_Message t
 WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545832
   AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID);
 
--- 4. en_US override (the real English text) + IsTranslated='Y'
 UPDATE AD_Message_Trl SET MsgText='None of the selected manufacturing orders is completed. Only completed orders can be closed.',
        IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-09 09:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
 WHERE AD_Language='en_US' AND AD_Message_ID=545832;
 
--- 5. flip de_DE + de_CH to IsTranslated='Y' (their text already equals the DE base)
+-- de_DE + de_CH already carry the base text, so only the flag flips
 UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-09 09:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545832;
 UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-09 09:00:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545832;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823260_sys_gh30811_AD_Message_PP_Order_CloseSelection_NoCompletedOrder.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823260_sys_gh30811_AD_Message_PP_Order_CloseSelection_NoCompletedOrder.sql
@@ -1,0 +1,32 @@
+-- Reason shown instead of the "close selection" action when the selection holds nothing closeable.
+-- Without it the action stays offered on, say, a selection of already-closed orders and fails at
+-- execution time with a bare "@NoSelection@", which reads as a malfunction rather than a refusal.
+--
+-- MsgType 'E' WITH an ErrorCode, matching AD_Message 545829 of the same delivery.
+
+-- 1. the message (base text = German)
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545832/*From ID Server*/,0,TO_TIMESTAMP('2026-09-09 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',
+        'Keiner der ausgewählten Fertigungsaufträge ist fertiggestellt. Geschlossen werden können nur fertiggestellte Aufträge.',
+        'E',TO_TIMESTAMP('2026-09-09 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,'org.eevolution.process.PP_Order_CloseSelection.NoCompletedOrderInSelection');
+
+-- 2. the short ErrorCode (the full key lives in Value)
+UPDATE AD_Message SET ErrorCode='PPOrderNoCompletedOrderInSelection',
+       Updated=TO_TIMESTAMP('2026-09-09 09:00:00.500000','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100
+WHERE AD_Message_ID=545832;
+
+-- 3. seed AD_Message_Trl for ALL active system languages with the base (DE) text, IsTranslated='N'
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545832
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID);
+
+-- 4. en_US override (the real English text) + IsTranslated='Y'
+UPDATE AD_Message_Trl SET MsgText='None of the selected manufacturing orders is completed. Only completed orders can be closed.',
+       IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-09 09:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545832;
+
+-- 5. flip de_DE + de_CH to IsTranslated='Y' (their text already equals the DE base)
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-09 09:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545832;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-09 09:00:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545832;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823270_sys_gh30811_PP_Order_CostMonitor_processes_RefreshAllAfterExecution.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823270_sys_gh30811_PP_Order_CostMonitor_processes_RefreshAllAfterExecution.sql
@@ -1,0 +1,14 @@
+-- Both cost-monitor actions end with their order closed, so both change the view they were run from,
+-- yet neither told the WebUI so: after execution the view was left as it was.
+--
+-- RefreshAllAfterExecution is the declarative form of that request - ProcessInfo copies the column into
+-- the execution result and ADProcessPostProcessService invalidates the view (or, when the action ran
+-- from a single document rather than a view, that document). No process code is involved, which is why
+-- the flag is set here rather than in Java.
+--
+-- It re-reads the rows of the view's EXISTING selection; it does not re-create that selection, so a
+-- closed order keeps its row in a DocStatus='CO'-scoped view until the view itself is rebuilt.
+
+UPDATE AD_Process SET RefreshAllAfterExecution='Y',
+       Updated=TO_TIMESTAMP('2026-09-09 09:10:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE AD_Process_ID IN (585649 /*PP_Order_PostCalculation*/, 585671 /*PP_Order_CloseSelection*/);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823270_sys_gh30811_PP_Order_CostMonitor_processes_RefreshAllAfterExecution.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823270_sys_gh30811_PP_Order_CostMonitor_processes_RefreshAllAfterExecution.sql
@@ -1,13 +1,7 @@
--- Both cost-monitor actions end with their order closed, so both change the view they were run from,
--- yet neither told the WebUI so: after execution the view was left as it was.
---
--- RefreshAllAfterExecution is the declarative form of that request - ProcessInfo copies the column into
--- the execution result and ADProcessPostProcessService invalidates the view (or, when the action ran
--- from a single document rather than a view, that document). No process code is involved, which is why
--- the flag is set here rather than in Java.
---
--- It re-reads the rows of the view's EXISTING selection; it does not re-create that selection, so a
--- closed order keeps its row in a DocStatus='CO'-scoped view until the view itself is rebuilt.
+-- Both cost-monitor actions change the view they run from. RefreshAllAfterExecution is the declarative
+-- way to say so (ProcessInfo -> execution result -> ADProcessPostProcessService), hence SQL, not Java.
+-- It re-reads the EXISTING selection, it does NOT rebuild it: a closed order keeps its row in a
+-- DocStatus='CO'-scoped view until the selection itself is recreated.
 
 UPDATE AD_Process SET RefreshAllAfterExecution='Y',
        Updated=TO_TIMESTAMP('2026-09-09 09:10:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823270_sys_gh30811_PP_Order_CostMonitor_processes_RefreshAllAfterExecution.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823270_sys_gh30811_PP_Order_CostMonitor_processes_RefreshAllAfterExecution.sql
@@ -1,8 +1,0 @@
--- Both cost-monitor actions change the view they run from. RefreshAllAfterExecution is the declarative
--- way to say so (ProcessInfo -> execution result -> ADProcessPostProcessService), hence SQL, not Java.
--- It re-reads the EXISTING selection, it does NOT rebuild it: a closed order keeps its row in a
--- DocStatus='CO'-scoped view until the selection itself is recreated.
-
-UPDATE AD_Process SET RefreshAllAfterExecution='Y',
-       Updated=TO_TIMESTAMP('2026-09-09 09:10:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
-WHERE AD_Process_ID IN (585649 /*PP_Order_PostCalculation*/, 585671 /*PP_Order_CloseSelection*/);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823280_sys_gh30811_PP_Order_Link_CostMonitor_ZoomToProductionOrder.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823280_sys_gh30811_PP_Order_Link_CostMonitor_ZoomToProductionOrder.sql
@@ -1,26 +1,16 @@
--- Navigation from "Kostenüberwachung Fertigung" (AD_Window 542175 / AD_Tab 549352) to the full
--- manufacturing order in "Produktionsauftrag" (AD_Window 53009).
+-- Navigation from "Kostenüberwachung Fertigung" (AD_Window 542175 / AD_Tab 549352) to the manufacturing
+-- order in "Produktionsauftrag" (AD_Window 53009). Both windows sit on PP_Order, so a row click only
+-- re-opens the monitor; only a lookup carries a zoom, hence a virtual FK column holding the order's id.
 --
--- Both windows sit on PP_Order, so clicking a monitor row only re-opens it in the monitor's own
--- read-only window. A lookup field is what carries a zoom, so this adds a virtual FK column whose
--- value is the order's own id, rendered as the document number and zooming to window 53009.
+-- The zoom target is AD_Ref_Table.AD_Window_ID, reachable only via AD_Reference_Value_ID
+-- (MLookupFactory.getLookup_Table) - hence a dedicated AD_Reference, modelled on 541143.
 --
--- Why a DEDICATED AD_Reference (Table) instead of plain Search-by-column-name: the zoom target of a
--- lookup comes from AD_Ref_Table.AD_Window_ID when the column carries an AD_Reference_Value_ID
--- (MLookupFactory.getLookup_Table -> ADRefTable.zoomAD_Window_ID_Override -> MLookupFactory ~L644,
--- which then wins over every other rule; DocumentZoomIntoService.getWindowId returns it before any
--- fallback runs). Naming 53009 there makes the target explicit data rather than a derived default.
--- The window the user is currently in is never an input to that resolution, so this cannot bounce
--- back into 542175. Same shape as S_Issue.Internal_Effort_S_Issue_ID / AD_Reference 541143, and the
--- same use of AD_Ref_Table.AD_Window_ID as 5751640_sys_gh20561_PLV_Zoom_Product_Window.sql.
+-- TRAP: AD_Column attributes are shared by every window on PP_Order. Column 593529 therefore gets
+-- exactly ONE AD_Field in the dictionary (tab 549352), IsSelectionColumn='N', IsFilterField='N' - tab
+-- 549352's Explicit filter set and window 53009 stay untouched.
 --
--- Nothing may leak into window 53009 (or any other PP_Order window): AD_Column attributes are shared
--- by every window showing PP_Order, so column 593529 gets exactly ONE AD_Field in the whole
--- dictionary - on tab 549352. IsSelectionColumn stays 'N' and the field is IsFilterField='N', so the
--- Explicit (IncludeFiltersStrategy='E') filter set of tab 549352 is left exactly as it was.
---
--- Qualifying the host table as PP_Order.PP_Order_ID follows the sibling virtual columns on this table
--- (CostDifference, HasCostDifference, C_Order_ID), which render in this very window today.
+-- ColumnSQL qualifies its own table like the sibling virtual columns here; SqlEntityBinding rewrites
+-- it to the alias.
 
 -- 1) AD_Element -- German in the base column, en_US as the translation override.
 INSERT INTO AD_Element (AD_Client_ID,IsActive,CreatedBy,PrintName,EntityType,ColumnName,AD_Element_ID,AD_Org_ID,Name,Description,UpdatedBy,Created,Updated)
@@ -53,11 +43,8 @@ UPDATE AD_Element_Trl SET Name='Manufacturing Order', PrintName='Manufacturing O
 WHERE AD_Element_ID=585442 AND AD_Language='en_US'
 ;
 
--- 2) The dedicated Table reference. AD_Ref_Table.AD_Window_ID=53009 is the whole point of it.
---    Its Name is a technical identifier, not a caption: it shows only in the System-Administrator
---    "Reference" window, never in the end-user UI, so the seeded AD_Reference_Trl rows are left
---    untranslated on purpose - same as the reference this is modelled on (541143 S_Effort_Issue_ID).
---    The user-visible wording lives on AD_Element 585442 above.
+-- 2) The dedicated Table reference; AD_Ref_Table.AD_Window_ID=53009 is its whole point. Name is a
+--    technical identifier (System-Administrator only), so its Trl rows stay untranslated on purpose.
 INSERT INTO AD_Reference (AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,CreatedBy,UpdatedBy,Name,Description,ValidationType,EntityType,IsOrderByValue,Created,Updated)
 VALUES (542138 /*From ID Server*/,0,0,'Y',100,100,
         'Link_PP_Order_ID',
@@ -74,8 +61,7 @@ WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Reference_ID=542138
 AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
 ;
 
--- AD_Key = PP_Order.PP_Order_ID (53659), AD_Display = PP_Order.DocumentNo (53621): the lookup shows
--- the document number, which is what a human recognises the order by.
+-- AD_Key = PP_Order_ID (53659), AD_Display = DocumentNo (53621): the lookup shows the document number.
 INSERT INTO AD_Ref_Table (AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,CreatedBy,UpdatedBy,AD_Table_ID,AD_Key,AD_Display,IsValueDisplayed,ShowInactiveValues,AD_Window_ID,EntityType,Created,Updated)
 VALUES (542138,0,0,'Y',100,100,
         53027,53659,53621,'N','N',
@@ -85,14 +71,10 @@ VALUES (542138,0,0,'Y',100,100,
         TO_TIMESTAMP('2026-09-09 11:01:10','YYYY-MM-DD HH24:MI:SS'))
 ;
 
--- 3) The virtual column. AD_Reference_ID 30 (Search) + AD_Reference_Value_ID 542138 is the branch in
---    MLookupFactory.getLookupInfo (~L299) that routes through AD_Ref_Table, i.e. the branch that
---    picks up AD_Window_ID=53009. Search rather than Table because PP_Order is high-volume.
---    IsSelectionColumn='N' and no filter attributes: those live on AD_Column and would otherwise
---    reach every window showing PP_Order.
---    IsExcludeFromZoomTargets='Y' (the column default): this must not be offered as a
---    Related-Documents target - it is a self-reference, and being virtual it has no physical FK for
---    ad_table_related_windows_v to walk anyway.
+-- 3) The virtual column. AD_Reference_ID 30 (Search) + AD_Reference_Value_ID 542138 is the
+--    MLookupFactory.getLookupInfo branch that routes through AD_Ref_Table; Search not Table because
+--    PP_Order is high-volume. IsExcludeFromZoomTargets='Y': a self-reference must not be offered as a
+--    Related-Documents target, and being virtual it has no FK for ad_table_related_windows_v to walk.
 INSERT INTO AD_Column (AD_Reference_ID,AD_Reference_Value_ID,IsKey,IsParent,IsTranslated,IsIdentifier,AD_Client_ID,IsActive,CreatedBy,
                         AD_Element_ID,IsUpdateable,IsSelectionColumn,IsSyncDatabase,IsAlwaysUpdateable,IsAllowLogging,
                         IsEncrypted,IsExcludeFromZoomTargets,AD_Table_ID,ColumnSQL,ColumnName,AD_Column_ID,IsMandatory,AD_Org_ID,UpdatedBy,
@@ -116,15 +98,11 @@ WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593529
 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
 ;
 
--- No AD_SQLColumn_SourceTableColumn: the expression reads only the record's own primary key, so
--- there is no other table whose change could stale the value.
+-- No AD_SQLColumn_SourceTableColumn: the expression reads only the record's own primary key.
 
--- 4) The field - on tab 549352 and nowhere else.
---    SeqNo/SeqNoGrid 15 puts it directly after DocumentNo (10) and before C_DocType_ID (20); 15 is
---    free on both the AD_Field and the AD_UI_Element grid layer.
---    IsReadOnly='Y': the monitor is read-only and the value is computed.
---    IsFilterField='N': tab 549352 runs IncludeFiltersStrategy='E', so its filter set is exactly the
---    fields flagged 'Y' - this one must not join it.
+-- 4) The field - on tab 549352 and nowhere else. SeqNo 15 sits between DocumentNo (10) and
+--    C_DocType_ID (20) and is free on both layers. IsReadOnly='Y' (monitor is read-only, value is
+--    computed); IsFilterField='N' because tab 549352 runs IncludeFiltersStrategy='E'.
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,IsFilterField,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,593529,784962 /*From ID Server*/,0,549352,
         TO_TIMESTAMP('2026-09-09 11:03:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','Y','N','N',

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823280_sys_gh30811_PP_Order_Link_CostMonitor_ZoomToProductionOrder.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823280_sys_gh30811_PP_Order_Link_CostMonitor_ZoomToProductionOrder.sql
@@ -1,0 +1,154 @@
+-- Navigation from "Kostenüberwachung Fertigung" (AD_Window 542175 / AD_Tab 549352) to the full
+-- manufacturing order in "Produktionsauftrag" (AD_Window 53009).
+--
+-- Both windows sit on PP_Order, so clicking a monitor row only re-opens it in the monitor's own
+-- read-only window. A lookup field is what carries a zoom, so this adds a virtual FK column whose
+-- value is the order's own id, rendered as the document number and zooming to window 53009.
+--
+-- Why a DEDICATED AD_Reference (Table) instead of plain Search-by-column-name: the zoom target of a
+-- lookup comes from AD_Ref_Table.AD_Window_ID when the column carries an AD_Reference_Value_ID
+-- (MLookupFactory.getLookup_Table -> ADRefTable.zoomAD_Window_ID_Override -> MLookupFactory ~L644,
+-- which then wins over every other rule; DocumentZoomIntoService.getWindowId returns it before any
+-- fallback runs). Naming 53009 there makes the target explicit data rather than a derived default.
+-- The window the user is currently in is never an input to that resolution, so this cannot bounce
+-- back into 542175. Same shape as S_Issue.Internal_Effort_S_Issue_ID / AD_Reference 541143, and the
+-- same use of AD_Ref_Table.AD_Window_ID as 5751640_sys_gh20561_PLV_Zoom_Product_Window.sql.
+--
+-- Nothing may leak into window 53009 (or any other PP_Order window): AD_Column attributes are shared
+-- by every window showing PP_Order, so column 593529 gets exactly ONE AD_Field in the whole
+-- dictionary - on tab 549352. IsSelectionColumn stays 'N' and the field is IsFilterField='N', so the
+-- Explicit (IncludeFiltersStrategy='E') filter set of tab 549352 is left exactly as it was.
+--
+-- Qualifying the host table as PP_Order.PP_Order_ID follows the sibling virtual columns on this table
+-- (CostDifference, HasCostDifference, C_Order_ID), which render in this very window today.
+
+-- 1) AD_Element -- German in the base column, en_US as the translation override.
+INSERT INTO AD_Element (AD_Client_ID,IsActive,CreatedBy,PrintName,EntityType,ColumnName,AD_Element_ID,AD_Org_ID,Name,Description,UpdatedBy,Created,Updated)
+VALUES (0,'Y',100,'Produktionsauftrag','D','Link_PP_Order_ID',585442 /*From ID Server*/,0,
+        'Produktionsauftrag',
+        'Öffnet den Fertigungsauftrag im Fenster Produktionsauftrag.',
+        100,
+        TO_TIMESTAMP('2026-09-09 11:00:00','YYYY-MM-DD HH24:MI:SS'),
+        TO_TIMESTAMP('2026-09-09 11:00:00','YYYY-MM-DD HH24:MI:SS'))
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, PO_Name,PO_PrintName,PrintName,PO_Description,PO_Help,Help,Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Element_ID, t.PO_Name,t.PO_PrintName,t.PrintName,t.PO_Description,t.PO_Help,t.Help,t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Element_ID=585442
+AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl SET Name='Produktionsauftrag', PrintName='Produktionsauftrag',
+       Description='Öffnet den Fertigungsauftrag im Fenster Produktionsauftrag.',
+       IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-09-09 11:00:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585442 AND AD_Language IN ('de_DE','de_CH')
+;
+
+UPDATE AD_Element_Trl SET Name='Manufacturing Order', PrintName='Manufacturing Order',
+       Description='Opens the manufacturing order in the Manufacturing Order window.',
+       IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-09-09 11:00:18','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585442 AND AD_Language='en_US'
+;
+
+-- 2) The dedicated Table reference. AD_Ref_Table.AD_Window_ID=53009 is the whole point of it.
+--    Its Name is a technical identifier, not a caption: it shows only in the System-Administrator
+--    "Reference" window, never in the end-user UI, so the seeded AD_Reference_Trl rows are left
+--    untranslated on purpose - same as the reference this is modelled on (541143 S_Effort_Issue_ID).
+--    The user-visible wording lives on AD_Element 585442 above.
+INSERT INTO AD_Reference (AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,CreatedBy,UpdatedBy,Name,Description,ValidationType,EntityType,IsOrderByValue,Created,Updated)
+VALUES (542138 /*From ID Server*/,0,0,'Y',100,100,
+        'Link_PP_Order_ID',
+        'PP_Order, gezoomt auf das Fenster Produktionsauftrag (53009).',
+        'T','D','N',
+        TO_TIMESTAMP('2026-09-09 11:01:00','YYYY-MM-DD HH24:MI:SS'),
+        TO_TIMESTAMP('2026-09-09 11:01:00','YYYY-MM-DD HH24:MI:SS'))
+;
+
+INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Name,Description, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Reference_ID, t.Name,t.Description, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Reference t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Reference_ID=542138
+AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
+;
+
+-- AD_Key = PP_Order.PP_Order_ID (53659), AD_Display = PP_Order.DocumentNo (53621): the lookup shows
+-- the document number, which is what a human recognises the order by.
+INSERT INTO AD_Ref_Table (AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,CreatedBy,UpdatedBy,AD_Table_ID,AD_Key,AD_Display,IsValueDisplayed,ShowInactiveValues,AD_Window_ID,EntityType,Created,Updated)
+VALUES (542138,0,0,'Y',100,100,
+        53027,53659,53621,'N','N',
+        53009,
+        'D',
+        TO_TIMESTAMP('2026-09-09 11:01:10','YYYY-MM-DD HH24:MI:SS'),
+        TO_TIMESTAMP('2026-09-09 11:01:10','YYYY-MM-DD HH24:MI:SS'))
+;
+
+-- 3) The virtual column. AD_Reference_ID 30 (Search) + AD_Reference_Value_ID 542138 is the branch in
+--    MLookupFactory.getLookupInfo (~L299) that routes through AD_Ref_Table, i.e. the branch that
+--    picks up AD_Window_ID=53009. Search rather than Table because PP_Order is high-volume.
+--    IsSelectionColumn='N' and no filter attributes: those live on AD_Column and would otherwise
+--    reach every window showing PP_Order.
+--    IsExcludeFromZoomTargets='Y' (the column default): this must not be offered as a
+--    Related-Documents target - it is a self-reference, and being virtual it has no physical FK for
+--    ad_table_related_windows_v to walk anyway.
+INSERT INTO AD_Column (AD_Reference_ID,AD_Reference_Value_ID,IsKey,IsParent,IsTranslated,IsIdentifier,AD_Client_ID,IsActive,CreatedBy,
+                        AD_Element_ID,IsUpdateable,IsSelectionColumn,IsSyncDatabase,IsAlwaysUpdateable,IsAllowLogging,
+                        IsEncrypted,IsExcludeFromZoomTargets,AD_Table_ID,ColumnSQL,ColumnName,AD_Column_ID,IsMandatory,AD_Org_ID,UpdatedBy,
+                        Name,Description,EntityType,FieldLength,Version,SeqNo,PersonalDataCategory,IsCalculated,Created,Updated)
+VALUES (30,542138,'N','N','N','N',0,'Y',100,
+        585442 /*From ID Server*/,'N','N','N','N','Y',
+        'N','Y',53027,
+        '(PP_Order.PP_Order_ID)',
+        'Link_PP_Order_ID',593529 /*From ID Server*/,'N',0,100,
+        'Produktionsauftrag',
+        'Öffnet den Fertigungsauftrag im Fenster Produktionsauftrag.',
+        'D',10,0,0,'NP','Y',
+        TO_TIMESTAMP('2026-09-09 11:02:00','YYYY-MM-DD HH24:MI:SS'),
+        TO_TIMESTAMP('2026-09-09 11:02:00','YYYY-MM-DD HH24:MI:SS'))
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593529
+AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- No AD_SQLColumn_SourceTableColumn: the expression reads only the record's own primary key, so
+-- there is no other table whose change could stale the value.
+
+-- 4) The field - on tab 549352 and nowhere else.
+--    SeqNo/SeqNoGrid 15 puts it directly after DocumentNo (10) and before C_DocType_ID (20); 15 is
+--    free on both the AD_Field and the AD_UI_Element grid layer.
+--    IsReadOnly='Y': the monitor is read-only and the value is computed.
+--    IsFilterField='N': tab 549352 runs IncludeFiltersStrategy='E', so its filter set is exactly the
+--    fields flagged 'Y' - this one must not join it.
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,IsFilterField,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,593529,784962 /*From ID Server*/,0,549352,
+        TO_TIMESTAMP('2026-09-09 11:03:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','Y','N','N',
+        'Produktionsauftrag',15,15,
+        TO_TIMESTAMP('2026-09-09 11:03:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=784962
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+SELECT update_FieldTranslation_From_AD_Name_Element(585442);
+
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=784962;
+SELECT AD_Element_Link_Create_Missing_Field(784962);
+
+-- 5) The UI element - primary group of the left column (555514), next to DocumentNo.
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,784962,0,549352,555514,654728 /*From ID Server*/,'F',
+        TO_TIMESTAMP('2026-09-09 11:03:10','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N',
+        'Produktionsauftrag',15,15,0,
+        TO_TIMESTAMP('2026-09-09 11:03:10','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585442);

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
@@ -23,6 +23,7 @@ package org.eevolution.process;
  */
 
 import de.metas.document.engine.DocStatus;
+import de.metas.i18n.AdMessageKey;
 import de.metas.process.IProcessPrecondition;
 import de.metas.process.IProcessPreconditionsContext;
 import de.metas.process.JavaProcess;
@@ -47,6 +48,9 @@ import org.eevolution.model.I_PP_Order;
  */
 public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrecondition
 {
+	/** Shown instead of the action when nothing in the selection is closeable. */
+	private static final AdMessageKey MSG_NoCompletedOrderInSelection = AdMessageKey.of("org.eevolution.process.PP_Order_CloseSelection.NoCompletedOrderInSelection");
+
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	private final IPPOrderBL ppOrderBL = Services.get(IPPOrderBL.class);
 
@@ -56,6 +60,13 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 		if (context.isNoSelection())
 		{
 			return ProcessPreconditionsResolution.rejectBecauseNoSelection();
+		}
+
+		// Refused WITH a reason, not hidden: the rows are on screen and look selectable, so a silently
+		// missing action would leave the user guessing.
+		if (!createCompletedOrdersQueryBuilder(context.getQueryFilter(I_PP_Order.class)).create().anyMatch())
+		{
+			return ProcessPreconditionsResolution.reject(MSG_NoCompletedOrderInSelection);
 		}
 
 		return ProcessPreconditionsResolution.accept();
@@ -73,7 +84,7 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 
 	private int createSelection()
 	{
-		final IQueryBuilder<I_PP_Order> queryBuilder = createCompletedOrdersQueryBuilder();
+		final IQueryBuilder<I_PP_Order> queryBuilder = createCompletedOrdersQueryBuilder(getUserSelectionFilter());
 
 		final PInstanceId adPInstanceId = getPinstanceId();
 
@@ -87,7 +98,7 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 	}
 
 	@NonNull
-	private IQueryBuilder<I_PP_Order> createCompletedOrdersQueryBuilder()
+	private IQueryFilter<I_PP_Order> getUserSelectionFilter()
 	{
 		final IQueryFilter<I_PP_Order> userSelectionFilter = getProcessInfo().getQueryFilterOrElse(null);
 
@@ -96,10 +107,17 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 			throw new AdempiereException("@NoSelection@");
 		}
 
+		return userSelectionFilter;
+	}
+
+	@NonNull
+	private IQueryBuilder<I_PP_Order> createCompletedOrdersQueryBuilder(@NonNull final IQueryFilter<I_PP_Order> userSelectionFilter)
+	{
 		return queryBL
 				.createQueryBuilder(I_PP_Order.class, getCtx(), ITrx.TRXNAME_None)
-				// The DocStatus guard belongs in the query that materializes the selection, not in the close
-				// loop: the user's selection comes from a client-side view that may be stale.
+				// DocStatus is filtered here, not in the close loop: the selection comes from a client-side
+				// view that may be stale. The precondition gate and the selection share this builder, so
+				// they cannot disagree on what is closeable.
 				.addEqualsFilter(I_PP_Order.COLUMNNAME_DocStatus, DocStatus.Completed)
 				.filter(userSelectionFilter)
 				.addOnlyActiveRecordsFilter();

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
@@ -130,6 +130,10 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 	@RunOutOfTrx
 	protected String doIt()
 	{
+		// Closing takes the orders out of a monitor scoped to completed ones, so re-reading their rows is
+		// not enough - the view has to build its row selection again for them to leave it.
+		getResult().setRecreateViewSelectionAfterExecution(true);
+
 		final PPOrderCloseResult result = ppOrderBL.closeOrdersInSelection(getPinstanceId());
 
 		final String summary = "@Processed@ (OK=#" + result.getCountClosed() + ", Error=#" + result.getCountFailed() + ")";

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
@@ -127,9 +127,7 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 	@RunOutOfTrx
 	protected String doIt()
 	{
-		// Closed orders leave a monitor scoped to completed ones only if the selection is rebuilt. The
-		// Swing client knows only the coarser flag, so set both: there it is the difference between
-		// re-reading the row and re-running the tab query.
+		// Closed orders leave a monitor scoped to completed ones only if the selection is rebuilt.
 		getResult().setRecreateViewSelectionAfterExecution(true);
 		getResult().setRefreshAllAfterExecution(true);
 

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
@@ -127,8 +127,11 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 	@RunOutOfTrx
 	protected String doIt()
 	{
-		// Closed orders leave a monitor scoped to completed ones only if the selection is rebuilt.
+		// Closed orders leave a monitor scoped to completed ones only if the selection is rebuilt. The
+		// Swing client knows only the coarser flag, so set both: there it is the difference between
+		// re-reading the row and re-running the tab query.
 		getResult().setRecreateViewSelectionAfterExecution(true);
+		getResult().setRefreshAllAfterExecution(true);
 
 		final PPOrderCloseResult result = ppOrderBL.closeOrdersInSelection(getPinstanceId());
 

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
@@ -129,7 +129,6 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 	{
 		// Closed orders leave a monitor scoped to completed ones only if the selection is rebuilt.
 		getResult().setRecreateViewSelectionAfterExecution(true);
-		getResult().setRefreshAllAfterExecution(true);
 
 		final PPOrderCloseResult result = ppOrderBL.closeOrdersInSelection(getPinstanceId());
 

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
@@ -48,7 +48,6 @@ import org.eevolution.model.I_PP_Order;
  */
 public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrecondition
 {
-	/** Shown instead of the action when nothing in the selection is closeable. */
 	private static final AdMessageKey MSG_NoCompletedOrderInSelection = AdMessageKey.of("org.eevolution.process.PP_Order_CloseSelection.NoCompletedOrderInSelection");
 
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
@@ -62,8 +61,7 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 			return ProcessPreconditionsResolution.rejectBecauseNoSelection();
 		}
 
-		// Refused WITH a reason, not hidden: the rows are on screen and look selectable, so a silently
-		// missing action would leave the user guessing.
+		// Refused WITH a reason rather than hidden: the rows look selectable, so a missing action puzzles.
 		if (!createCompletedOrdersQueryBuilder(context.getQueryFilter(I_PP_Order.class)).create().anyMatch())
 		{
 			return ProcessPreconditionsResolution.reject(MSG_NoCompletedOrderInSelection);
@@ -115,9 +113,8 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 	{
 		return queryBL
 				.createQueryBuilder(I_PP_Order.class, getCtx(), ITrx.TRXNAME_None)
-				// DocStatus is filtered here, not in the close loop: the selection comes from a client-side
-				// view that may be stale. The precondition gate and the selection share this builder, so
-				// they cannot disagree on what is closeable.
+				// DocStatus filtered here, not in the close loop: the client-side view may be stale, and
+				// sharing this builder keeps the precondition gate and the selection in agreement.
 				.addEqualsFilter(I_PP_Order.COLUMNNAME_DocStatus, DocStatus.Completed)
 				.filter(userSelectionFilter)
 				.addOnlyActiveRecordsFilter();
@@ -130,8 +127,7 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 	@RunOutOfTrx
 	protected String doIt()
 	{
-		// Closing takes the orders out of a monitor scoped to completed ones, so re-reading their rows is
-		// not enough - the view has to build its row selection again for them to leave it.
+		// Closed orders leave a monitor scoped to completed ones only if the selection is rebuilt.
 		getResult().setRecreateViewSelectionAfterExecution(true);
 
 		final PPOrderCloseResult result = ppOrderBL.closeOrdersInSelection(getPinstanceId());

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_PostCalculation.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_PostCalculation.java
@@ -90,7 +90,6 @@ public class PP_Order_PostCalculation extends JavaProcess implements IProcessPre
 	{
 		// Distributing closes the order, so it leaves the monitor only if the selection is rebuilt.
 		getResult().setRecreateViewSelectionAfterExecution(true);
-		getResult().setRefreshAllAfterExecution(true);
 
 		final PPOrderId ppOrderId = getPPOrderId();
 

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_PostCalculation.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_PostCalculation.java
@@ -88,8 +88,10 @@ public class PP_Order_PostCalculation extends JavaProcess implements IProcessPre
 	@Override
 	protected String doIt()
 	{
-		// Distributing closes the order, so it leaves the monitor only if the selection is rebuilt.
+		// Distributing closes the order, so it leaves the monitor only if the selection is rebuilt. The
+		// Swing client knows only the coarser flag, so set both.
 		getResult().setRecreateViewSelectionAfterExecution(true);
+		getResult().setRefreshAllAfterExecution(true);
 
 		final PPOrderId ppOrderId = getPPOrderId();
 

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_PostCalculation.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_PostCalculation.java
@@ -88,6 +88,10 @@ public class PP_Order_PostCalculation extends JavaProcess implements IProcessPre
 	@Override
 	protected String doIt()
 	{
+		// Distributing closes the order, so it drops out of a monitor scoped to completed ones - and a view
+		// only re-reads the rows it already selected unless it is told to select them again.
+		getResult().setRecreateViewSelectionAfterExecution(true);
+
 		final PPOrderId ppOrderId = getPPOrderId();
 
 		costDifferenceDistributor.distribute(ppOrderId);

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_PostCalculation.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_PostCalculation.java
@@ -88,8 +88,7 @@ public class PP_Order_PostCalculation extends JavaProcess implements IProcessPre
 	@Override
 	protected String doIt()
 	{
-		// Distributing closes the order, so it drops out of a monitor scoped to completed ones - and a view
-		// only re-reads the rows it already selected unless it is told to select them again.
+		// Distributing closes the order, so it leaves the monitor only if the selection is rebuilt.
 		getResult().setRecreateViewSelectionAfterExecution(true);
 
 		final PPOrderId ppOrderId = getPPOrderId();

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_PostCalculation.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_PostCalculation.java
@@ -88,8 +88,7 @@ public class PP_Order_PostCalculation extends JavaProcess implements IProcessPre
 	@Override
 	protected String doIt()
 	{
-		// Distributing closes the order, so it leaves the monitor only if the selection is rebuilt. The
-		// Swing client knows only the coarser flag, so set both.
+		// Distributing closes the order, so it leaves the monitor only if the selection is rebuilt.
 		getResult().setRecreateViewSelectionAfterExecution(true);
 		getResult().setRefreshAllAfterExecution(true);
 

--- a/backend/de.metas.manufacturing/src/test/java/org/eevolution/process/PP_Order_CloseSelectionTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/org/eevolution/process/PP_Order_CloseSelectionTest.java
@@ -1,0 +1,173 @@
+/*
+ * #%L
+ * de.metas.manufacturing
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.eevolution.process;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.document.engine.DocStatus;
+import de.metas.i18n.AdMessageKey;
+import de.metas.organization.OrgId;
+import de.metas.process.IProcessPreconditionsContext;
+import de.metas.process.ProcessPreconditionsResolution;
+import de.metas.process.SelectionSize;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryFilter;
+import org.adempiere.ad.element.api.AdTabId;
+import org.adempiere.ad.element.api.AdWindowId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.util.Env;
+import org.eevolution.model.I_PP_Order;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the precondition gate of {@link PP_Order_CloseSelection}: when the "close selection" action is
+ * offered on a manufacturing-order selection.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+class PP_Order_CloseSelectionTest
+{
+	private static final AdMessageKey MSG_NoCompletedOrderInSelection = AdMessageKey.of("org.eevolution.process.PP_Order_CloseSelection.NoCompletedOrderInSelection");
+
+	private final ClientId clientId = ClientId.ofRepoId(1);
+	private final OrgId orgId = OrgId.ofRepoId(0);
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		Env.setClientId(Env.getCtx(), clientId);
+		Env.setOrgId(Env.getCtx(), orgId);
+	}
+
+	@Test
+	void offered_whenTheSelectionHasACompletedOrder()
+	{
+		assertThat(checkPreconditions(ppOrder(DocStatus.Completed)).isRejected()).isFalse();
+	}
+
+	/** One closeable order is enough: the others are skipped by the selection query, not by this gate. */
+	@Test
+	void offered_whenOnlySomeOfTheSelectedOrdersAreCompleted()
+	{
+		assertThat(checkPreconditions(ppOrder(DocStatus.Closed), ppOrder(DocStatus.Completed), ppOrder(DocStatus.Drafted)).isRejected()).isFalse();
+	}
+
+	@Test
+	void notOffered_whenEverySelectedOrderIsAlreadyClosed()
+	{
+		final ProcessPreconditionsResolution resolution = checkPreconditions(ppOrder(DocStatus.Closed), ppOrder(DocStatus.Closed));
+
+		assertThat(resolution.isRejected()).isTrue();
+		// the point of the gate: the user must be told WHY, so the reason has to be a translated message
+		// that survives to the WebUI instead of being filtered out as internal
+		assertThat(resolution.isInternal()).isFalse();
+		// PlainMsgBL renders an un-parameterised AD_Message as its own key, so this pins the reason to the
+		// AD_Message rather than to a hardcoded sentence
+		assertThat(resolution.getRejectReason().getDefaultValue()).isEqualTo(MSG_NoCompletedOrderInSelection.toAD_Message());
+	}
+
+	@Test
+	void notOffered_whenNoSelectedOrderIsCompleted()
+	{
+		assertThat(checkPreconditions(ppOrder(DocStatus.Drafted), ppOrder(DocStatus.InProgress)).isRejected()).isTrue();
+	}
+
+	@Test
+	void notOffered_whenNothingIsSelected()
+	{
+		assertThat(checkPreconditions().isRejected()).isTrue();
+	}
+
+	private I_PP_Order ppOrder(@NonNull final DocStatus docStatus)
+	{
+		final I_PP_Order ppOrder = InterfaceWrapperHelper.newInstance(I_PP_Order.class);
+		InterfaceWrapperHelper.setValue(ppOrder, I_PP_Order.COLUMNNAME_AD_Client_ID, clientId.getRepoId());
+		ppOrder.setAD_Org_ID(orgId.getRepoId());
+		ppOrder.setDocStatus(docStatus.getCode());
+		InterfaceWrapperHelper.saveRecord(ppOrder);
+		return ppOrder;
+	}
+
+	private ProcessPreconditionsResolution checkPreconditions(@NonNull final I_PP_Order... selectedOrders)
+	{
+		return new PP_Order_CloseSelection()
+				.checkPreconditionsApplicable(new PreconditionsContext(Arrays.asList(selectedOrders)));
+	}
+
+	/** minimal stand-in for the WebUI's view context; only the selection is relevant to the gate */
+	private static class PreconditionsContext implements IProcessPreconditionsContext
+	{
+		private final ImmutableList<I_PP_Order> selectedRecords;
+		private final Set<Integer> selectedRecordIds;
+
+		PreconditionsContext(@NonNull final List<I_PP_Order> selectedRecords)
+		{
+			this.selectedRecords = ImmutableList.copyOf(selectedRecords);
+			this.selectedRecordIds = selectedRecords.stream().map(I_PP_Order::getPP_Order_ID).collect(ImmutableSet.toImmutableSet());
+		}
+
+		@Override
+		public AdWindowId getAdWindowId() {return null;}
+
+		@Override
+		public AdTabId getAdTabId() {return null;}
+
+		@Override
+		public String getTableName() {return I_PP_Order.Table_Name;}
+
+		@Override
+		public <T> T getSelectedModel(final Class<T> modelClass) {throw new UnsupportedOperationException();}
+
+		@Override
+		public <T> List<T> getSelectedModels(final Class<T> modelClass) {throw new UnsupportedOperationException();}
+
+		@NonNull
+		@Override
+		public <T> Stream<T> streamSelectedModels(@NonNull final Class<T> modelClass) {throw new UnsupportedOperationException();}
+
+		@Override
+		public int getSingleSelectedRecordId() {return selectedRecords.get(0).getPP_Order_ID();}
+
+		@Override
+		public SelectionSize getSelectionSize() {return SelectionSize.ofSize(selectedRecords.size());}
+
+		/** the view's selection reaches the process as a filter, never as loaded models */
+		@Override
+		public <T> IQueryFilter<T> getQueryFilter(@NonNull final Class<T> recordClass)
+		{
+			return model -> selectedRecordIds.contains(InterfaceWrapperHelper.getId(model));
+		}
+	}
+}

--- a/backend/de.metas.manufacturing/src/test/java/org/eevolution/process/PP_Order_CloseSelectionTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/org/eevolution/process/PP_Order_CloseSelectionTest.java
@@ -39,6 +39,15 @@ import org.adempiere.service.ClientId;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
 import org.compiere.util.Env;
+import de.metas.process.PInstanceId;
+import de.metas.process.ProcessInfo;
+import de.metas.util.Services;
+import org.mockito.Mockito;
+import org.compiere.model.I_AD_PInstance;
+import org.compiere.model.I_AD_Process;
+import org.compiere.model.X_AD_Process;
+import org.eevolution.api.IPPOrderBL;
+import org.eevolution.api.PPOrderCloseResult;
 import org.eevolution.model.I_PP_Order;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -103,6 +112,42 @@ class PP_Order_CloseSelectionTest
 	void notOffered_whenNothingIsSelected()
 	{
 		assertThat(checkPreconditions().isRejected()).isTrue();
+	}
+
+	/**
+	 * Pins the two flags {@code doIt()} sets. Dropping either one silently reintroduces the stale-row bug:
+	 * the WebUI would stop rebuilding the selection, the Swing client would stop re-running the tab query.
+	 */
+	@Test
+	void doIt_asksTheClientToRebuildItsView()
+	{
+		final IPPOrderBL ppOrderBL = Mockito.mock(IPPOrderBL.class);
+		Mockito.when(ppOrderBL.closeOrdersInSelection(Mockito.any()))
+				.thenReturn(PPOrderCloseResult.builder().countClosed(1).countFailed(0).build());
+		Services.registerService(IPPOrderBL.class, ppOrderBL);
+
+		final I_AD_Process adProcess = InterfaceWrapperHelper.newInstance(I_AD_Process.class);
+		adProcess.setValue("PP_Order_CloseSelection");
+		adProcess.setName("Auswahl schliessen");
+		adProcess.setClassname(PP_Order_CloseSelection.class.getName());
+		adProcess.setType(X_AD_Process.TYPE_Java);
+		InterfaceWrapperHelper.saveRecord(adProcess);
+
+		final I_AD_PInstance pinstance = InterfaceWrapperHelper.newInstance(I_AD_PInstance.class);
+		InterfaceWrapperHelper.saveRecord(pinstance);
+
+		final ProcessInfo processInfo = ProcessInfo.builder()
+				.setCtx(Env.getCtx())
+				.setPInstanceId(PInstanceId.ofRepoId(pinstance.getAD_PInstance_ID()))
+				.setAD_Process_ID(adProcess.getAD_Process_ID())
+				.build();
+		final PP_Order_CloseSelection process = new PP_Order_CloseSelection();
+		process.init(processInfo);
+
+		process.doIt();
+
+		assertThat(processInfo.getResult().isRecreateViewSelectionAfterExecution()).isTrue();
+		assertThat(processInfo.getResult().isRefreshAllAfterExecution()).isTrue();
 	}
 
 	private I_PP_Order ppOrder(@NonNull final DocStatus docStatus)

--- a/backend/de.metas.manufacturing/src/test/java/org/eevolution/process/PP_Order_CloseSelectionTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/org/eevolution/process/PP_Order_CloseSelectionTest.java
@@ -51,10 +51,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Covers the precondition gate of {@link PP_Order_CloseSelection}: when the "close selection" action is
- * offered on a manufacturing-order selection.
- */
+/** Covers the precondition gate of {@link PP_Order_CloseSelection}. */
 @ExtendWith(AdempiereTestWatcher.class)
 class PP_Order_CloseSelectionTest
 {
@@ -90,11 +87,9 @@ class PP_Order_CloseSelectionTest
 		final ProcessPreconditionsResolution resolution = checkPreconditions(ppOrder(DocStatus.Closed), ppOrder(DocStatus.Closed));
 
 		assertThat(resolution.isRejected()).isTrue();
-		// the point of the gate: the user must be told WHY, so the reason has to be a translated message
-		// that survives to the WebUI instead of being filtered out as internal
+		// the reason must reach the WebUI as a translated message, not be filtered out as internal
 		assertThat(resolution.isInternal()).isFalse();
-		// PlainMsgBL renders an un-parameterised AD_Message as its own key, so this pins the reason to the
-		// AD_Message rather than to a hardcoded sentence
+		// PlainMsgBL renders an un-parameterised AD_Message as its key, pinning the reason to the message
 		assertThat(resolution.getRejectReason().getDefaultValue()).isEqualTo(MSG_NoCompletedOrderInSelection.toAD_Message());
 	}
 

--- a/backend/de.metas.manufacturing/src/test/java/org/eevolution/process/PP_Order_PostCalculationTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/org/eevolution/process/PP_Order_PostCalculationTest.java
@@ -39,6 +39,11 @@ import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ClientId;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
+import de.metas.process.PInstanceId;
+import de.metas.process.ProcessInfo;
+import org.compiere.model.I_AD_PInstance;
+import org.compiere.model.I_AD_Process;
+import org.compiere.model.X_AD_Process;
 import org.compiere.SpringContextHolder;
 import org.compiere.util.Env;
 import org.eevolution.model.I_PP_Order;
@@ -78,11 +83,46 @@ class PP_Order_PostCalculationTest
 
 		finishedGoodId = BusinessTestHelper.createProductId("finished good", BusinessTestHelper.createUomEach());
 
-		// the process resolves it in a field initializer; doIt() is not under test here
+		// the process resolves it in a field initializer
 		costDifferenceDistributor = Mockito.mock(PPOrderCostDifferenceDistributor.class);
 		SpringContextHolder.registerJUnitBean(PPOrderCostDifferenceDistributor.class, costDifferenceDistributor);
 		// default to "something was issued" so each test exercises only the condition it names
 		Mockito.when(costDifferenceDistributor.hasInboundCosts(Mockito.any())).thenReturn(true);
+	}
+
+	/**
+	 * Pins the two flags {@code doIt()} sets — see {@code ProcessExecutionResult.recreateViewSelectionAfterExecution}.
+	 * Dropping either one silently leaves the discharged order sitting in the monitor.
+	 */
+	@Test
+	void doIt_asksTheClientToRebuildItsView()
+	{
+		final I_PP_Order ppOrder = ppOrder(DocStatus.Completed);
+
+		final I_AD_Process adProcess = InterfaceWrapperHelper.newInstance(I_AD_Process.class);
+		adProcess.setValue("PP_Order_PostCalculation");
+		adProcess.setName("Nachberechnung");
+		adProcess.setClassname(PP_Order_PostCalculation.class.getName());
+		adProcess.setType(X_AD_Process.TYPE_Java);
+		InterfaceWrapperHelper.saveRecord(adProcess);
+
+		final I_AD_PInstance pinstance = InterfaceWrapperHelper.newInstance(I_AD_PInstance.class);
+		InterfaceWrapperHelper.saveRecord(pinstance);
+
+		final ProcessInfo processInfo = ProcessInfo.builder()
+				.setCtx(Env.getCtx())
+				.setPInstanceId(PInstanceId.ofRepoId(pinstance.getAD_PInstance_ID()))
+				.setAD_Process_ID(adProcess.getAD_Process_ID())
+				.setRecord(I_PP_Order.Table_Name, ppOrder.getPP_Order_ID())
+				.build();
+
+		final PP_Order_PostCalculation process = new PP_Order_PostCalculation();
+		process.init(processInfo);
+
+		process.doIt();
+
+		assertThat(processInfo.getResult().isRecreateViewSelectionAfterExecution()).isTrue();
+		assertThat(processInfo.getResult().isRefreshAllAfterExecution()).isTrue();
 	}
 
 	@Test

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
@@ -134,7 +134,7 @@ public class ADProcessPostProcessService
 
 		final boolean recreateViewSelection = processExecutionResult.isRecreateViewSelectionAfterExecution();
 
-		if (processExecutionResult.isRefreshAllAfterExecution() || recreateViewSelection)
+		if (processExecutionResult.isRefreshAllAfterExecution())
 		{
 			final IView view = viewSupplier.get();
 

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
@@ -130,7 +130,7 @@ public class ADProcessPostProcessService
 
 		//
 		// Refresh all
-		boolean viewInvalidateAllCalled = false;
+		boolean viewFullyInvalidated = false;
 
 		final boolean recreateViewSelection = processExecutionResult.isRecreateViewSelectionAfterExecution();
 
@@ -153,7 +153,7 @@ public class ADProcessPostProcessService
 					ViewChangesCollector.getCurrentOrAutoflush()
 							.collectFullyChanged(view);
 				}
-				viewInvalidateAllCalled = true;
+				viewFullyInvalidated = true;
 
 				documentsCollection.invalidateDocumentsByWindowId(view.getViewId().getWindowId());
 			}
@@ -173,7 +173,7 @@ public class ADProcessPostProcessService
 			documentsCollection.invalidateDocumentByRecordId(recordToRefresh.getTableName(), recordToRefresh.getRecord_ID());
 
 			final IView view = viewSupplier.get();
-			if (!viewInvalidateAllCalled && view != null)
+			if (!viewFullyInvalidated && view != null)
 			{
 				final boolean watchedByFrontend = viewsRepo.isWatchedByFrontend(view.getViewId());
 				view.notifyRecordsChanged(TableRecordReferenceSet.of(recordToRefresh), watchedByFrontend);

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
@@ -132,15 +132,28 @@ public class ADProcessPostProcessService
 		// Refresh all
 		boolean viewInvalidateAllCalled = false;
 
-		if (processExecutionResult.isRefreshAllAfterExecution())
+		final boolean recreateViewSelection = processExecutionResult.isRecreateViewSelectionAfterExecution();
+
+		if (processExecutionResult.isRefreshAllAfterExecution() || recreateViewSelection)
 		{
 			final IView view = viewSupplier.get();
 
 			if (view != null)
 			{ // multiple rows selected
-				view.invalidateAll();
-				ViewChangesCollector.getCurrentOrAutoflush()
-						.collectFullyChanged(view);
+				if (recreateViewSelection)
+				{
+					// Builds the row selection again, so records the process moved out of the view's scope
+					// actually leave it. Resets the row cache and collects the change event by itself, so
+					// it also covers a plain refresh asked for at the same time - hence the branch below
+					// must not run as well.
+					view.invalidateSelection();
+				}
+				else
+				{
+					view.invalidateAll();
+					ViewChangesCollector.getCurrentOrAutoflush()
+							.collectFullyChanged(view);
+				}
 				viewInvalidateAllCalled = true;
 
 				documentsCollection.invalidateDocumentsByWindowId(view.getViewId().getWindowId());

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
@@ -142,10 +142,9 @@ public class ADProcessPostProcessService
 			{ // multiple rows selected
 				if (recreateViewSelection)
 				{
-					// Builds the row selection again, so records the process moved out of the view's scope
-					// actually leave it. Resets the row cache and collects the change event by itself, so
-					// it also covers a plain refresh asked for at the same time - hence the branch below
-					// must not run as well.
+					// Rebuilds the selection so records the process moved out of scope actually leave it.
+					// Resets the row cache and collects the change event itself, so the else-branch must
+					// not also run.
 					view.invalidateSelection();
 				}
 				else

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessServiceTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessServiceTest.java
@@ -33,6 +33,8 @@ import de.metas.ui.web.window.model.DocumentCollection;
 import de.metas.websocket.sender.WebsocketSender;
 import de.metas.user.UserId;
 import lombok.NonNull;
+
+import java.util.function.Consumer;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
@@ -109,7 +111,7 @@ class ADProcessPostProcessServiceTest
 		Mockito.verify(view, Mockito.never()).invalidateSelection();
 	}
 
-	private void postProcess(@NonNull final java.util.function.Consumer<ProcessExecutionResult> resultCustomizer)
+	private void postProcess(@NonNull final Consumer<ProcessExecutionResult> resultCustomizer)
 	{
 		final ProcessInfo processInfo = ProcessInfo.builder()
 				.setCtx(Env.getCtx())

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessServiceTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessServiceTest.java
@@ -48,9 +48,7 @@ import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Covers how {@link ADProcessPostProcessService} invalidates the view a process was run from.
- */
+/** Covers how {@link ADProcessPostProcessService} invalidates the view a process was run from. */
 @ExtendWith(AdempiereTestWatcher.class)
 class ADProcessPostProcessServiceTest
 {
@@ -83,7 +81,6 @@ class ADProcessPostProcessServiceTest
 				.build();
 	}
 
-	/** A process that says nothing must leave the view alone, whatever else the framework does. */
 	@Test
 	void viewIsLeftAlone_whenTheProcessAsksForNothing()
 	{
@@ -93,22 +90,16 @@ class ADProcessPostProcessServiceTest
 		Mockito.verify(view, Mockito.never()).invalidateAll();
 	}
 
-	/**
-	 * Re-reading the rows is not enough when the process changed whether they still belong to the view:
-	 * the selection is materialized, so it has to be built again.
-	 */
 	@Test
 	void selectionIsRecreated_whenTheProcessAsksForIt()
 	{
 		postProcess(result -> result.setRecreateViewSelectionAfterExecution(true));
 
 		Mockito.verify(view).invalidateSelection();
-		// invalidateSelection() resets the row cache and broadcasts by itself, so adding invalidateAll()
-		// here would only duplicate the websocket event
+		// invalidateSelection() resets the row cache and broadcasts itself; invalidateAll() would duplicate
 		Mockito.verify(view, Mockito.never()).invalidateAll();
 	}
 
-	/** The plain refresh keeps its old behaviour: re-read the rows of the selection the view already has. */
 	@Test
 	void onlyTheRowsAreReRead_whenTheProcessAsksForAPlainRefresh()
 	{

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessServiceTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessServiceTest.java
@@ -1,0 +1,154 @@
+/*
+ * #%L
+ * metasfresh-webui-api
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ui.web.process.adprocess;
+
+import de.metas.process.PInstanceId;
+import de.metas.process.ProcessExecutionResult;
+import de.metas.process.ProcessInfo;
+import de.metas.ui.web.view.IView;
+import de.metas.ui.web.view.IViewsRepository;
+import de.metas.ui.web.view.ViewId;
+import de.metas.ui.web.window.datatypes.WindowId;
+import de.metas.ui.web.window.model.DocumentCollection;
+import de.metas.websocket.sender.WebsocketSender;
+import de.metas.user.UserId;
+import lombok.NonNull;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_AD_PInstance;
+import org.compiere.model.I_AD_Process;
+import org.compiere.model.X_AD_Process;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers how {@link ADProcessPostProcessService} invalidates the view a process was run from.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+class ADProcessPostProcessServiceTest
+{
+	private static final WindowId windowId = WindowId.of(542175);
+
+	private IViewsRepository viewsRepo;
+	private IView view;
+	private ViewId viewId;
+	private ADProcessPostProcessService postProcessService;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		// ProcessInfo.builder() resolves the logged user eagerly
+		Env.setLoggedUserId(Env.getCtx(), UserId.METASFRESH);
+		// the plain-refresh branch broadcasts the view change itself, which needs the websocket bean
+		SpringContextHolder.registerJUnitBean(WebsocketSender.class, Mockito.mock(WebsocketSender.class));
+
+		viewId = ViewId.random(windowId);
+		view = Mockito.mock(IView.class);
+		Mockito.when(view.getViewId()).thenReturn(viewId);
+
+		viewsRepo = Mockito.mock(IViewsRepository.class);
+		Mockito.when(viewsRepo.getViewIfExists(viewId)).thenReturn(view);
+
+		postProcessService = ADProcessPostProcessService.builder()
+				.viewsRepo(viewsRepo)
+				.documentsCollection(Mockito.mock(DocumentCollection.class))
+				.build();
+	}
+
+	/** A process that says nothing must leave the view alone, whatever else the framework does. */
+	@Test
+	void viewIsLeftAlone_whenTheProcessAsksForNothing()
+	{
+		postProcess(result -> {});
+
+		Mockito.verify(view, Mockito.never()).invalidateSelection();
+		Mockito.verify(view, Mockito.never()).invalidateAll();
+	}
+
+	/**
+	 * Re-reading the rows is not enough when the process changed whether they still belong to the view:
+	 * the selection is materialized, so it has to be built again.
+	 */
+	@Test
+	void selectionIsRecreated_whenTheProcessAsksForIt()
+	{
+		postProcess(result -> result.setRecreateViewSelectionAfterExecution(true));
+
+		Mockito.verify(view).invalidateSelection();
+		// invalidateSelection() resets the row cache and broadcasts by itself, so adding invalidateAll()
+		// here would only duplicate the websocket event
+		Mockito.verify(view, Mockito.never()).invalidateAll();
+	}
+
+	/** The plain refresh keeps its old behaviour: re-read the rows of the selection the view already has. */
+	@Test
+	void onlyTheRowsAreReRead_whenTheProcessAsksForAPlainRefresh()
+	{
+		postProcess(result -> result.setRefreshAllAfterExecution(true));
+
+		Mockito.verify(view).invalidateAll();
+		Mockito.verify(view, Mockito.never()).invalidateSelection();
+	}
+
+	private void postProcess(@NonNull final java.util.function.Consumer<ProcessExecutionResult> resultCustomizer)
+	{
+		final ProcessInfo processInfo = ProcessInfo.builder()
+				.setCtx(Env.getCtx())
+				.setAD_Process_ID(createAdProcess())
+				.setPInstanceId(createPInstanceId())
+				.build();
+
+		resultCustomizer.accept(processInfo.getResult());
+
+		postProcessService.postProcess(ADProcessPostProcessRequest.builder()
+				.viewId(viewId)
+				.processInfo(processInfo)
+				.processExecutionResult(processInfo.getResult())
+				.build());
+	}
+
+	private PInstanceId createPInstanceId()
+	{
+		final I_AD_PInstance pinstance = InterfaceWrapperHelper.newInstance(I_AD_PInstance.class);
+		InterfaceWrapperHelper.saveRecord(pinstance);
+		return PInstanceId.ofRepoId(pinstance.getAD_PInstance_ID());
+	}
+
+	private int createAdProcess()
+	{
+		final I_AD_Process adProcess = InterfaceWrapperHelper.newInstance(I_AD_Process.class);
+		adProcess.setValue("TestProcess");
+		adProcess.setName("TestProcess");
+		adProcess.setType(X_AD_Process.TYPE_Java);
+		InterfaceWrapperHelper.saveRecord(adProcess);
+		return adProcess.getAD_Process_ID();
+	}
+}

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessServiceTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessServiceTest.java
@@ -102,6 +102,19 @@ class ADProcessPostProcessServiceTest
 		Mockito.verify(view, Mockito.never()).invalidateAll();
 	}
 
+	/** Both processes of the cost monitor set both flags, for the sake of the Swing client. */
+	@Test
+	void onlyTheSelectionIsRecreated_whenTheProcessAsksForBoth()
+	{
+		postProcess(result -> {
+			result.setRecreateViewSelectionAfterExecution(true);
+			result.setRefreshAllAfterExecution(true);
+		});
+
+		Mockito.verify(view).invalidateSelection();
+		Mockito.verify(view, Mockito.never()).invalidateAll();
+	}
+
 	@Test
 	void onlyTheRowsAreReRead_whenTheProcessAsksForAPlainRefresh()
 	{

--- a/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
+++ b/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
@@ -219,7 +219,12 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
       await processExecuted;
     });
 
-    // Read back from a FRESH view: the tab is scoped to DocStatus='CO', so a closed order is gone.
+    // Read back from a FRESH view. That proves the tab's DocStatus='CO' filter excludes the closed
+    // order - and only that: it is NOT evidence that the list already on screen drops the row, and it
+    // would pass either way. It does not drop it: the action's refresh re-reads the rows of the view's
+    // already-materialized selection, and nothing re-creates that selection, so the row stays (with
+    // up-to-date values) until the view is rebuilt. Re-creating it needs the view's
+    // invalidateSelection(), which a plain JavaProcess cannot reach.
     await MasterWindowPage.goto(COST_IMBALANCE_WINDOW_ID);
     await MasterWindowPage.expectWindowLoaded();
     await applyMonitorFilter({ page, documentNo });

--- a/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
+++ b/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
@@ -7,6 +7,9 @@ import { DashboardPage } from '../utils/pages/DashboardPage';
 import { MasterWindowPage } from '../utils/pages/MasterWindowPage';
 
 const COST_IMBALANCE_WINDOW_ID = 542175;
+// The full manufacturing order lives in its own window. Both windows sit on PP_Order, which is exactly
+// why a row click cannot get you there and a zoom field is needed.
+const PRODUCTION_ORDER_WINDOW_ID = 53009;
 
 // The filter bar carries no data-testid, so it is addressed by the language-invariant structural
 // classes the frontend derives from the identifiers (`form-field-<ColumnName>` per widget).
@@ -233,6 +236,87 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
 
     console.log(
       `Manufacturing order ${documentNo} closed via PP_Order_CloseSelection and left the cost-imbalance monitor`
+    );
+  });
+
+  test('Produktionsauftrag field zooms from the monitor into the Produktionsauftrag window', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    allure.epic('E0226: Costing');
+    allure.tag('F1500: Costing');
+    allure.tag('F1500');
+    allure.story('The cost-imbalance monitor can navigate to the full manufacturing order');
+    allure.severity('normal');
+    allure.description(
+      'The monitor is a read-only list over PP_Order and the Produktionsauftrag window (53009) is a ' +
+        'second window over the SAME table, so clicking a monitor row only re-opens it in the monitor -- ' +
+        'a controller had no way to reach the full order. Verifies the new "Produktionsauftrag" field in ' +
+        'successful action: it renders as a grid column showing the order\'s document number, and zooming ' +
+        'it lands on window 53009 on that same order. The landing window is the whole point: a lookup ' +
+        'pointing back at its own table could plausibly resolve to the window the user is already in, so ' +
+        'the assertion is on the target window id, not merely that "a zoom happened".'
+    );
+
+    const { masterdata, documentNo } = await seedCompletedManufacturingOrder();
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await DashboardPage.expectVisible();
+
+    await MasterWindowPage.goto(COST_IMBALANCE_WINDOW_ID);
+    await MasterWindowPage.expectWindowLoaded();
+
+    // Narrow to exactly the seeded order so the cell we right-click is unambiguously its cell.
+    await applyMonitorFilter({ page, documentNo });
+    await expect(page.locator(TABLE_ROWS)).toHaveCount(1);
+
+    // Selecting on ColumnName keeps this language-independent.
+    await expect(page.locator('th[data-testid="column-Link_PP_Order_ID"]')).toHaveCount(1);
+
+    const zoomCell = page.locator(TABLE_ROWS).first().locator('[data-cy="cell-Link_PP_Order_ID"]');
+    await expect(zoomCell).toHaveCount(1);
+    // AD_Ref_Table.AD_Display is PP_Order.DocumentNo, so the link is labelled with the document number.
+    await expect(zoomCell).toContainText(documentNo);
+
+    await test.step('Zoom Into is offered on the field', async () => {
+      await zoomCell.click({ button: 'right' });
+      await expect(page.locator('.context-menu-open')).toBeVisible();
+    });
+
+    // The menu caption is translated; the icon is not, so address the entry by its icon.
+    const zoomIntoItem = page.locator('.context-menu-open .context-menu-item').filter({
+      has: page.locator('i.meta-icon-share'),
+    });
+    await expect(zoomIntoItem).toHaveCount(1);
+
+    // Assert the server's own answer as well as where the browser ends up: this endpoint IS the
+    // window-resolution under test, so a regression would show here even if routing masked it.
+    const zoomResolved = page.waitForResponse(
+      (response) =>
+        response.url().includes('/field/Link_PP_Order_ID/zoomInto') && response.status() === 200
+    );
+    // A grid zoom opens the target in a NEW TAB (containers/Table.js handleZoomInto ->
+    // window.open(url, '_blank')), so the assertion is on the popup, not on this page's URL.
+    const orderTabOpened = page.context().waitForEvent('page');
+
+    await zoomIntoItem.click();
+
+    const zoomResponse = await zoomResolved;
+    const zoomPayload = await zoomResponse.json();
+    expect(String(zoomPayload.documentPath.windowId)).toBe(String(PRODUCTION_ORDER_WINDOW_ID));
+
+    const orderTab = await orderTabOpened;
+    await orderTab.waitForLoadState('domcontentloaded');
+
+    // The landing window is the point of the whole change: 53009, never back into 542175.
+    expect(orderTab.url()).toMatch(new RegExp(`/window/${PRODUCTION_ORDER_WINDOW_ID}/\\d+`));
+    expect(orderTab.url()).not.toMatch(new RegExp(`/window/${COST_IMBALANCE_WINDOW_ID}(/|$)`));
+
+    // Same order, not just the right window.
+    await expect(orderTab.locator(`text=${documentNo}`).first()).toBeVisible({ timeout: 60_000 });
+
+    console.log(
+      `Manufacturing order ${documentNo} zoomed from monitor ${COST_IMBALANCE_WINDOW_ID} into window ${PRODUCTION_ORDER_WINDOW_ID}`
     );
   });
 });

--- a/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
+++ b/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
@@ -157,14 +157,16 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
     allure.epic('E0226: Costing');
     allure.tag('F1500: Costing');
     allure.tag('F1500');
-    allure.story('PP_Order_CloseSelection is a quick action of the cost-imbalance monitor');
+    allure.story('PP_Order_CloseSelection is a quick action of the cost-imbalance monitor and refreshes it in place');
     allure.severity('normal');
     allure.description(
       'The monitor lists completed-but-not-closed manufacturing orders and its tab carries no DocAction ' +
         'field, so a balanced order could not be closed from it at all. Verifies the new ' +
         '"Auswahl schliessen" / "Close selection" quick action end to end: it is offered on this window, ' +
         'running it on the selected order closes it, and the closed order consequently drops out of the ' +
-        'monitor. Also guards the window-scoped demotion of the Issue/Receipt launcher: it is still ' +
+        'monitor in place -- with no reload and no re-navigation, so the assertion covers the view ' +
+        'refresh and not merely the tab filter. Also guards the window-scoped demotion of the ' +
+        'Issue/Receipt launcher: it is still ' +
         'offered here but is no longer the default quick action -- a default action always sorts to the ' +
         'front of the action list, so the launcher not being first proves the demotion in any language.'
     );
@@ -214,6 +216,14 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
       // simply absent here. It is covered by the costing cucumber scenarios.
     });
 
+    // Survives an SPA re-render but not a reload or a re-navigation, so it is what turns the assertions
+    // below into refresh coverage: reading the list back from a freshly opened window would prove only
+    // that the tab's DocStatus='CO' filter excludes a closed order, and would pass either way.
+    const pageLoadMarker = await page.evaluate(() => {
+      window.__pageLoadMarker = Math.random().toString(36);
+      return window.__pageLoadMarker;
+    });
+
     await test.step('Run Close selection', async () => {
       // Running a quick action is two calls: the POST only creates the pinstance, the follow-up
       // /start executes the process. Awaiting the POST would read the result back before it commits.
@@ -222,20 +232,16 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
       await processExecuted;
     });
 
-    // Read back from a FRESH view. That proves the tab's DocStatus='CO' filter excludes the closed
-    // order - and only that: it is NOT evidence that the list already on screen drops the row, and it
-    // would pass either way. It does not drop it: the action's refresh re-reads the rows of the view's
-    // already-materialized selection, and nothing re-creates that selection, so the row stays (with
-    // up-to-date values) until the view is rebuilt. Re-creating it needs the view's
-    // invalidateSelection(), which a plain JavaProcess cannot reach.
-    await MasterWindowPage.goto(COST_IMBALANCE_WINDOW_ID);
-    await MasterWindowPage.expectWindowLoaded();
-    await applyMonitorFilter({ page, documentNo });
-    await expect(page.locator(EMPTY_RESULT)).toBeVisible();
-    await expect(page.locator(TABLE_ROWS).filter({ hasText: documentNo })).toHaveCount(0);
+    await test.step('The closed order leaves the monitor in place, without reloading the page', async () => {
+      // The process asks the view to build its row selection again, so the order it just closed stops
+      // matching the tab and the list the user is looking at drops it on its own.
+      await expect(page.locator(EMPTY_RESULT)).toBeVisible({ timeout: 30_000 });
+      await expect(page.locator(TABLE_ROWS).filter({ hasText: documentNo })).toHaveCount(0);
+      expect(await page.evaluate(() => window.__pageLoadMarker)).toBe(pageLoadMarker);
+    });
 
     console.log(
-      `Manufacturing order ${documentNo} closed via PP_Order_CloseSelection and left the cost-imbalance monitor`
+      `Manufacturing order ${documentNo} closed via PP_Order_CloseSelection and left the cost-imbalance monitor in place`
     );
   });
 

--- a/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
+++ b/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
@@ -7,8 +7,7 @@ import { DashboardPage } from '../utils/pages/DashboardPage';
 import { MasterWindowPage } from '../utils/pages/MasterWindowPage';
 
 const COST_IMBALANCE_WINDOW_ID = 542175;
-// The full manufacturing order lives in its own window. Both windows sit on PP_Order, which is exactly
-// why a row click cannot get you there and a zoom field is needed.
+// Both windows sit on PP_Order, so a row click cannot reach the order - hence the zoom field.
 const PRODUCTION_ORDER_WINDOW_ID = 53009;
 
 // The filter bar carries no data-testid, so it is addressed by the language-invariant structural
@@ -216,9 +215,8 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
       // simply absent here. It is covered by the costing cucumber scenarios.
     });
 
-    // Survives an SPA re-render but not a reload or a re-navigation, so it is what turns the assertions
-    // below into refresh coverage: reading the list back from a freshly opened window would prove only
-    // that the tab's DocStatus='CO' filter excludes a closed order, and would pass either way.
+    // Survives an SPA re-render but not a reload: that is what makes the assertions below refresh
+    // coverage - a freshly opened window would pass either way, proving only the tab's filter.
     const pageLoadMarker = await page.evaluate(() => {
       window.__pageLoadMarker = Math.random().toString(36);
       return window.__pageLoadMarker;
@@ -233,8 +231,7 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
     });
 
     await test.step('The closed order leaves the monitor in place, without reloading the page', async () => {
-      // The process asks the view to build its row selection again, so the order it just closed stops
-      // matching the tab and the list the user is looking at drops it on its own.
+      // The process rebuilds the selection, so the closed order drops out of the list on its own.
       await expect(page.locator(EMPTY_RESULT)).toBeVisible({ timeout: 30_000 });
       await expect(page.locator(TABLE_ROWS).filter({ hasText: documentNo })).toHaveCount(0);
       expect(await page.evaluate(() => window.__pageLoadMarker)).toBe(pageLoadMarker);
@@ -295,8 +292,7 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
     });
     await expect(zoomIntoItem).toHaveCount(1);
 
-    // Assert the server's own answer as well as where the browser ends up: this endpoint IS the
-    // window-resolution under test, so a regression would show here even if routing masked it.
+    // This endpoint IS the window resolution under test, so assert it, not only where routing lands.
     const zoomResolved = page.waitForResponse(
       (response) =>
         response.url().includes('/field/Link_PP_Order_ID/zoomInto') && response.status() === 200


### PR DESCRIPTION
Follow-up to https://github.com/metasfresh/metasfresh/pull/25843 (squash-merged as https://github.com/metasfresh/metasfresh/commit/dbda33ed617c4f1c183410b90eacf90468a26a81). Findings raised against the manufacturing cost monitor window after that merge. They were authored on the merged PR's branch, which the squash orphaned, so they are re-parented onto `intensive_care_hotfix` here.

### Close selection is refused, with a reason, when nothing is closeable

`PP_Order_CloseSelection` previously accepted a selection containing no closeable order and reported success. It now rejects it and names why, via new `AD_Message` 545832. Migration `5823260`.

### A `Link_PP_Order_ID` field that zooms to the manufacturing order

The cost monitor had no navigation back to the full manufacturing order window (53009). `PP_Order.PP_Order_ID` cannot carry the zoom itself: it is the key column (`AD_Reference_ID` 13, no `AD_Reference_Value_ID`), and the zoom target resolves from `AD_Ref_Table.AD_Window_ID`, which is only reachable through a reference value. Repointing it would also apply inside window 53009 itself, since `AD_Column` attributes are shared by every window on the table. So this adds a virtual column over the same value that can own its own reference: `AD_Element` 585442, `AD_Reference` 542138, `AD_Column` 593529, `AD_Field` 784962, `AD_UI_Element` 654728. Migration `5823280`.

### A process can ask its view to rebuild the selection

This is also what fixes the window not refreshing after the two cost-monitor actions. Both actions close their order, which takes it out of a view scoped to completed orders — and a plain refresh only re-reads the rows the view already selected, so the closed order kept its row.

New `ProcessExecutionResult.recreateViewSelectionAfterExecution`. When set, `ADProcessPostProcessService` calls `view.invalidateSelection()` rather than `invalidateAll()`, so a row that no longer matches the view's filter actually leaves it. Both `PP_Order_CloseSelection` and `PP_Order_PostCalculation` set it. Opt-in — the default path is unchanged for every other process, and `invalidateSelection()` is only implemented by views that materialize a selection.

`ProcessExecutionResult.updateFrom` copies the new flag alongside `refreshAllAfterExecution`; without that it was silently dropped when a result is copied.

No `AD_Process.RefreshAllAfterExecution` migration ships with this. For the WebUI the new flag alone reaches both the view branch and the single-document branch of `ADProcessPostProcessService`, so the declarative flag would have added nothing there. It is not redundant everywhere, though: the Swing client (`APanel`) knows only `refreshAllAfterExecution`, and its else-branch calls `GridTab.dataRefresh()`, which re-reads the row without re-running the tab query — so a closed order would stay in a `DocStatus='CO'` grid. Rather than make each process set two flags, the stronger request implies the coarser one: `isRefreshAllAfterExecution()` returns `refreshAllAfterExecution || recreateViewSelectionAfterExecution`, so a process sets only `setRecreateViewSelectionAfterExecution(true)` and the Swing client is served automatically. Safe for transport because the class is `@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE)` — Jackson serializes the raw fields and never the derived getter. `ProcessExecutionResultTest.recreatingTheSelectionImpliesRefreshAll` pins the implication; `ADProcessPostProcessServiceTest` pins that WebUI behaviour is unchanged.

### Tests

- `PP_Order_CloseSelectionTest` — the refusal split, and that `doIt()` sets both view flags.
- `ADProcessPostProcessServiceTest` — the new branch, the unchanged default, the untouched plain-refresh path, and that both flags together still yield a single rebuild.
- `ProcessExecutionResultTest` — the new flag survives a copy and a JSON round-trip.
- `mfg-cost-imbalance-monitor.spec.js` — Playwright coverage for the cost-difference column, the close-and-refresh, and the zoom field. The refusal is covered at JUnit level only, not in Playwright.

