### PR TITLE
Merge intensive_care_release into new_dawn_uat

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/I_PP_Order.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/I_PP_Order.java
@@ -1099,6 +1099,36 @@ public interface I_PP_Order
 	String COLUMNNAME_Line = "Line";
 
 	/**
+	 * Set Manufacturing Order.
+	 * Opens the manufacturing order in the Manufacturing Order window.
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true
+	 * @deprecated Please don't use it because this is a virtual column
+	 */
+	@Deprecated
+	void setLink_PP_Order_ID (int Link_PP_Order_ID);
+
+	/**
+	 * Get Manufacturing Order.
+	 * Opens the manufacturing order in the Manufacturing Order window.
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true
+	 */
+	int getLink_PP_Order_ID();
+
+	@Nullable org.eevolution.model.I_PP_Order getLink_PP_Order();
+
+	@Deprecated
+	void setLink_PP_Order(@Nullable org.eevolution.model.I_PP_Order Link_PP_Order);
+
+	ModelColumn<I_PP_Order, org.eevolution.model.I_PP_Order> COLUMN_Link_PP_Order_ID = new ModelColumn<>(I_PP_Order.class, "Link_PP_Order_ID", org.eevolution.model.I_PP_Order.class);
+	String COLUMNNAME_Link_PP_Order_ID = "Link_PP_Order_ID";
+
+	/**
 	 * Set Lot No..
 	 *
 	 * <br>Type: String

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/X_PP_Order.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/X_PP_Order.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 public class X_PP_Order extends org.compiere.model.PO implements I_PP_Order, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 2126020309L;
+	private static final long serialVersionUID = 1476785033L;
 
     /** Standard Constructor */
     public X_PP_Order (final Properties ctx, final int PP_Order_ID, @Nullable final String trxName)
@@ -820,6 +820,29 @@ public class X_PP_Order extends org.compiere.model.PO implements I_PP_Order, org
 	public int getLine() 
 	{
 		return get_ValueAsInt(COLUMNNAME_Line);
+	}
+
+	@Override
+	public org.eevolution.model.I_PP_Order getLink_PP_Order()
+	{
+		return get_ValueAsPO(COLUMNNAME_Link_PP_Order_ID, org.eevolution.model.I_PP_Order.class);
+	}
+
+	@Override
+	public void setLink_PP_Order(final org.eevolution.model.I_PP_Order Link_PP_Order)
+	{
+		set_ValueFromPO(COLUMNNAME_Link_PP_Order_ID, org.eevolution.model.I_PP_Order.class, Link_PP_Order);
+	}
+
+	@Override
+	public void setLink_PP_Order_ID (final int Link_PP_Order_ID)
+	{
+		throw new IllegalArgumentException ("Link_PP_Order_ID is virtual column");	}
+
+	@Override
+	public int getLink_PP_Order_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_Link_PP_Order_ID);
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
@@ -160,7 +160,27 @@ public class ProcessExecutionResult
 	/**
 	 * Tells if the whole window tab shall be refreshed after process execution (applies only when the process was started from a user window)
 	 */
-	@Setter @Getter private boolean refreshAllAfterExecution = false;
+	@Setter private boolean refreshAllAfterExecution = false;
+
+	/**
+	 * Tells that the view's row selection has to be rebuilt, not merely re-read (the process changed
+	 * whether its records still belong to the view). The stronger form of {@link #refreshAllAfterExecution}:
+	 * a process asks for this one alone, and {@link #isRefreshAllAfterExecution()} answers true as well,
+	 * so a client that knows only the coarser flag (the Swing one) still refreshes.
+	 * <p>
+	 * Only a view that materializes a selection implements the rebuild, so set this only on a process that
+	 * runs on an AD-window view; elsewhere it throws after the process has already committed.
+	 */
+	@Setter @Getter private boolean recreateViewSelectionAfterExecution = false;
+
+	/**
+	 * True when anything at all has to be refreshed — including the stronger
+	 * {@link #recreateViewSelectionAfterExecution}, which subsumes it.
+	 */
+	public boolean isRefreshAllAfterExecution()
+	{
+		return refreshAllAfterExecution || recreateViewSelectionAfterExecution;
+	}
 
 	@Setter @Getter @JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private TableRecordReference recordToRefreshAfterExecution = null;
@@ -819,6 +839,7 @@ public class ProcessExecutionResult
 		reportData = otherResult.reportData;
 
 		refreshAllAfterExecution = otherResult.refreshAllAfterExecution;
+		recreateViewSelectionAfterExecution = otherResult.recreateViewSelectionAfterExecution;
 
 		recordToSelectAfterExecution = otherResult.recordToSelectAfterExecution;
 		recordsToOpen = otherResult.recordsToOpen;

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/process/ProcessExecutionResultTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/process/ProcessExecutionResultTest.java
@@ -15,6 +15,8 @@ import org.compiere.util.Env;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.springframework.core.io.ByteArrayResource;
 
 import java.io.IOException;
