### PR TITLE
EDI DESADV: assert packs on the DESADV created at shipment completion

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/externalSystemBased/ediDesadvExportViaExternalSystem.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/externalSystemBased/ediDesadvExportViaExternalSystem.feature
@@ -898,6 +898,24 @@ Feature: EDI DESADV export via External System
       | EDI_DesadvLine_ID | EDI_Desadv_ID | M_Product_ID | OPT.QtyEntered | OPT.QtyDeliveredInUOM | OPT.QtyDeliveredInStockingUOM |
       | d_l_80            | d_80          | product        | 3              | 3                     | 3                             |
 
+    # ─── CORE ASSERTION (regression guard) ──────────────────────────────────
+    # The bug this scenario guards against: the retro-created DESADV reached the clearing centre with
+    # delivered quantities but ZERO EDI_Desadv_Pack rows (root cause: the second
+    # addInOutLinesToDesadvLines walk in DesadvBL was never invoked for this path). o_80 has a single
+    # order line, so d_80 has exactly one EDI_DesadvLine (d_l_80) — the pack below must belong to d_80,
+    # and its single item must carry the shipment line (s_l_80) that fulfils d_l_80.
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed | OPT.C_OrderLine_ID.Identifier |
+      | s_l_80                    | s_80                  | product                 | 3           | true      | ol_80_1                       |
+
+    And after not more than 60s, EDI_Desadv_Pack records are found:
+      | EDI_Desadv_Pack_ID.Identifier | EDI_Desadv_ID.Identifier | IsManual_IPA_SSCC18 | SeqNo |
+      | d_p_80                        | d_80                     | true                | 1     |
+
+    And after not more than 60s, the EDI_Desadv_Pack_Item has only the following records:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | M_InOutLine_ID | QtyItemCapacity | OPT.QtyTU |
+      | d_pi_80                 | d_p_80             | 3           | s_l_80         | 0               | 1         |
+
 
   @from:cucumber
   @allure.label.epic:E0292_EDI

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/externalSystemBased/ediDesadvExportViaExternalSystem.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/externalSystemBased/ediDesadvExportViaExternalSystem.feature
@@ -844,6 +844,14 @@ Feature: EDI DESADV export via External System
   ## at shipment completion, by DesadvBL.addToDesadvCreateForInOutIfNotExist via its C_Order fallback.
   ## That fallback creates the EDI_DesadvLines only at that moment, so the delivered quantities have to
   ## be derived AFTER they exist — otherwise the recipient receives a DESADV announcing zero delivered.
+    # Eleven scenarios before this one complete shipments for the Background's shared EDI-recipient
+    # customer1, silently creating EDI_Desadv_Pack / EDI_Desadv_Pack_Item rows as a side effect of the
+    # M_InOut before-complete interceptor (nothing in those scenarios asserts packs, so nothing cleans
+    # them up). Reset both tables here, before anything else in this scenario runs, so the pack
+    # assertions below see only what THIS scenario creates.
+    And metasfresh initially has no EDI_Desadv_Pack_Item data
+    And metasfresh initially has no EDI_Desadv_Pack data
+
     And RabbitMQ MF_TO_ExternalSystem queue is purged
 
     # POReference is deliberately absent here: that is what keeps the order out of the DESADV at

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
@@ -67,8 +67,11 @@ import java.util.Properties;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack.COLUMNNAME_IPA_SSCC18;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_BestBeforeDate;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_ID;
+import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_M_InOutLine_ID;
+import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_MovementQty;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerLU;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerTU;
+import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyItemCapacity;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyTU;
 import static java.math.BigDecimal.TEN;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
@@ -758,6 +761,24 @@ class DesadvBL_addToDesadvCreateForInOutIfNotExist_Test
 		InterfaceWrapperHelper.refresh(result);
 		assertThat(result.getSumDeliveredInStockingUOM()).isEqualByComparingTo("3");
 		assertThat(result.getFulfillmentPercent()).isEqualByComparingTo("100");
+
+		// the EDI export is rejected by the clearing centre when a DESADV carries delivered qtys
+		// but no packs -- so the fallback-created DESADV must also get its EDI_Desadv_Pack(_Item) rows.
+		final List<I_EDI_Desadv_Pack> packRecords = POJOLookupMap.get().getRecords(I_EDI_Desadv_Pack.class);
+		assertThat(packRecords)
+				.as("a pack must have been created for the DESADV that was built at shipment completion")
+				.isNotEmpty();
+		assertThat(packRecords)
+				.as("every pack found must belong to the DESADV created for this shipment")
+				.allMatch(pack -> pack.getEDI_Desadv_ID() == result.getEDI_Desadv_ID());
+
+		final List<I_EDI_Desadv_Pack_Item> packItemRecords = POJOLookupMap.get().getRecords(I_EDI_Desadv_Pack_Item.class);
+		assertThat(packItemRecords)
+				.as("a pack item must reference the shipment line, with its shipped qty, TU count and TU capacity")
+				.extracting(COLUMNNAME_M_InOutLine_ID, COLUMNNAME_MovementQty, COLUMNNAME_QtyTU, COLUMNNAME_QtyItemCapacity)
+				.containsOnly(
+						tuple(shipmentLine.getM_InOutLine_ID(), new BigDecimal("3"), 1, new BigDecimal("5"))
+				);
 	}
 
 	private void changeDesadvLineToCOLIasUOM()

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
@@ -67,6 +67,7 @@ import java.util.Properties;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack.COLUMNNAME_IPA_SSCC18;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_BestBeforeDate;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_ID;
+import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_DesadvLine_ID;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_M_InOutLine_ID;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_MovementQty;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerLU;
@@ -766,18 +767,18 @@ class DesadvBL_addToDesadvCreateForInOutIfNotExist_Test
 		// but no packs -- so the fallback-created DESADV must also get its EDI_Desadv_Pack(_Item) rows.
 		final List<I_EDI_Desadv_Pack> packRecords = POJOLookupMap.get().getRecords(I_EDI_Desadv_Pack.class);
 		assertThat(packRecords)
