### PR TITLE
Merge: soft_panda_hotfix -> soft_panda_release (EDI DESADV pack assertions)

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/externalSystemBased/ediDesadvExportViaExternalSystem.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/externalSystemBased/ediDesadvExportViaExternalSystem.feature
@@ -844,6 +844,14 @@ Feature: EDI DESADV export via External System
   ## at shipment completion, by DesadvBL.addToDesadvCreateForInOutIfNotExist via its C_Order fallback.
   ## That fallback creates the EDI_DesadvLines only at that moment, so the delivered quantities have to
   ## be derived AFTER they exist — otherwise the recipient receives a DESADV announcing zero delivered.
+    # Eleven scenarios before this one complete shipments for the Background's shared EDI-recipient
+    # customer1, silently creating EDI_Desadv_Pack / EDI_Desadv_Pack_Item rows as a side effect of the
+    # M_InOut before-complete interceptor (nothing in those scenarios asserts packs, so nothing cleans
+    # them up). Reset both tables here, before anything else in this scenario runs, so the pack
+    # assertions below see only what THIS scenario creates.
+    And metasfresh initially has no EDI_Desadv_Pack_Item data
+    And metasfresh initially has no EDI_Desadv_Pack data
+
     And RabbitMQ MF_TO_ExternalSystem queue is purged
 
     # POReference is deliberately absent here: that is what keeps the order out of the DESADV at
@@ -897,6 +905,24 @@ Feature: EDI DESADV export via External System
     And EDI_DesadvLine records are found:
       | EDI_DesadvLine_ID | EDI_Desadv_ID | M_Product_ID | OPT.QtyEntered | OPT.QtyDeliveredInUOM | OPT.QtyDeliveredInStockingUOM |
       | d_l_80            | d_80          | product        | 3              | 3                     | 3                             |
+
+    # ─── CORE ASSERTION (regression guard) ──────────────────────────────────
+    # The bug this scenario guards against: the retro-created DESADV reached the clearing centre with
+    # delivered quantities but ZERO EDI_Desadv_Pack rows (root cause: the second
+    # addInOutLinesToDesadvLines walk in DesadvBL was never invoked for this path). o_80 has a single
+    # order line, so d_80 has exactly one EDI_DesadvLine (d_l_80) — the pack below must belong to d_80,
+    # and its single item must carry the shipment line (s_l_80) that fulfils d_l_80.
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed | OPT.C_OrderLine_ID.Identifier |
+      | s_l_80                    | s_80                  | product                 | 3           | true      | ol_80_1                       |
+
+    And after not more than 60s, EDI_Desadv_Pack records are found:
+      | EDI_Desadv_Pack_ID.Identifier | EDI_Desadv_ID.Identifier | IsManual_IPA_SSCC18 | SeqNo |
+      | d_p_80                        | d_80                     | true                | 1     |
+
+    And after not more than 60s, the EDI_Desadv_Pack_Item has only the following records:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | M_InOutLine_ID | QtyItemCapacity | OPT.QtyTU |
+      | d_pi_80                 | d_p_80             | 3           | s_l_80         | 0               | 1         |
 
 
   @from:cucumber

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
@@ -67,8 +67,12 @@ import java.util.Properties;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack.COLUMNNAME_IPA_SSCC18;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_BestBeforeDate;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_ID;
+import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_DesadvLine_ID;
+import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_M_InOutLine_ID;
+import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_MovementQty;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerLU;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerTU;
+import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyItemCapacity;
 import static de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyTU;
 import static java.math.BigDecimal.TEN;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
@@ -758,6 +762,24 @@ class DesadvBL_addToDesadvCreateForInOutIfNotExist_Test
 		InterfaceWrapperHelper.refresh(result);
 		assertThat(result.getSumDeliveredInStockingUOM()).isEqualByComparingTo("3");
 		assertThat(result.getFulfillmentPercent()).isEqualByComparingTo("100");
+
+		// the EDI export is rejected by the clearing centre when a DESADV carries delivered qtys
+		// but no packs -- so the fallback-created DESADV must also get its EDI_Desadv_Pack(_Item) rows.
+		final List<I_EDI_Desadv_Pack> packRecords = POJOLookupMap.get().getRecords(I_EDI_Desadv_Pack.class);
+		assertThat(packRecords)
+				.as("exactly one pack must have been created for the DESADV that was built at shipment completion (one TU, one pack)")
+				.hasSize(1);
+		assertThat(packRecords)
+				.as("every pack found must belong to the DESADV created for this shipment")
+				.allMatch(pack -> pack.getEDI_Desadv_ID() == result.getEDI_Desadv_ID());
+
+		final List<I_EDI_Desadv_Pack_Item> packItemRecords = POJOLookupMap.get().getRecords(I_EDI_Desadv_Pack_Item.class);
+		assertThat(packItemRecords)
+				.as("a pack item must reference both the created DESADV line and the shipment line, with its shipped qty, TU count and TU capacity")
+				.extracting(COLUMNNAME_EDI_DesadvLine_ID, COLUMNNAME_M_InOutLine_ID, COLUMNNAME_MovementQty, COLUMNNAME_QtyTU, COLUMNNAME_QtyItemCapacity)
+				.containsOnly(
+						tuple(createdLine.getEDI_DesadvLine_ID(), shipmentLine.getM_InOutLine_ID(), new BigDecimal("3"), 1, new BigDecimal("5"))
+				);
 	}
 
 	private void changeDesadvLineToCOLIasUOM()


### PR DESCRIPTION
Forward-merge of `soft_panda_hotfix` into `soft_panda_release`, hop 1 of 2 on the way to `new_dawn_uat`.

Carries one commit: https://github.com/metasfresh/metasfresh/commit/179466e1bb0 — pack assertions for the DESADV created at shipment completion (test-only, 2 files under `src/test/`, +48/-0). No production code, no migrations.

The merge is clean — no conflicts, and the diff against `soft_panda_release` is exactly those two test files.

**Merge with a merge commit, not squash.** This is a merge-through PR: squashing it would collapse the merge and destroy the parent relationship between the two branches, so every future `soft_panda_hotfix` → `soft_panda_release` merge would re-conflict on already-merged changes.