@@ -75,6 +77,7 @@ public class ProcessExecutionResultTest
 	{
 		final ProcessExecutionResult result = ProcessExecutionResult.newInstanceForADPInstanceId(PInstanceId.ofRepoId(12345));
 		result.setRecordToSelectAfterExecution(createDummyTableRecordReference());
+		result.setRecreateViewSelectionAfterExecution(true);
 		result.markAsError("error summary1");
 		result.setReportData(new ByteArrayResource(new byte[] { 1, 2, 3 }), "report.pdf", "application/pdf");
 		//
@@ -129,6 +132,7 @@ public class ProcessExecutionResultTest
 		Assertions.assertEquals(result.isErrorWasReportedToUser(), resultFromJson.isErrorWasReportedToUser());
 		Assertions.assertEquals(result.isShowProcessLogs(), resultFromJson.isShowProcessLogs());
 		Assertions.assertEquals(result.isRefreshAllAfterExecution(), resultFromJson.isRefreshAllAfterExecution());
+		Assertions.assertEquals(result.isRecreateViewSelectionAfterExecution(), resultFromJson.isRecreateViewSelectionAfterExecution());
 		//
 		Assertions.assertEquals(result.getReportData(), resultFromJson.getReportData());
 		Assertions.assertEquals(result.getReportFilename(), resultFromJson.getReportFilename());
@@ -145,6 +149,18 @@ public class ProcessExecutionResultTest
 		// Assert.assertEquals(result.get, resultFromJson.get);
 
 		assertEqualsAsJson(result, resultFromJson);
+	}
+
+	/** Rebuilding the selection is the stronger request, so it must also answer the plain refresh-all question. */
+	@Test
+	public void recreatingTheSelectionImpliesRefreshAll()
+	{
+		final ProcessExecutionResult result = ProcessExecutionResult.newInstanceForADPInstanceId(PInstanceId.ofRepoId(1));
+		assertThat(result.isRefreshAllAfterExecution()).isFalse();
+
+		result.setRecreateViewSelectionAfterExecution(true);
+
+		assertThat(result.isRefreshAllAfterExecution()).isTrue();
 	}
 
 	@Test

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823260_sys_gh30811_AD_Message_PP_Order_CloseSelection_NoCompletedOrder.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823260_sys_gh30811_AD_Message_PP_Order_CloseSelection_NoCompletedOrder.sql
@@ -1,0 +1,26 @@
+-- Reason shown instead of the "close selection" action when nothing in the selection is closeable;
+-- without it the action fails at execution with a bare "@NoSelection@", i.e. reads as a malfunction.
+-- MsgType 'E' with an ErrorCode, same shape as AD_Message 545829.
+
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545832/*From ID Server*/,0,TO_TIMESTAMP('2026-09-09 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',
+        'Keiner der ausgewählten Fertigungsaufträge ist fertiggestellt. Geschlossen werden können nur fertiggestellte Aufträge.',
+        'E',TO_TIMESTAMP('2026-09-09 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,'org.eevolution.process.PP_Order_CloseSelection.NoCompletedOrderInSelection');
+
+UPDATE AD_Message SET ErrorCode='PPOrderNoCompletedOrderInSelection',
+       Updated=TO_TIMESTAMP('2026-09-09 09:00:00.500000','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100
+WHERE AD_Message_ID=545832;
+
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545832
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID);
+
+UPDATE AD_Message_Trl SET MsgText='None of the selected manufacturing orders is completed. Only completed orders can be closed.',
+       IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-09 09:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545832;
+
+-- de_DE + de_CH already carry the base text, so only the flag flips
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-09 09:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545832;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-09-09 09:00:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545832;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823280_sys_gh30811_PP_Order_Link_CostMonitor_ZoomToProductionOrder.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823280_sys_gh30811_PP_Order_Link_CostMonitor_ZoomToProductionOrder.sql
@@ -1,0 +1,132 @@
+-- Navigation from "Kostenüberwachung Fertigung" (AD_Window 542175 / AD_Tab 549352) to the manufacturing
+-- order in "Produktionsauftrag" (AD_Window 53009). Both windows sit on PP_Order, so a row click only
+-- re-opens the monitor; only a lookup carries a zoom, hence a virtual FK column holding the order's id.
+--
+-- The zoom target is AD_Ref_Table.AD_Window_ID, reachable only via AD_Reference_Value_ID
+-- (MLookupFactory.getLookup_Table) - hence a dedicated AD_Reference, modelled on 541143.
+--
+-- TRAP: AD_Column attributes are shared by every window on PP_Order. Column 593529 therefore gets
+-- exactly ONE AD_Field in the dictionary (tab 549352), IsSelectionColumn='N', IsFilterField='N' - tab
+-- 549352's Explicit filter set and window 53009 stay untouched.
+--
+-- ColumnSQL qualifies its own table like the sibling virtual columns here; SqlEntityBinding rewrites
+-- it to the alias.
+
+-- 1) AD_Element -- German in the base column, en_US as the translation override.
+INSERT INTO AD_Element (AD_Client_ID,IsActive,CreatedBy,PrintName,EntityType,ColumnName,AD_Element_ID,AD_Org_ID,Name,Description,UpdatedBy,Created,Updated)
+VALUES (0,'Y',100,'Produktionsauftrag','D','Link_PP_Order_ID',585442 /*From ID Server*/,0,
+        'Produktionsauftrag',
+        'Öffnet den Fertigungsauftrag im Fenster Produktionsauftrag.',
+        100,
+        TO_TIMESTAMP('2026-09-09 11:00:00','YYYY-MM-DD HH24:MI:SS'),
+        TO_TIMESTAMP('2026-09-09 11:00:00','YYYY-MM-DD HH24:MI:SS'))
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, PO_Name,PO_PrintName,PrintName,PO_Description,PO_Help,Help,Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Element_ID, t.PO_Name,t.PO_PrintName,t.PrintName,t.PO_Description,t.PO_Help,t.Help,t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Element_ID=585442
+AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl SET Name='Produktionsauftrag', PrintName='Produktionsauftrag',
+       Description='Öffnet den Fertigungsauftrag im Fenster Produktionsauftrag.',
+       IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-09-09 11:00:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585442 AND AD_Language IN ('de_DE','de_CH')
+;
+
+UPDATE AD_Element_Trl SET Name='Manufacturing Order', PrintName='Manufacturing Order',
+       Description='Opens the manufacturing order in the Manufacturing Order window.',
+       IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-09-09 11:00:18','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585442 AND AD_Language='en_US'
+;
+
+-- 2) The dedicated Table reference; AD_Ref_Table.AD_Window_ID=53009 is its whole point. Name is a
+--    technical identifier (System-Administrator only), so its Trl rows stay untranslated on purpose.
+INSERT INTO AD_Reference (AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,CreatedBy,UpdatedBy,Name,Description,ValidationType,EntityType,IsOrderByValue,Created,Updated)
+VALUES (542138 /*From ID Server*/,0,0,'Y',100,100,
+        'Link_PP_Order_ID',
+        'PP_Order, gezoomt auf das Fenster Produktionsauftrag (53009).',
+        'T','D','N',
+        TO_TIMESTAMP('2026-09-09 11:01:00','YYYY-MM-DD HH24:MI:SS'),
+        TO_TIMESTAMP('2026-09-09 11:01:00','YYYY-MM-DD HH24:MI:SS'))
+;
+
+INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Name,Description, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Reference_ID, t.Name,t.Description, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Reference t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Reference_ID=542138
+AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
+;
+
+-- AD_Key = PP_Order_ID (53659), AD_Display = DocumentNo (53621): the lookup shows the document number.
+INSERT INTO AD_Ref_Table (AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,CreatedBy,UpdatedBy,AD_Table_ID,AD_Key,AD_Display,IsValueDisplayed,ShowInactiveValues,AD_Window_ID,EntityType,Created,Updated)
+VALUES (542138,0,0,'Y',100,100,
+        53027,53659,53621,'N','N',
+        53009,
+        'D',
+        TO_TIMESTAMP('2026-09-09 11:01:10','YYYY-MM-DD HH24:MI:SS'),
+        TO_TIMESTAMP('2026-09-09 11:01:10','YYYY-MM-DD HH24:MI:SS'))
+;
+
+-- 3) The virtual column. AD_Reference_ID 30 (Search) + AD_Reference_Value_ID 542138 is the
+--    MLookupFactory.getLookupInfo branch that routes through AD_Ref_Table; Search not Table because
+--    PP_Order is high-volume. IsExcludeFromZoomTargets='Y': a self-reference must not be offered as a
+--    Related-Documents target, and being virtual it has no FK for ad_table_related_windows_v to walk.
+INSERT INTO AD_Column (AD_Reference_ID,AD_Reference_Value_ID,IsKey,IsParent,IsTranslated,IsIdentifier,AD_Client_ID,IsActive,CreatedBy,
+                        AD_Element_ID,IsUpdateable,IsSelectionColumn,IsSyncDatabase,IsAlwaysUpdateable,IsAllowLogging,
+                        IsEncrypted,IsExcludeFromZoomTargets,AD_Table_ID,ColumnSQL,ColumnName,AD_Column_ID,IsMandatory,AD_Org_ID,UpdatedBy,
+                        Name,Description,EntityType,FieldLength,Version,SeqNo,PersonalDataCategory,IsCalculated,Created,Updated)
+VALUES (30,542138,'N','N','N','N',0,'Y',100,
+        585442 /*From ID Server*/,'N','N','N','N','Y',
+        'N','Y',53027,
+        '(PP_Order.PP_Order_ID)',
+        'Link_PP_Order_ID',593529 /*From ID Server*/,'N',0,100,
+        'Produktionsauftrag',
+        'Öffnet den Fertigungsauftrag im Fenster Produktionsauftrag.',
+        'D',10,0,0,'NP','Y',
+        TO_TIMESTAMP('2026-09-09 11:02:00','YYYY-MM-DD HH24:MI:SS'),
+        TO_TIMESTAMP('2026-09-09 11:02:00','YYYY-MM-DD HH24:MI:SS'))
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593529
+AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- No AD_SQLColumn_SourceTableColumn: the expression reads only the record's own primary key.
+
+-- 4) The field - on tab 549352 and nowhere else. SeqNo 15 sits between DocumentNo (10) and
+--    C_DocType_ID (20) and is free on both layers. IsReadOnly='Y' (monitor is read-only, value is
+--    computed); IsFilterField='N' because tab 549352 runs IncludeFiltersStrategy='E'.
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,IsFilterField,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,593529,784962 /*From ID Server*/,0,549352,
+        TO_TIMESTAMP('2026-09-09 11:03:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','Y','N','N',
+        'Produktionsauftrag',15,15,
+        TO_TIMESTAMP('2026-09-09 11:03:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=784962
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+SELECT update_FieldTranslation_From_AD_Name_Element(585442);
+
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=784962;
+SELECT AD_Element_Link_Create_Missing_Field(784962);
+
+-- 5) The UI element - primary group of the left column (555514), next to DocumentNo.
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,784962,0,549352,555514,654728 /*From ID Server*/,'F',
+        TO_TIMESTAMP('2026-09-09 11:03:10','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N',
+        'Produktionsauftrag',15,15,0,
+        TO_TIMESTAMP('2026-09-09 11:03:10','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585442);

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5823430_sys_gh31997_M_ShipperTransportation_SalesRep_TransportDirection_lookup.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5823430_sys_gh31997_M_ShipperTransportation_SalesRep_TransportDirection_lookup.sql
@@ -1,0 +1,87 @@
+-- M_ShipperTransportation.SalesRep_ID lookup must not depend on @IsSOTrx@
+--
+-- WHY
+--   5820850_sys_M_ShipperTransportation_Drop_IsSOTrx.sql dropped M_ShipperTransportation.IsSOTrx and
+--   replaced it with TransportDirection. The SalesRep_ID lookup still resolved through AD_Reference
+--   190, whose WhereClause is
+--       (AD_User.IsSystemUser = 'Y' OR '@IsSOTrx@'='N')
+--   so the context variable it names no longer exists and WindowHealthCheckCommand reports both
+--   M_ShipperTransportation windows (540020, 541657) as NOK. The cleanup of that change was
+--   incomplete: the meaning of the flag moved to TransportDirection, the lookup did not follow.
+--
+-- WHAT THIS DOES
+--   Introduces an AD_User table reference whose restriction is the TransportDirection equivalent of
+--   the old clause, and repoints ONLY M_ShipperTransportation.SalesRep_ID (AD_Column 551101) at it.
+--
+--   The equivalence is not invented here — it is the one 5821070_..._catchup_backfill.sql used to
+--   migrate the data:
+--       IsSOTrx = 'N' (purchase) -> 'Incoming', or 'Dropship' when all orders are drop-ship
+--       IsSOTrx = 'Y' (sales)    -> 'Outgoing'
+--   so  '@IsSOTrx@'='N'  becomes  '@TransportDirection@' IN ('Incoming','Dropship').
+--   Behaviour is therefore preserved: system users always, plus every user on an incoming or
+--   drop-ship transport.
+--
+-- WHAT THIS DELIBERATELY DOES *NOT* DO
+--   * AD_Reference 190 is left untouched. Many other columns still resolve through it, and they all
+--     fall into one of two harmless groups:
+--       - the table HAS IsSOTrx (C_Invoice, C_Order, M_InOut, M_RMA, I_Invoice, I_Order,
+--         C_Invoice_Candidate) -> @IsSOTrx@ resolves normally, nothing to fix;
+--       - the table lacks IsSOTrx but its windows are listed in
+--         MissingContextVariables.KNOWN_MISSING_CONTEXT_VARIABLES_IN_LOOKUPS (C_Project 130/286/
+--         540668/540680/541015, M_Product 140/344/53010/540410, C_RfQ 315, M_Movement 170,
+--         C_SalesRegion 152, W_Store 350, M_Material_Tracking 540226, C_Phonecall_Schedule 540607,
+--         RV_R_Group_Prospect 540013, ... 39 SalesRep_ID entries in total) -> the health check
+--         deliberately suppresses the warning there.
+--     M_ShipperTransportation is the only column in NEITHER group, which is exactly why windows
+--     540020 and 541657 are the only two reported NOK. Repointing this one column therefore closes
+--     the whole defect without touching AD_Reference 190 or the allowlist.
+--   * IsAutoApplyValidationRule on AD_Column 551101 is not changed. The sibling C_BPartner fix set it
+--     to 'Y' in 5787080_c_bpartner_sales_rep_fix_LookupDescriptor.sql and reverted it to 'N' in
+--     5787160_c_bpartner_sales_rep_fix_LookupDescriptor2.sql; 'N' is the corrected end state.
+--   * It does not repoint the column at AD_Reference 540401 ('AD_User.IsSystemUser = ''Y''').
+--     That would make the health check pass by DELETING the second arm of the condition, narrowing
+--     the picker on incoming/drop-ship transports from every user to system users only.
+--
+--   AD_Ref_Table's presentation columns (AD_Key, AD_Display, IsValueDisplayed, OrderByClause,
+--   AD_Window_ID) are SELECTed from AD_Reference 190's own row rather than hardcoded, so the new
+--   reference renders identically to the old one on every instance.
+--
+-- IDs allocated from idserver.metas.de on 2026-09-09:
+--   AD_Reference     542139 (AD_User - SalesRep systemuser or incoming transport)
+--   AD_MigrationScript prefix 5823430
+
+-- 2026-09-09 12:52:39
+INSERT INTO AD_Reference (AD_Client_ID,AD_Org_ID,AD_Reference_ID,Created,CreatedBy,EntityType,IsActive,IsOrderByValue,Name,Updated,UpdatedBy,ValidationType) VALUES (0,0,542139 /*From ID Server*/,TO_TIMESTAMP('2026-09-09 12:52:39','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','N','AD_User - SalesRep systemuser or incoming transport',TO_TIMESTAMP('2026-09-09 12:52:39','YYYY-MM-DD HH24:MI:SS'),100,'T')
+;
+
+-- 2026-09-09 12:52:39
+INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Reference_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Reference t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Reference_ID=542139 AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
+;
+
+-- 2026-09-09 12:52:39
+-- Presentation copied from AD_Reference 190's row; only the WhereClause differs.
+INSERT INTO AD_Ref_Table (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,AD_Key,AD_Display,AD_Window_ID,IsValueDisplayed,OrderByClause,WhereClause,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy)
+SELECT rt.AD_Client_ID,
+       rt.AD_Org_ID,
+       542139 /*From ID Server*/,
+       rt.AD_Table_ID,
+       rt.AD_Key,
+       rt.AD_Display,
+       rt.AD_Window_ID,
+       rt.IsValueDisplayed,
+       rt.OrderByClause,
+       '(AD_User.IsSystemUser = ''Y'' OR ''@TransportDirection@'' IN (''Incoming'',''Dropship''))',
+       TO_TIMESTAMP('2026-09-09 12:52:40','YYYY-MM-DD HH24:MI:SS'),
+       100,
+       'D',
+       'Y',
+       TO_TIMESTAMP('2026-09-09 12:52:40','YYYY-MM-DD HH24:MI:SS'),
+       100
+FROM   AD_Ref_Table rt
+WHERE  rt.AD_Reference_ID = 190
+;
+
+-- 2026-09-09 12:52:39
+-- Column: M_ShipperTransportation.SalesRep_ID
+UPDATE AD_Column SET AD_Reference_Value_ID=542139 /*From ID Server*/,Updated=TO_TIMESTAMP('2026-09-09 12:52:41','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=551101
+;

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_CloseSelection.java
@@ -23,6 +23,7 @@ package org.eevolution.process;
  */
 
 import de.metas.document.engine.DocStatus;
+import de.metas.i18n.AdMessageKey;
 import de.metas.process.IProcessPrecondition;
 import de.metas.process.IProcessPreconditionsContext;
 import de.metas.process.JavaProcess;
@@ -47,6 +48,8 @@ import org.eevolution.model.I_PP_Order;
  */
 public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrecondition
 {
+	private static final AdMessageKey MSG_NoCompletedOrderInSelection = AdMessageKey.of("org.eevolution.process.PP_Order_CloseSelection.NoCompletedOrderInSelection");
+
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	private final IPPOrderBL ppOrderBL = Services.get(IPPOrderBL.class);
 
@@ -56,6 +59,12 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 		if (context.isNoSelection())
 		{
 			return ProcessPreconditionsResolution.rejectBecauseNoSelection();
+		}
+
+		// Refused WITH a reason rather than hidden: the rows look selectable, so a missing action puzzles.
+		if (!createCompletedOrdersQueryBuilder(context.getQueryFilter(I_PP_Order.class)).create().anyMatch())
+		{
+			return ProcessPreconditionsResolution.reject(MSG_NoCompletedOrderInSelection);
 		}
 
 		return ProcessPreconditionsResolution.accept();
@@ -73,7 +82,7 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 
 	private int createSelection()
 	{
-		final IQueryBuilder<I_PP_Order> queryBuilder = createCompletedOrdersQueryBuilder();
+		final IQueryBuilder<I_PP_Order> queryBuilder = createCompletedOrdersQueryBuilder(getUserSelectionFilter());
 
 		final PInstanceId adPInstanceId = getPinstanceId();
 
@@ -87,7 +96,7 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 	}
 
 	@NonNull
-	private IQueryBuilder<I_PP_Order> createCompletedOrdersQueryBuilder()
+	private IQueryFilter<I_PP_Order> getUserSelectionFilter()
 	{
 		final IQueryFilter<I_PP_Order> userSelectionFilter = getProcessInfo().getQueryFilterOrElse(null);
 
@@ -96,10 +105,16 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 			throw new AdempiereException("@NoSelection@");
 		}
 
+		return userSelectionFilter;
+	}
+
+	@NonNull
+	private IQueryBuilder<I_PP_Order> createCompletedOrdersQueryBuilder(@NonNull final IQueryFilter<I_PP_Order> userSelectionFilter)
+	{
 		return queryBL
 				.createQueryBuilder(I_PP_Order.class, getCtx(), ITrx.TRXNAME_None)
-				// The DocStatus guard belongs in the query that materializes the selection, not in the close
-				// loop: the user's selection comes from a client-side view that may be stale.
+				// DocStatus filtered here, not in the close loop: the client-side view may be stale, and
+				// sharing this builder keeps the precondition gate and the selection in agreement.
 				.addEqualsFilter(I_PP_Order.COLUMNNAME_DocStatus, DocStatus.Completed)
 				.filter(userSelectionFilter)
 				.addOnlyActiveRecordsFilter();
@@ -112,6 +127,9 @@ public class PP_Order_CloseSelection extends JavaProcess implements IProcessPrec
 	@RunOutOfTrx
 	protected String doIt()
 	{
+		// Closed orders leave a monitor scoped to completed ones only if the selection is rebuilt.
+		getResult().setRecreateViewSelectionAfterExecution(true);
+
 		final PPOrderCloseResult result = ppOrderBL.closeOrdersInSelection(getPinstanceId());
 
 		final String summary = "@Processed@ (OK=#" + result.getCountClosed() + ", Error=#" + result.getCountFailed() + ")";

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_PostCalculation.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/process/PP_Order_PostCalculation.java
@@ -88,6 +88,9 @@ public class PP_Order_PostCalculation extends JavaProcess implements IProcessPre
 	@Override
 	protected String doIt()
 	{
+		// Distributing closes the order, so it leaves the monitor only if the selection is rebuilt.
+		getResult().setRecreateViewSelectionAfterExecution(true);
+
 		final PPOrderId ppOrderId = getPPOrderId();
 
 		costDifferenceDistributor.distribute(ppOrderId);

--- a/backend/de.metas.manufacturing/src/test/java/org/eevolution/process/PP_Order_CloseSelectionTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/org/eevolution/process/PP_Order_CloseSelectionTest.java
@@ -1,0 +1,213 @@
+/*
+ * #%L
+ * de.metas.manufacturing
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.eevolution.process;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.document.engine.DocStatus;
+import de.metas.i18n.AdMessageKey;
+import de.metas.organization.OrgId;
+import de.metas.process.IProcessPreconditionsContext;
+import de.metas.process.ProcessPreconditionsResolution;
+import de.metas.process.SelectionSize;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryFilter;
+import org.adempiere.ad.element.api.AdTabId;
+import org.adempiere.ad.element.api.AdWindowId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.util.Env;
+import de.metas.process.PInstanceId;
+import de.metas.process.ProcessInfo;
+import de.metas.util.Services;
+import org.mockito.Mockito;
+import org.compiere.model.I_AD_PInstance;
+import org.compiere.model.I_AD_Process;
+import org.compiere.model.X_AD_Process;
+import org.eevolution.api.IPPOrderBL;
+import org.eevolution.api.PPOrderCloseResult;
+import org.eevolution.model.I_PP_Order;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Covers the precondition gate of {@link PP_Order_CloseSelection}. */
+@ExtendWith(AdempiereTestWatcher.class)
+class PP_Order_CloseSelectionTest
+{
+	private static final AdMessageKey MSG_NoCompletedOrderInSelection = AdMessageKey.of("org.eevolution.process.PP_Order_CloseSelection.NoCompletedOrderInSelection");
+
+	private final ClientId clientId = ClientId.ofRepoId(1);
+	private final OrgId orgId = OrgId.ofRepoId(0);
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		Env.setClientId(Env.getCtx(), clientId);
+		Env.setOrgId(Env.getCtx(), orgId);
+	}
+
+	@Test
+	void offered_whenTheSelectionHasACompletedOrder()
+	{
+		assertThat(checkPreconditions(ppOrder(DocStatus.Completed)).isRejected()).isFalse();
+	}
+
+	/** One closeable order is enough: the others are skipped by the selection query, not by this gate. */
+	@Test
+	void offered_whenOnlySomeOfTheSelectedOrdersAreCompleted()
+	{
+		assertThat(checkPreconditions(ppOrder(DocStatus.Closed), ppOrder(DocStatus.Completed), ppOrder(DocStatus.Drafted)).isRejected()).isFalse();
+	}
+
+	@Test
+	void notOffered_whenEverySelectedOrderIsAlreadyClosed()
+	{
+		final ProcessPreconditionsResolution resolution = checkPreconditions(ppOrder(DocStatus.Closed), ppOrder(DocStatus.Closed));
+
+		assertThat(resolution.isRejected()).isTrue();
+		// the reason must reach the WebUI as a translated message, not be filtered out as internal
+		assertThat(resolution.isInternal()).isFalse();
+		// PlainMsgBL renders an un-parameterised AD_Message as its key, pinning the reason to the message
+		assertThat(resolution.getRejectReason().getDefaultValue()).isEqualTo(MSG_NoCompletedOrderInSelection.toAD_Message());
+	}
+
+	@Test
+	void notOffered_whenNoSelectedOrderIsCompleted()
+	{
+		assertThat(checkPreconditions(ppOrder(DocStatus.Drafted), ppOrder(DocStatus.InProgress)).isRejected()).isTrue();
+	}
+
+	@Test
+	void notOffered_whenNothingIsSelected()
+	{
+		assertThat(checkPreconditions().isRejected()).isTrue();
+	}
+
+	/**
+	 * Pins the two flags {@code doIt()} sets. Dropping either one silently reintroduces the stale-row bug:
+	 * the WebUI would stop rebuilding the selection, the Swing client would stop re-running the tab query.
+	 */
+	@Test
+	void doIt_asksTheClientToRebuildItsView()
+	{
+		final IPPOrderBL ppOrderBL = Mockito.mock(IPPOrderBL.class);
+		Mockito.when(ppOrderBL.closeOrdersInSelection(Mockito.any()))
+				.thenReturn(PPOrderCloseResult.builder().countClosed(1).countFailed(0).build());
+		Services.registerService(IPPOrderBL.class, ppOrderBL);
+
+		final I_AD_Process adProcess = InterfaceWrapperHelper.newInstance(I_AD_Process.class);
+		adProcess.setValue("PP_Order_CloseSelection");
+		adProcess.setName("Auswahl schliessen");
+		adProcess.setClassname(PP_Order_CloseSelection.class.getName());
+		adProcess.setType(X_AD_Process.TYPE_Java);
+		InterfaceWrapperHelper.saveRecord(adProcess);
+
+		final I_AD_PInstance pinstance = InterfaceWrapperHelper.newInstance(I_AD_PInstance.class);
+		InterfaceWrapperHelper.saveRecord(pinstance);
+
+		final ProcessInfo processInfo = ProcessInfo.builder()
+				.setCtx(Env.getCtx())
+				.setPInstanceId(PInstanceId.ofRepoId(pinstance.getAD_PInstance_ID()))
+				.setAD_Process_ID(adProcess.getAD_Process_ID())
+				.build();
+		final PP_Order_CloseSelection process = new PP_Order_CloseSelection();
+		process.init(processInfo);
+
+		process.doIt();
+
+		assertThat(processInfo.getResult().isRecreateViewSelectionAfterExecution()).isTrue();
+		assertThat(processInfo.getResult().isRefreshAllAfterExecution()).isTrue();
+	}
+
+	private I_PP_Order ppOrder(@NonNull final DocStatus docStatus)
+	{
+		final I_PP_Order ppOrder = InterfaceWrapperHelper.newInstance(I_PP_Order.class);
+		InterfaceWrapperHelper.setValue(ppOrder, I_PP_Order.COLUMNNAME_AD_Client_ID, clientId.getRepoId());
+		ppOrder.setAD_Org_ID(orgId.getRepoId());
+		ppOrder.setDocStatus(docStatus.getCode());
+		InterfaceWrapperHelper.saveRecord(ppOrder);
+		return ppOrder;
+	}
+
+	private ProcessPreconditionsResolution checkPreconditions(@NonNull final I_PP_Order... selectedOrders)
+	{
+		return new PP_Order_CloseSelection()
+				.checkPreconditionsApplicable(new PreconditionsContext(Arrays.asList(selectedOrders)));
+	}
+
+	/** minimal stand-in for the WebUI's view context; only the selection is relevant to the gate */
+	private static class PreconditionsContext implements IProcessPreconditionsContext
+	{
+		private final ImmutableList<I_PP_Order> selectedRecords;
+		private final Set<Integer> selectedRecordIds;
+
+		PreconditionsContext(@NonNull final List<I_PP_Order> selectedRecords)
+		{
+			this.selectedRecords = ImmutableList.copyOf(selectedRecords);
+			this.selectedRecordIds = selectedRecords.stream().map(I_PP_Order::getPP_Order_ID).collect(ImmutableSet.toImmutableSet());
+		}
+
+		@Override
+		public AdWindowId getAdWindowId() {return null;}
+
+		@Override
+		public AdTabId getAdTabId() {return null;}
+
+		@Override
+		public String getTableName() {return I_PP_Order.Table_Name;}
+
+		@Override
+		public <T> T getSelectedModel(final Class<T> modelClass) {throw new UnsupportedOperationException();}
+
+		@Override
+		public <T> List<T> getSelectedModels(final Class<T> modelClass) {throw new UnsupportedOperationException();}
+
+		@NonNull
+		@Override
+		public <T> Stream<T> streamSelectedModels(@NonNull final Class<T> modelClass) {throw new UnsupportedOperationException();}
+
+		@Override
+		public int getSingleSelectedRecordId() {return selectedRecords.get(0).getPP_Order_ID();}
+
+		@Override
+		public SelectionSize getSelectionSize() {return SelectionSize.ofSize(selectedRecords.size());}
+
+		/** the view's selection reaches the process as a filter, never as loaded models */
+		@Override
+		public <T> IQueryFilter<T> getQueryFilter(@NonNull final Class<T> recordClass)
+		{
+			return model -> selectedRecordIds.contains(InterfaceWrapperHelper.getId(model));
+		}
+	}
+}

--- a/backend/de.metas.manufacturing/src/test/java/org/eevolution/process/PP_Order_PostCalculationTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/org/eevolution/process/PP_Order_PostCalculationTest.java
@@ -39,6 +39,11 @@ import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ClientId;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
+import de.metas.process.PInstanceId;
+import de.metas.process.ProcessInfo;
+import org.compiere.model.I_AD_PInstance;
+import org.compiere.model.I_AD_Process;
+import org.compiere.model.X_AD_Process;
 import org.compiere.SpringContextHolder;
 import org.compiere.util.Env;
 import org.eevolution.model.I_PP_Order;
@@ -78,11 +83,46 @@ class PP_Order_PostCalculationTest
 
 		finishedGoodId = BusinessTestHelper.createProductId("finished good", BusinessTestHelper.createUomEach());
 
-		// the process resolves it in a field initializer; doIt() is not under test here
+		// the process resolves it in a field initializer
 		costDifferenceDistributor = Mockito.mock(PPOrderCostDifferenceDistributor.class);
 		SpringContextHolder.registerJUnitBean(PPOrderCostDifferenceDistributor.class, costDifferenceDistributor);
 		// default to "something was issued" so each test exercises only the condition it names
 		Mockito.when(costDifferenceDistributor.hasInboundCosts(Mockito.any())).thenReturn(true);
+	}
+
+	/**
+	 * Pins the two flags {@code doIt()} sets — see {@code ProcessExecutionResult.recreateViewSelectionAfterExecution}.
+	 * Dropping either one silently leaves the discharged order sitting in the monitor.
+	 */
+	@Test
+	void doIt_asksTheClientToRebuildItsView()
+	{
+		final I_PP_Order ppOrder = ppOrder(DocStatus.Completed);
+
+		final I_AD_Process adProcess = InterfaceWrapperHelper.newInstance(I_AD_Process.class);
+		adProcess.setValue("PP_Order_PostCalculation");
+		adProcess.setName("Nachberechnung");
+		adProcess.setClassname(PP_Order_PostCalculation.class.getName());
+		adProcess.setType(X_AD_Process.TYPE_Java);
+		InterfaceWrapperHelper.saveRecord(adProcess);
+
+		final I_AD_PInstance pinstance = InterfaceWrapperHelper.newInstance(I_AD_PInstance.class);
+		InterfaceWrapperHelper.saveRecord(pinstance);
+
+		final ProcessInfo processInfo = ProcessInfo.builder()
+				.setCtx(Env.getCtx())
+				.setPInstanceId(PInstanceId.ofRepoId(pinstance.getAD_PInstance_ID()))
+				.setAD_Process_ID(adProcess.getAD_Process_ID())
+				.setRecord(I_PP_Order.Table_Name, ppOrder.getPP_Order_ID())
+				.build();
+
+		final PP_Order_PostCalculation process = new PP_Order_PostCalculation();
+		process.init(processInfo);
+
+		process.doIt();
+
+		assertThat(processInfo.getResult().isRecreateViewSelectionAfterExecution()).isTrue();
+		assertThat(processInfo.getResult().isRefreshAllAfterExecution()).isTrue();
 	}
 
 	@Test

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
@@ -130,7 +130,9 @@ public class ADProcessPostProcessService
 
 		//
 		// Refresh all
-		boolean viewInvalidateAllCalled = false;
+		boolean viewFullyInvalidated = false;
+
+		final boolean recreateViewSelection = processExecutionResult.isRecreateViewSelectionAfterExecution();
 
 		if (processExecutionResult.isRefreshAllAfterExecution())
 		{
@@ -138,10 +140,20 @@ public class ADProcessPostProcessService
 
 			if (view != null)
 			{ // multiple rows selected
-				view.invalidateAll();
-				ViewChangesCollector.getCurrentOrAutoflush()
-						.collectFullyChanged(view);
-				viewInvalidateAllCalled = true;
+				if (recreateViewSelection)
+				{
+					// Rebuilds the selection so records the process moved out of scope actually leave it.
+					// Resets the row cache and collects the change event itself, so the else-branch must
+					// not also run.
+					view.invalidateSelection();
+				}
+				else
+				{
+					view.invalidateAll();
+					ViewChangesCollector.getCurrentOrAutoflush()
+							.collectFullyChanged(view);
+				}
+				viewFullyInvalidated = true;
 
 				documentsCollection.invalidateDocumentsByWindowId(view.getViewId().getWindowId());
 			}
@@ -161,7 +173,7 @@ public class ADProcessPostProcessService
 			documentsCollection.invalidateDocumentByRecordId(recordToRefresh.getTableName(), recordToRefresh.getRecord_ID());
 
 			final IView view = viewSupplier.get();
-			if (!viewInvalidateAllCalled && view != null)
+			if (!viewFullyInvalidated && view != null)
 			{
 				final boolean watchedByFrontend = viewsRepo.isWatchedByFrontend(view.getViewId());
 				view.notifyRecordsChanged(TableRecordReferenceSet.of(recordToRefresh), watchedByFrontend);

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessServiceTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessServiceTest.java
@@ -1,0 +1,160 @@
+/*
+ * #%L
+ * metasfresh-webui-api
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ui.web.process.adprocess;
+
+import de.metas.process.PInstanceId;
+import de.metas.process.ProcessExecutionResult;
+import de.metas.process.ProcessInfo;
+import de.metas.ui.web.view.IView;
+import de.metas.ui.web.view.IViewsRepository;
+import de.metas.ui.web.view.ViewId;
+import de.metas.ui.web.window.datatypes.WindowId;
+import de.metas.ui.web.window.model.DocumentCollection;
+import de.metas.websocket.sender.WebsocketSender;
+import de.metas.user.UserId;
+import lombok.NonNull;
+
+import java.util.function.Consumer;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_AD_PInstance;
+import org.compiere.model.I_AD_Process;
+import org.compiere.model.X_AD_Process;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Covers how {@link ADProcessPostProcessService} invalidates the view a process was run from. */
+@ExtendWith(AdempiereTestWatcher.class)
+class ADProcessPostProcessServiceTest
+{
+	private static final WindowId windowId = WindowId.of(542175);
+
+	private IViewsRepository viewsRepo;
+	private IView view;
+	private ViewId viewId;
+	private ADProcessPostProcessService postProcessService;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		// ProcessInfo.builder() resolves the logged user eagerly
+		Env.setLoggedUserId(Env.getCtx(), UserId.METASFRESH);
+		// the plain-refresh branch broadcasts the view change itself, which needs the websocket bean
+		SpringContextHolder.registerJUnitBean(WebsocketSender.class, Mockito.mock(WebsocketSender.class));
+
+		viewId = ViewId.random(windowId);
+		view = Mockito.mock(IView.class);
+		Mockito.when(view.getViewId()).thenReturn(viewId);
+
+		viewsRepo = Mockito.mock(IViewsRepository.class);
+		Mockito.when(viewsRepo.getViewIfExists(viewId)).thenReturn(view);
+
+		postProcessService = ADProcessPostProcessService.builder()
+				.viewsRepo(viewsRepo)
+				.documentsCollection(Mockito.mock(DocumentCollection.class))
+				.build();
+	}
+
+	@Test
+	void viewIsLeftAlone_whenTheProcessAsksForNothing()
+	{
+		postProcess(result -> {});
+
+		Mockito.verify(view, Mockito.never()).invalidateSelection();
+		Mockito.verify(view, Mockito.never()).invalidateAll();
+	}
+
+	@Test
+	void selectionIsRecreated_whenTheProcessAsksForIt()
+	{
+		postProcess(result -> result.setRecreateViewSelectionAfterExecution(true));
+
+		Mockito.verify(view).invalidateSelection();
+		// invalidateSelection() resets the row cache and broadcasts itself; invalidateAll() would duplicate
+		Mockito.verify(view, Mockito.never()).invalidateAll();
+	}
+
+	/** Both processes of the cost monitor set both flags, for the sake of the Swing client. */
+	@Test
+	void onlyTheSelectionIsRecreated_whenTheProcessAsksForBoth()
+	{
+		postProcess(result -> {
+			result.setRecreateViewSelectionAfterExecution(true);
+			result.setRefreshAllAfterExecution(true);
+		});
+
+		Mockito.verify(view).invalidateSelection();
+		Mockito.verify(view, Mockito.never()).invalidateAll();
+	}
+
+	@Test
+	void onlyTheRowsAreReRead_whenTheProcessAsksForAPlainRefresh()
+	{
+		postProcess(result -> result.setRefreshAllAfterExecution(true));
+
+		Mockito.verify(view).invalidateAll();
+		Mockito.verify(view, Mockito.never()).invalidateSelection();
+	}
+
+	private void postProcess(@NonNull final Consumer<ProcessExecutionResult> resultCustomizer)
+	{
+		final ProcessInfo processInfo = ProcessInfo.builder()
+				.setCtx(Env.getCtx())
+				.setAD_Process_ID(createAdProcess())
+				.setPInstanceId(createPInstanceId())
+				.build();
+
+		resultCustomizer.accept(processInfo.getResult());
+
+		postProcessService.postProcess(ADProcessPostProcessRequest.builder()
+				.viewId(viewId)
+				.processInfo(processInfo)
+				.processExecutionResult(processInfo.getResult())
+				.build());
+	}
+
+	private PInstanceId createPInstanceId()
+	{
+		final I_AD_PInstance pinstance = InterfaceWrapperHelper.newInstance(I_AD_PInstance.class);
+		InterfaceWrapperHelper.saveRecord(pinstance);
+		return PInstanceId.ofRepoId(pinstance.getAD_PInstance_ID());
+	}
+
+	private int createAdProcess()
+	{
+		final I_AD_Process adProcess = InterfaceWrapperHelper.newInstance(I_AD_Process.class);
+		adProcess.setValue("TestProcess");
+		adProcess.setName("TestProcess");
+		adProcess.setType(X_AD_Process.TYPE_Java);
+		InterfaceWrapperHelper.saveRecord(adProcess);
+		return adProcess.getAD_Process_ID();
+	}
+}

--- a/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
+++ b/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
@@ -7,6 +7,8 @@ import { DashboardPage } from '../utils/pages/DashboardPage';
 import { MasterWindowPage } from '../utils/pages/MasterWindowPage';
 
 const COST_IMBALANCE_WINDOW_ID = 542175;
+// Both windows sit on PP_Order, so a row click cannot reach the order - hence the zoom field.
+const PRODUCTION_ORDER_WINDOW_ID = 53009;
 
 // The filter bar carries no data-testid, so it is addressed by the language-invariant structural
 // classes the frontend derives from the identifiers (`form-field-<ColumnName>` per widget).
@@ -154,14 +156,16 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
     allure.epic('E0226: Costing');
     allure.tag('F1500: Costing');
     allure.tag('F1500');
-    allure.story('PP_Order_CloseSelection is a quick action of the cost-imbalance monitor');
+    allure.story('PP_Order_CloseSelection is a quick action of the cost-imbalance monitor and refreshes it in place');
     allure.severity('normal');
     allure.description(
       'The monitor lists completed-but-not-closed manufacturing orders and its tab carries no DocAction ' +
         'field, so a balanced order could not be closed from it at all. Verifies the new ' +
         '"Auswahl schliessen" / "Close selection" quick action end to end: it is offered on this window, ' +
         'running it on the selected order closes it, and the closed order consequently drops out of the ' +
-        'monitor. Also guards the window-scoped demotion of the Issue/Receipt launcher: it is still ' +
+        'monitor in place -- with no reload and no re-navigation, so the assertion covers the view ' +
+        'refresh and not merely the tab filter. Also guards the window-scoped demotion of the ' +
+        'Issue/Receipt launcher: it is still ' +
         'offered here but is no longer the default quick action -- a default action always sorts to the ' +
         'front of the action list, so the launcher not being first proves the demotion in any language.'
     );
@@ -211,6 +215,13 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
       // simply absent here. It is covered by the costing cucumber scenarios.
     });
 
+    // Survives an SPA re-render but not a reload: that is what makes the assertions below refresh
+    // coverage - a freshly opened window would pass either way, proving only the tab's filter.
+    const pageLoadMarker = await page.evaluate(() => {
+      window.__pageLoadMarker = Math.random().toString(36);
+      return window.__pageLoadMarker;
+    });
+
     await test.step('Run Close selection', async () => {
       // Running a quick action is two calls: the POST only creates the pinstance, the follow-up
       // /start executes the process. Awaiting the POST would read the result back before it commits.
@@ -219,15 +230,95 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
       await processExecuted;
     });
 
-    // Read back from a FRESH view: the tab is scoped to DocStatus='CO', so a closed order is gone.
-    await MasterWindowPage.goto(COST_IMBALANCE_WINDOW_ID);
-    await MasterWindowPage.expectWindowLoaded();
-    await applyMonitorFilter({ page, documentNo });
-    await expect(page.locator(EMPTY_RESULT)).toBeVisible();
-    await expect(page.locator(TABLE_ROWS).filter({ hasText: documentNo })).toHaveCount(0);
+    await test.step('The closed order leaves the monitor in place, without reloading the page', async () => {
+      // The process rebuilds the selection, so the closed order drops out of the list on its own.
+      await expect(page.locator(EMPTY_RESULT)).toBeVisible({ timeout: 30_000 });
+      await expect(page.locator(TABLE_ROWS).filter({ hasText: documentNo })).toHaveCount(0);
+      expect(await page.evaluate(() => window.__pageLoadMarker)).toBe(pageLoadMarker);
+    });
 
     console.log(
-      `Manufacturing order ${documentNo} closed via PP_Order_CloseSelection and left the cost-imbalance monitor`
+      `Manufacturing order ${documentNo} closed via PP_Order_CloseSelection and left the cost-imbalance monitor in place`
+    );
+  });
+
+  test('Produktionsauftrag field zooms from the monitor into the Produktionsauftrag window', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    allure.epic('E0226: Costing');
+    allure.tag('F1500: Costing');
+    allure.tag('F1500');
+    allure.story('The cost-imbalance monitor can navigate to the full manufacturing order');
+    allure.severity('normal');
+    allure.description(
+      'The monitor is a read-only list over PP_Order and the Produktionsauftrag window (53009) is a ' +
+        'second window over the SAME table, so clicking a monitor row only re-opens it in the monitor -- ' +
+        'a controller had no way to reach the full order. Verifies the new "Produktionsauftrag" field in ' +
+        'successful action: it renders as a grid column showing the order\'s document number, and zooming ' +
+        'it lands on window 53009 on that same order. The landing window is the whole point: a lookup ' +
+        'pointing back at its own table could plausibly resolve to the window the user is already in, so ' +
+        'the assertion is on the target window id, not merely that "a zoom happened".'
+    );
+
+    const { masterdata, documentNo } = await seedCompletedManufacturingOrder();
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await DashboardPage.expectVisible();
+
+    await MasterWindowPage.goto(COST_IMBALANCE_WINDOW_ID);
+    await MasterWindowPage.expectWindowLoaded();
+
+    // Narrow to exactly the seeded order so the cell we right-click is unambiguously its cell.
+    await applyMonitorFilter({ page, documentNo });
+    await expect(page.locator(TABLE_ROWS)).toHaveCount(1);
+
+    // Selecting on ColumnName keeps this language-independent.
+    await expect(page.locator('th[data-testid="column-Link_PP_Order_ID"]')).toHaveCount(1);
+
+    const zoomCell = page.locator(TABLE_ROWS).first().locator('[data-cy="cell-Link_PP_Order_ID"]');
+    await expect(zoomCell).toHaveCount(1);
+    // AD_Ref_Table.AD_Display is PP_Order.DocumentNo, so the link is labelled with the document number.
+    await expect(zoomCell).toContainText(documentNo);
+
+    await test.step('Zoom Into is offered on the field', async () => {
+      await zoomCell.click({ button: 'right' });
+      await expect(page.locator('.context-menu-open')).toBeVisible();
+    });
+
+    // The menu caption is translated; the icon is not, so address the entry by its icon.
+    const zoomIntoItem = page.locator('.context-menu-open .context-menu-item').filter({
+      has: page.locator('i.meta-icon-share'),
+    });
+    await expect(zoomIntoItem).toHaveCount(1);
+
+    // This endpoint IS the window resolution under test, so assert it, not only where routing lands.
+    const zoomResolved = page.waitForResponse(
+      (response) =>
+        response.url().includes('/field/Link_PP_Order_ID/zoomInto') && response.status() === 200
+    );
+    // A grid zoom opens the target in a NEW TAB (containers/Table.js handleZoomInto ->
+    // window.open(url, '_blank')), so the assertion is on the popup, not on this page's URL.
+    const orderTabOpened = page.context().waitForEvent('page');
+
+    await zoomIntoItem.click();
+
+    const zoomResponse = await zoomResolved;
+    const zoomPayload = await zoomResponse.json();
+    expect(String(zoomPayload.documentPath.windowId)).toBe(String(PRODUCTION_ORDER_WINDOW_ID));
+
+    const orderTab = await orderTabOpened;
+    await orderTab.waitForLoadState('domcontentloaded');
+
+    // The landing window is the point of the whole change: 53009, never back into 542175.
+    expect(orderTab.url()).toMatch(new RegExp(`/window/${PRODUCTION_ORDER_WINDOW_ID}/\\d+`));
+    expect(orderTab.url()).not.toMatch(new RegExp(`/window/${COST_IMBALANCE_WINDOW_ID}(/|$)`));
+
+    // Same order, not just the right window.
+    await expect(orderTab.locator(`text=${documentNo}`).first()).toBeVisible({ timeout: 60_000 });
+
+    console.log(
+      `Manufacturing order ${documentNo} zoomed from monitor ${COST_IMBALANCE_WINDOW_ID} into window ${PRODUCTION_ORDER_WINDOW_ID}`
     );
   });
 });