-				.as("a pack must have been created for the DESADV that was built at shipment completion")
-				.isNotEmpty();
+				.as("exactly one pack must have been created for the DESADV that was built at shipment completion (one TU, one pack)")
+				.hasSize(1);
 		assertThat(packRecords)
 				.as("every pack found must belong to the DESADV created for this shipment")
 				.allMatch(pack -> pack.getEDI_Desadv_ID() == result.getEDI_Desadv_ID());
 
 		final List<I_EDI_Desadv_Pack_Item> packItemRecords = POJOLookupMap.get().getRecords(I_EDI_Desadv_Pack_Item.class);
 		assertThat(packItemRecords)
-				.as("a pack item must reference the shipment line, with its shipped qty, TU count and TU capacity")
-				.extracting(COLUMNNAME_M_InOutLine_ID, COLUMNNAME_MovementQty, COLUMNNAME_QtyTU, COLUMNNAME_QtyItemCapacity)
+				.as("a pack item must reference both the created DESADV line and the shipment line, with its shipped qty, TU count and TU capacity")
+				.extracting(COLUMNNAME_EDI_DesadvLine_ID, COLUMNNAME_M_InOutLine_ID, COLUMNNAME_MovementQty, COLUMNNAME_QtyTU, COLUMNNAME_QtyItemCapacity)
 				.containsOnly(
-						tuple(shipmentLine.getM_InOutLine_ID(), new BigDecimal("3"), 1, new BigDecimal("5"))
+						tuple(createdLine.getEDI_DesadvLine_ID(), shipmentLine.getM_InOutLine_ID(), new BigDecimal("3"), 1, new BigDecimal("5"))
 				);
 	}
 


### PR DESCRIPTION
Test-only. Adds the pack assertions that the "DESADV created at shipment completion" path never had.

## Background

When a sales order is completed without a PO reference, `C_Order`'s before-complete interceptor skips DESADV creation. The DESADV is then created later, at *shipment* completion, by `DesadvBL.addToDesadvCreateForInOutIfNotExist` via its `C_Order` fallback. That fallback creates the `EDI_DesadvLine`s only at that moment, so the first walk over the shipment lines finds no links yet and derives nothing.

`DesadvBL.java:414` fixes that by walking the shipment lines a second time, after the fallback has created the lines and wired `C_OrderLine.EDI_DesadvLine_ID` — which is also the only route from this path to `EDIDesadvPackService.createOrExtendPacks`. It landed in https://github.com/metasfresh/metasfresh/pull/25612.

Both existing tests on this path assert only the delivered-quantity half; neither asserts that the packs were created. A DESADV that carries quantities but no `EDI_Desadv_Pack` rows is rejected downstream, so that is the half worth pinning.

## Changes

**`DesadvBL_addToDesadvCreateForInOutIfNotExist_Test`** — extends `addToDesadvCreateForInOutIfNotExist_orderWithoutDesadvLines_getsDeliveredQtys` with assertions that exactly one `EDI_Desadv_Pack` was created for the DESADV, and that its single `EDI_Desadv_Pack_Item` references both the created DESADV line and the shipment line, with the shipped quantity, transport-unit count and item capacity. Same assertion idiom as the sibling tests in the class; no new helper or assertion library.

**`ediDesadvExportViaExternalSystem.feature`, scenario `S30013_80`** — adds the cucumber equivalent: an `M_InOutLine` alias step, a pack assertion scoped to the scenario's DESADV, and a pack-item assertion scoped to that pack and the shipment line. Reuses the existing `EDI_Desadv_Pack` / `EDI_Desadv_Pack_Item` step definitions unchanged.

The scenario also gains two `metasfresh initially has no EDI_Desadv_Pack(_Item) data` steps at its start. The pack-item step's exact-count check queries the whole table with no scoping filter, and eleven scenarios earlier in the same file complete shipments for the shared EDI-recipient partner in `Background`, each creating pack rows as a side effect of the before-complete interceptor with no cleanup anywhere in the file. Without the reset the exact count sees those rows too. They are placed at the top of the scenario rather than next to the assertions because this scenario's own packs are created mid-scenario, by the shipment-completion interceptor.

Follow-up filed for the underlying step-def scoping so future scenarios do not need this workaround.

## Verification

Unit: full `DesadvBL_addToDesadvCreateForInOutIfNotExist_Test` class green (10/10) under JDK 8.

Cucumber: `S30013_80` passes. Ten other scenarios in the file fail with an identical `M_ShipmentSchedules are found` / "Not valid yet" async-settle timeout that is unrelated to this change — eight of them run *earlier in the file* than `S30013_80`, and the two that run after it fail the same way when re-run in isolation with `S30013_80` not executing at all. CI is the authoritative verdict for the file as a whole.

No production code is touched.
