### PR TITLE
M_ShipperTransportation.SalesRep_ID lookup: replace the dropped @IsSOTrx@ dependency with @TransportDirection@

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5823430_sys_gh31997_M_ShipperTransportation_SalesRep_TransportDirection_lookup.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5823430_sys_gh31997_M_ShipperTransportation_SalesRep_TransportDirection_lookup.sql
@@ -1,0 +1,77 @@
+-- M_ShipperTransportation.SalesRep_ID lookup must not depend on @IsSOTrx@
+--
+-- WHY
+--   5820850_sys_M_ShipperTransportation_Drop_IsSOTrx.sql dropped M_ShipperTransportation.IsSOTrx and
+--   replaced it with TransportDirection. The SalesRep_ID lookup still resolved through AD_Reference
+--   190, whose WhereClause is
+--       (AD_User.IsSystemUser = 'Y' OR '@IsSOTrx@'='N')
+--   so the context variable it names no longer exists and WindowHealthCheckCommand reports both
+--   M_ShipperTransportation windows (540020, 541657) as NOK. The cleanup of that change was
+--   incomplete: the meaning of the flag moved to TransportDirection, the lookup did not follow.
+--
+-- WHAT THIS DOES
+--   Introduces an AD_User table reference whose restriction is the TransportDirection equivalent of
+--   the old clause, and repoints ONLY M_ShipperTransportation.SalesRep_ID (AD_Column 551101) at it.
+--
+--   The equivalence is not invented here — it is the one 5821070_..._catchup_backfill.sql used to
+--   migrate the data:
+--       IsSOTrx = 'N' (purchase) -> 'Incoming', or 'Dropship' when all orders are drop-ship
+--       IsSOTrx = 'Y' (sales)    -> 'Outgoing'
+--   so  '@IsSOTrx@'='N'  becomes  '@TransportDirection@' IN ('Incoming','Dropship').
+--   Behaviour is therefore preserved: system users always, plus every user on an incoming or
+--   drop-ship transport.
+--
+-- WHAT THIS DELIBERATELY DOES *NOT* DO
+--   * AD_Reference 190 is left untouched. 20+ other columns still resolve through it on tables that
+--     DO have IsSOTrx (C_Invoice, C_Order, M_InOut, M_RMA, I_Invoice, I_Order, C_Invoice_Candidate),
+--     where @IsSOTrx@ still resolves correctly.
+--   * IsAutoApplyValidationRule on AD_Column 551101 is not changed. The sibling C_BPartner fix set it
+--     to 'Y' in 5787080_c_bpartner_sales_rep_fix_LookupDescriptor.sql and reverted it to 'N' in
+--     5787160_c_bpartner_sales_rep_fix_LookupDescriptor2.sql; 'N' is the corrected end state.
+--   * It does not repoint the column at AD_Reference 540401 ('AD_User.IsSystemUser = ''Y''').
+--     That would make the health check pass by DELETING the second arm of the condition, narrowing
+--     the picker on incoming/drop-ship transports from every user to system users only.
+--
+--   AD_Ref_Table's presentation columns (AD_Key, AD_Display, IsValueDisplayed, OrderByClause,
+--   AD_Window_ID) are SELECTed from AD_Reference 190's own row rather than hardcoded, so the new
+--   reference renders identically to the old one on every instance.
+--
+-- IDs allocated from idserver.metas.de on 2026-09-09:
+--   AD_Reference     542139 (AD_User - SalesRep systemuser or incoming transport)
+--   AD_MigrationScript prefix 5823430
+
+-- 2026-09-09 12:52:39
+INSERT INTO AD_Reference (AD_Client_ID,AD_Org_ID,AD_Reference_ID,Created,CreatedBy,EntityType,IsActive,IsOrderByValue,Name,Updated,UpdatedBy,ValidationType) VALUES (0,0,542139 /*From ID Server*/,TO_TIMESTAMP('2026-09-09 12:52:39','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','N','AD_User - SalesRep systemuser or incoming transport',TO_TIMESTAMP('2026-09-09 12:52:39','YYYY-MM-DD HH24:MI:SS'),100,'T')
+;
+
+-- 2026-09-09 12:52:39
+INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Reference_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Reference t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Reference_ID=542139 AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
+;
+
+-- 2026-09-09 12:52:39
+-- Presentation copied from AD_Reference 190's row; only the WhereClause differs.
+INSERT INTO AD_Ref_Table (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,AD_Key,AD_Display,AD_Window_ID,IsValueDisplayed,OrderByClause,WhereClause,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy)
+SELECT rt.AD_Client_ID,
+       rt.AD_Org_ID,
+       542139 /*From ID Server*/,
+       rt.AD_Table_ID,
+       rt.AD_Key,
+       rt.AD_Display,
+       rt.AD_Window_ID,
+       rt.IsValueDisplayed,
+       rt.OrderByClause,
+       '(AD_User.IsSystemUser = ''Y'' OR ''@TransportDirection@'' IN (''Incoming'',''Dropship''))',
+       TO_TIMESTAMP('2026-09-09 12:52:39','YYYY-MM-DD HH24:MI:SS'),
+       100,
+       'D',
+       'Y',
+       TO_TIMESTAMP('2026-09-09 12:52:39','YYYY-MM-DD HH24:MI:SS'),
+       100
+FROM   AD_Ref_Table rt
+WHERE  rt.AD_Reference_ID = 190
+;
+
+-- 2026-09-09 12:52:39
+-- Column: M_ShipperTransportation.SalesRep_ID
+UPDATE AD_Column SET AD_Reference_Value_ID=542139 /*From ID Server*/,Updated=TO_TIMESTAMP('2026-09-09 12:52:39','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=551101
+;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5823430_sys_gh31997_M_ShipperTransportation_SalesRep_TransportDirection_lookup.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5823430_sys_gh31997_M_ShipperTransportation_SalesRep_TransportDirection_lookup.sql
@@ -22,9 +22,19 @@
 --   drop-ship transport.
 --
 -- WHAT THIS DELIBERATELY DOES *NOT* DO
---   * AD_Reference 190 is left untouched. 20+ other columns still resolve through it on tables that
---     DO have IsSOTrx (C_Invoice, C_Order, M_InOut, M_RMA, I_Invoice, I_Order, C_Invoice_Candidate),
---     where @IsSOTrx@ still resolves correctly.
+--   * AD_Reference 190 is left untouched. Many other columns still resolve through it, and they all
+--     fall into one of two harmless groups:
+--       - the table HAS IsSOTrx (C_Invoice, C_Order, M_InOut, M_RMA, I_Invoice, I_Order,
+--         C_Invoice_Candidate) -> @IsSOTrx@ resolves normally, nothing to fix;
+--       - the table lacks IsSOTrx but its windows are listed in
+--         MissingContextVariables.KNOWN_MISSING_CONTEXT_VARIABLES_IN_LOOKUPS (C_Project 130/286/
+--         540668/540680/541015, M_Product 140/344/53010/540410, C_RfQ 315, M_Movement 170,
+--         C_SalesRegion 152, W_Store 350, M_Material_Tracking 540226, C_Phonecall_Schedule 540607,
+--         RV_R_Group_Prospect 540013, ... 39 SalesRep_ID entries in total) -> the health check
+--         deliberately suppresses the warning there.
+--     M_ShipperTransportation is the only column in NEITHER group, which is exactly why windows
+--     540020 and 541657 are the only two reported NOK. Repointing this one column therefore closes
+--     the whole defect without touching AD_Reference 190 or the allowlist.
 --   * IsAutoApplyValidationRule on AD_Column 551101 is not changed. The sibling C_BPartner fix set it
 --     to 'Y' in 5787080_c_bpartner_sales_rep_fix_LookupDescriptor.sql and reverted it to 'N' in
 --     5787160_c_bpartner_sales_rep_fix_LookupDescriptor2.sql; 'N' is the corrected end state.
@@ -61,11 +71,11 @@ SELECT rt.AD_Client_ID,
        rt.IsValueDisplayed,
        rt.OrderByClause,
        '(AD_User.IsSystemUser = ''Y'' OR ''@TransportDirection@'' IN (''Incoming'',''Dropship''))',
-       TO_TIMESTAMP('2026-09-09 12:52:39','YYYY-MM-DD HH24:MI:SS'),
+       TO_TIMESTAMP('2026-09-09 12:52:40','YYYY-MM-DD HH24:MI:SS'),
        100,
        'D',
        'Y',
-       TO_TIMESTAMP('2026-09-09 12:52:39','YYYY-MM-DD HH24:MI:SS'),
+       TO_TIMESTAMP('2026-09-09 12:52:40','YYYY-MM-DD HH24:MI:SS'),
        100
 FROM   AD_Ref_Table rt
 WHERE  rt.AD_Reference_ID = 190
@@ -73,5 +83,5 @@ WHERE  rt.AD_Reference_ID = 190
 
 -- 2026-09-09 12:52:39
 -- Column: M_ShipperTransportation.SalesRep_ID
-UPDATE AD_Column SET AD_Reference_Value_ID=542139 /*From ID Server*/,Updated=TO_TIMESTAMP('2026-09-09 12:52:39','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=551101
+UPDATE AD_Column SET AD_Reference_Value_ID=542139 /*From ID Server*/,Updated=TO_TIMESTAMP('2026-09-09 12:52:41','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=551101
 ;


### PR DESCRIPTION
`M_ShipperTransportation.SalesRep_ID` still resolved through `AD_Reference` 190, whose `AD_Ref_Table.WhereClause` is

```
(AD_User.IsSystemUser = 'Y' OR '@IsSOTrx@'='N')
```

but `5820850_sys_M_ShipperTransportation_Drop_IsSOTrx.sql` dropped `M_ShipperTransportation.IsSOTrx` in favour of `TransportDirection`. The context variable the lookup names no longer exists, so `WindowHealthCheckCommand` reports both `M_ShipperTransportation` windows (540020, 541657) as NOK:

```
No context variable `IsSOTrx` found in M_ShipperTransportation/540020.SalesRep_ID.LookupDescriptor.
No context variable `IsSOTrx` found in M_ShipperTransportation/541657.SalesRep_ID.LookupDescriptor.
```

The cleanup of that change was incomplete: the meaning of the flag moved to `TransportDirection`, the lookup did not follow it.

### The fix keeps the behaviour rather than dropping the condition

New `AD_Reference` 542139 — an `AD_User` table reference carrying the `TransportDirection` equivalent of the old clause — and `AD_Column` 551101 repointed at it:

```
(AD_User.IsSystemUser = 'Y' OR '@TransportDirection@' IN ('Incoming','Dropship'))
```

The equivalence is not invented here. It is the one `5821070_sys_M_ShipperTransportation_TransportDirection_catchup_backfill.sql` used to migrate the data:

| old | new |
|---|---|
| `IsSOTrx = 'N'` (purchase) | `Incoming`, or `Dropship` when all orders are drop-ship |
| `IsSOTrx = 'Y'` (sales) | `Outgoing` |

So the dropdown keeps offering system users always, plus every user on an incoming or drop-ship transport.

`AD_Ref_Table`'s presentation columns (`AD_Key`, `AD_Display`, `AD_Window_ID`, `IsValueDisplayed`, `OrderByClause`) are `SELECT`ed from reference 190's own row rather than hardcoded, so the new reference renders identically on every instance.

### Deliberately not done

- **`AD_Reference` 190 is untouched.** 20+ other columns still resolve through it on tables that *do* have `IsSOTrx` — `C_Invoice`, `C_Order`, `M_InOut`, `M_RMA`, `I_Invoice`, `I_Order`, `C_Invoice_Candidate` — where `@IsSOTrx@` resolves correctly.
- **`IsAutoApplyValidationRule` is not changed.** The sibling `C_BPartner` fix set it to `'Y'` in `5787080_c_bpartner_sales_rep_fix_LookupDescriptor.sql` and reverted it to `'N'` in `5787160_c_bpartner_sales_rep_fix_LookupDescriptor2.sql`; `'N'` is the corrected end state.
- **The column is not repointed at `AD_Reference` 540401** (`AD_User.IsSystemUser = 'Y'`). That would green the health check by deleting the second arm of the condition, silently narrowing the picker on incoming and drop-ship transports from every user to system users only.

### Verification

The script was applied against a scratch Postgres seeded with reference 190's row as it stands on a live instance, and the resulting state asserted:

```
still_depends_on_issotrx | f      presentation_identical (vs ref 190) | t
uses_transportdirection  | t      ref 190 WhereClause                 | unchanged
covers_incoming          | t      AD_Column 551101 -> 542139          | yes
covers_dropship          | t      IsAutoApplyValidationRule           | N (unchanged)
keeps_systemuser_arm     | t      AD_Reference_Trl                    | de_DE + de_CH created
```

The end-to-end gate is the customer-side window health check reporting `countErrors: 0` for the window stage. Note the ordering: core must build this branch's base, `auto-update-base-version` must re-pin the customer repo, and only then does a customer run exercise the fix — an earlier customer run will still show the old red.

### Scope

Only this branch line and the upward propagation to `new_dawn_uat` are in scope. 36 other base branches already lack the column and will inherit this fix when they next take the drop; branches that still have `IsSOTrx` are unaffected until then.