### PR DESCRIPTION
Forward-merge of the `intensive_care_release` line into `new_dawn_uat`.

**!!Don't squash please!!** — this is a merge-through, and squashing it would drop the branch relationship that later propagation checks rely on (a squash creates a new commit, so `git merge-base --is-ancestor` can no longer prove the line arrived).

### What it carries

The whole release line, not one issue's commit — every commit on `intensive_care_release` is destined for `new_dawn_uat`, so the breadth is the propagation working as designed:

- the `M_ShipperTransportation.SalesRep_ID` lookup fix from https://github.com/metasfresh/metasfresh/pull/25891 — migration `5823430_sys_gh31997_M_ShipperTransportation_SalesRep_TransportDirection_lookup.sql`, which replaces the dependency on the dropped `IsSOTrx` column with `@TransportDirection@`
- the `intensive_care_hotfix` → `intensive_care_release` merge chain (https://github.com/metasfresh/metasfresh/pull/25817)
- the manufacturing cost monitor changes from https://github.com/metasfresh/metasfresh/pull/25882

### Why this branch, not a new one

`merge/intensive_care_release-to-new_dawn_uat` is the existing rolling merge-train branch; its head was frozen at the previous round (https://github.com/metasfresh/metasfresh/pull/25824) and had already been fully merged into `new_dawn_uat`. Advancing it keeps one propagation path for this line rather than opening a parallel one.

The auto-port refresh had not yet run for the new head — its trigger is a successful `cicd` on the source branch, and that run (https://github.com/metasfresh/metasfresh/actions/runs/34370307469) was still queued. Dry-merged locally first: zero conflicts, so the train was awaiting a tick rather than conflict-stuck.

### Note on the lookup fix

The migration adds a new `AD_Reference` rather than repointing the column at an existing one. Reference 190's clause has two arms — `(AD_User.IsSystemUser = 'Y' OR '@IsSOTrx@'='N')` — and the single-arm alternative would have gone green while narrowing the `SalesRep_ID` picker on incoming and drop-ship transports from every user to system users only. The replacement keeps both arms:

```sql
(AD_User.IsSystemUser = 'Y' OR '@TransportDirection@' IN ('Incoming','Dropship'))
```

The equivalence is structural: the backfill in `5821070` derives `Incoming`/`Dropship` only from orders with `IsSOTrx = 'N'` and `Outgoing` only from `IsSOTrx = 'Y'`. `AD_Reference` 190 itself is left untouched, and no allowlist entry is added.
