### PR TITLE
Quick input: Enter confirms the empty packing instruction and advances

### DIFF
--- a/e2e/frontend-webui/tests/spec/quick-input.spec.js
+++ b/e2e/frontend-webui/tests/spec/quick-input.spec.js
@@ -668,8 +668,8 @@ Continuous keyboard entry: line1 → line2 → ... without reopening batch entry
        * packing-instruction sub-field. Quantity is typed WITHOUT clicking, so the assertion
        * that it lands in Menge is the proof that focus advanced (TC8 step 5).
        */
-      const enterOneLine = async (escapeKeys, qty, label) => {
-        await test.step(`Line ${qty}: ${label}`, async () => {
+      const enterOneLine = async (escapeKeys, qty, stepLabel) => {
+        await test.step(`Line ${qty}: ${stepLabel}`, async () => {
           await test.step('Type the product code, press Enter', async () => {
             await typeProductAndWaitForDropdown(page, productCode);
             await page.keyboard.press('Enter');
@@ -678,7 +678,7 @@ Continuous keyboard entry: line1 → line2 → ... without reopening batch entry
           });
 
           await test.step(
-            `Packvorschrift has no value - press ${label}`,
+            `Packvorschrift has no value - press ${stepLabel}`,
             async () => {
               for (const key of escapeKeys) {
                 if (key.startsWith('type:')) {

--- a/e2e/frontend-webui/tests/spec/quick-input.spec.js
+++ b/e2e/frontend-webui/tests/spec/quick-input.spec.js
@@ -668,57 +668,89 @@ Continuous keyboard entry: line1 → line2 → ... without reopening batch entry
        * packing-instruction sub-field. Quantity is typed WITHOUT clicking, so the assertion
        * that it lands in Menge is the proof that focus advanced (TC8 step 5).
        */
-      const enterOneLine = async (escapeKeys, qty) => {
-        await typeProductAndWaitForDropdown(page, productCode);
-        await page.keyboard.press('Enter');
-        await page.waitForTimeout(1500);
+      const enterOneLine = async (escapeKeys, qty, label) => {
+        await test.step(`Line ${qty}: ${label}`, async () => {
+          await test.step('Type the product code, press Enter', async () => {
+            await typeProductAndWaitForDropdown(page, productCode);
+            await page.keyboard.press('Enter');
+            await page.waitForTimeout(1500);
+            await expect(piInput).toBeEnabled({ timeout: SLOW_ACTION_TIMEOUT });
+          });
 
-        await expect(piInput).toBeEnabled({ timeout: SLOW_ACTION_TIMEOUT });
-        for (const key of escapeKeys) {
-          if (key.startsWith('type:')) {
-            await page.keyboard.type(key.slice('type:'.length));
-          } else {
-            await page.keyboard.press(key);
-          }
-          await page.waitForTimeout(500);
-        }
-        await page.waitForTimeout(1000);
+          await test.step(
+            `Packvorschrift has no value - press ${label}`,
+            async () => {
+              for (const key of escapeKeys) {
+                if (key.startsWith('type:')) {
+                  await page.keyboard.type(key.slice('type:'.length));
+                } else {
+                  await page.keyboard.press(key);
+                }
+                await page.waitForTimeout(500);
+              }
+              await page.waitForTimeout(1000);
+            }
+          );
 
-        // Focus must now be on Menge: type the quantity blind and assert it landed there.
-        await page.keyboard.type(String(qty));
-        await page.waitForTimeout(400);
-        await expect(quantityInput).toHaveValue(String(qty), {
-          timeout: SLOW_ACTION_TIMEOUT,
+          // Focus must now be on Menge: type the quantity blind and assert it landed there.
+          await test.step(
+            `Type quantity ${qty} blind - it must land in Menge, not in Packvorschrift`,
+            async () => {
+              await page.keyboard.type(String(qty));
+              await page.waitForTimeout(400);
+              await expect(quantityInput).toHaveValue(String(qty), {
+                timeout: SLOW_ACTION_TIMEOUT,
+              });
+              await expect(piInput).toHaveValue('');
+            }
+          );
+
+          await test.step('Press Enter - the order line is created', async () => {
+            await page.keyboard.press('Enter');
+            await page.waitForTimeout(2500);
+          });
         });
-        await expect(piInput).toHaveValue('');
-
-        await page.keyboard.press('Enter');
-        await page.waitForTimeout(2500);
       };
 
       // CONTROL: Tab — the pre-existing escape that already worked.
-      await enterOneLine(['Tab'], 3);
+      await enterOneLine(['Tab'], 3, 'Tab (control: already worked before the fix)');
       // Bare Enter on the empty field (dropdown closed).
-      await enterOneLine(['Enter'], 4);
+      await enterOneLine(['Enter'], 4, 'Enter on the empty field');
       // ArrowDown twice (first opens the list, second highlights the empty row), then Enter.
-      await enterOneLine(['ArrowDown', 'ArrowDown', 'Enter'], 5);
+      await enterOneLine(
+        ['ArrowDown', 'ArrowDown', 'Enter'],
+        5,
+        'ArrowDown x2 then Enter (the reported case)'
+      );
       // Typed text matching nothing, then Enter — Tab-identical by decision 2026-09-09.
-      await enterOneLine(['type:xyzzy', 'Enter'], 6);
+      await enterOneLine(
+        ['type:xyzzy', 'Enter'],
+        6,
+        'type text matching nothing, then Enter'
+      );
 
       expect(errors, `browser errors: ${errors.join('\n')}`).toEqual([]);
 
       const rows = await getTabRows(SALES_ORDER_WINDOW_ID, recordId, 'AD_Tab-187');
       expect(rows).toHaveLength(4);
 
+      // NOTE: fieldsByName.<X> is the field WRAPPER; the lookup id lives at .value.key
+      // (same accessor as expectSingleLineWithPackingInstruction above).
       const byQty = {};
       for (const row of rows) {
-        byQty[String(row.fieldsByName.QtyEntered.value)] =
-          row.fieldsByName.M_HU_PI_Item_Product_ID;
+        const piField = row.fieldsByName.M_HU_PI_Item_Product_ID;
+        byQty[String(row.fieldsByName.QtyEntered.value)] = piField && piField.value;
       }
       expect(Object.keys(byQty).sort()).toEqual(['3', '4', '5', '6']);
 
       // The Tab line defines the expected packing instruction; the three Enter lines must match it.
       const tabLinePi = byQty['3'];
+      // Pin the control itself: without this, a regression that dropped the packing instruction
+      // from EVERY line would let the loop below pass by mutual absence (undefined === undefined).
+      expect(
+        tabLinePi && tabLinePi.key,
+        'the Tab control line must itself carry a packing instruction'
+      ).toBeTruthy();
       for (const qty of ['4', '5', '6']) {
         expect(
           byQty[qty] && byQty[qty].key,

--- a/e2e/frontend-webui/tests/spec/quick-input.spec.js
+++ b/e2e/frontend-webui/tests/spec/quick-input.spec.js
@@ -26,7 +26,9 @@ import { waitForTabAllowsNew, getTabRows, waitForRecordSaved } from '../utils/We
  * 7. Mouse-click selects packing instruction on secondary sub-field (regression)
  * 8. Regular-form composite partner lookup: server auto-fill of the location and
  *    contact secondary sub-fields (RawList-rendered sub-fields, not RawLookup)
- * (TESTs 6–8 are placed after TEST 3 in the file)
+ * 9. Keyboard-only line entry when the product has NO packing instruction: Enter
+ *    confirms the empty entry and advances, Tab-identical (TC8)
+ * (TESTs 6–9 are placed after TEST 3 in the file)
  */
 
 // ============================================================================
@@ -627,6 +629,102 @@ Continuous keyboard entry: line1 → line2 → ... without reopening batch entry
       await waitForRecordSaved(SALES_ORDER_WINDOW_ID, recordId, { maxRetries: 20, retryDelayMs: 1000 });
 
       expect(errors, `browser errors: ${errors.join('\n')}`).toEqual([]);
+    });
+
+    // ------------------------------------------------------------------
+    // TEST 9 (TC8): keyboard-only line entry when the packing-instruction lookup
+    // resolves to NO match. The product deliberately has no M_HU_PI_Item_Product,
+    // so the dropdown offers only the synthetic empty row.
+    //
+    // Four lines in one order, same masterdata: the Tab path is the CONTROL, and the
+    // three Enter shapes must reach the same outcome. The packing instruction is
+    // asserted EQUAL TO THE TAB LINE's, never against a hard-coded id.
+    // ------------------------------------------------------------------
+    test(`Keyboard-only line entry when the product has no packing instruction (${label})`, async ({ page }) => {
+      allure.epic('E0100: Sales');
+      allure.tag('F00101.10: Sales Order Quick Entry packing instruction');
+      allure.tag('F00101.10');
+      allure.story('Quick Input: Enter confirms the empty packing instruction');
+      allure.severity('critical');
+      allure.parameter('Language', language);
+      allure.tag(language);
+      test.setTimeout(240000);
+
+      const errors = collectPageErrors(page);
+      // No packingInstructions → the product has none at all (the reported data state).
+      const masterdata = await createMasterdata(language);
+      allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+      const productCode = masterdata.products.Product1.productCode;
+
+      const { recordId } = await setupOrderWithBatchEntry(page, masterdata, language);
+
+      const piInput = page.locator('#lookup_M_HU_PI_Item_Product_ID input.input-field');
+      const quantityInput = page.getByRole('spinbutton');
+
+      errors.length = 0; // contract: zero browser errors during the keyboard steps
+
+      /**
+       * Enter one line keyboard-only. `escapeKeys` is what the operator presses on the
+       * packing-instruction sub-field. Quantity is typed WITHOUT clicking, so the assertion
+       * that it lands in Menge is the proof that focus advanced (TC8 step 5).
+       */
+      const enterOneLine = async (escapeKeys, qty) => {
+        await typeProductAndWaitForDropdown(page, productCode);
+        await page.keyboard.press('Enter');
+        await page.waitForTimeout(1500);
+
+        await expect(piInput).toBeEnabled({ timeout: SLOW_ACTION_TIMEOUT });
+        for (const key of escapeKeys) {
+          if (key.startsWith('type:')) {
+            await page.keyboard.type(key.slice('type:'.length));
+          } else {
+            await page.keyboard.press(key);
+          }
+          await page.waitForTimeout(500);
+        }
+        await page.waitForTimeout(1000);
+
+        // Focus must now be on Menge: type the quantity blind and assert it landed there.
+        await page.keyboard.type(String(qty));
+        await page.waitForTimeout(400);
+        await expect(quantityInput).toHaveValue(String(qty), {
+          timeout: SLOW_ACTION_TIMEOUT,
+        });
+        await expect(piInput).toHaveValue('');
+
+        await page.keyboard.press('Enter');
+        await page.waitForTimeout(2500);
+      };
+
+      // CONTROL: Tab — the pre-existing escape that already worked.
+      await enterOneLine(['Tab'], 3);
+      // Bare Enter on the empty field (dropdown closed).
+      await enterOneLine(['Enter'], 4);
+      // ArrowDown twice (first opens the list, second highlights the empty row), then Enter.
+      await enterOneLine(['ArrowDown', 'ArrowDown', 'Enter'], 5);
+      // Typed text matching nothing, then Enter — Tab-identical by decision 2026-09-09.
+      await enterOneLine(['type:xyzzy', 'Enter'], 6);
+
+      expect(errors, `browser errors: ${errors.join('\n')}`).toEqual([]);
+
+      const rows = await getTabRows(SALES_ORDER_WINDOW_ID, recordId, 'AD_Tab-187');
+      expect(rows).toHaveLength(4);
+
+      const byQty = {};
+      for (const row of rows) {
+        byQty[String(row.fieldsByName.QtyEntered.value)] =
+          row.fieldsByName.M_HU_PI_Item_Product_ID;
+      }
+      expect(Object.keys(byQty).sort()).toEqual(['3', '4', '5', '6']);
+
+      // The Tab line defines the expected packing instruction; the three Enter lines must match it.
+      const tabLinePi = byQty['3'];
+      for (const qty of ['4', '5', '6']) {
+        expect(
+          byQty[qty] && byQty[qty].key,
+          `line qty=${qty} must carry the same packing instruction as the Tab line`
+        ).toBe(tabLinePi && tabLinePi.key);
+      }
     });
 
     // ------------------------------------------------------------------

--- a/frontend/src/__tests__/components/widget/Lookup/RawLookup.test.js
+++ b/frontend/src/__tests__/components/widget/Lookup/RawLookup.test.js
@@ -164,6 +164,109 @@ describe('RawLookup component', () => {
     });
   });
 
+  // ------------------------------------------------------------------
+  // TC8: keyboard-only completion when the lookup resolves to NO match.
+  // Decision 2026-09-09: on a NON-MANDATORY sub-field, Enter is Tab-identical for
+  // the no-match case — it commits the empty entry and advances focus, instead of
+  // dead-ending. The mandatory product sub-field keeps the old beep-and-hold.
+  //
+  // The commit contract is asserted (onChange with null + focus advance), not the
+  // beep: playBeep is module-local and its Web-Audio call is swallowed by a
+  // try/catch under jsdom, so "did it beep" is not observable here.
+  // ------------------------------------------------------------------
+  describe('TC8: Enter with no match on a non-mandatory sub-field commits empty and advances', () => {
+    const noneItem = { key: null, caption: 'none' };
+    const realItem = { key: '1000123', caption: 'KT x 18 KG' };
+
+    const mountQuickInput = (extraProps = {}) => {
+      const onChange = jest.fn(); // undefined → doThen runs its callback synchronously
+      const props = createDummyProps({
+        subentity: 'quickInput',
+        mandatory: false,
+        onChange,
+        handleInputEmptyStatus: jest.fn(),
+        ...extraProps,
+      });
+      const wrapper = mount(<RawLookup {...props} />);
+      const instance = wrapper.instance();
+      const advanceSpy = jest
+        .spyOn(instance, 'focusNextFieldInForm')
+        .mockImplementation(() => {}); // no parent <form> in the test DOM
+      return { wrapper, instance, onChange, advanceSpy };
+    };
+
+    it('resolveItems with no match commits null and advances', () => {
+      const { instance, onChange, advanceSpy } = mountQuickInput();
+      instance.inputSearch.value = 'leer';
+
+      instance.resolveItems([]);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith('someField', null);
+      expect(instance.inputSearch.value).toBe('');
+      expect(advanceSpy).toHaveBeenCalled();
+    });
+
+    it('bare Enter on an empty input with a closed dropdown commits null and advances', () => {
+      const { instance, onChange, advanceSpy } = mountQuickInput();
+      instance.inputSearch.value = '';
+      instance.setState({ list: [], loading: false });
+
+      instance.resolveAndSelectOnEnter();
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith('someField', null);
+      expect(advanceSpy).toHaveBeenCalled();
+    });
+
+    it('Enter with only the synthetic empty row in the open dropdown commits null and advances', () => {
+      const { instance, onChange, advanceSpy } = mountQuickInput();
+      instance.inputSearch.value = '';
+      instance.setState({ list: [noneItem], loading: false });
+
+      instance.resolveAndSelectOnEnter();
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith('someField', null);
+      expect(advanceSpy).toHaveBeenCalled();
+    });
+
+    it('Enter on typed text that matches nothing commits null and advances (Tab-identical)', () => {
+      const { instance, onChange, advanceSpy } = mountQuickInput();
+      instance.inputSearch.value = 'xyzzy';
+      instance.setState({ list: [noneItem], loading: false });
+
+      instance.resolveAndSelectOnEnter();
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith('someField', null);
+      expect(instance.inputSearch.value).toBe('');
+      expect(advanceSpy).toHaveBeenCalled();
+    });
+
+    it('MANDATORY sub-field (product) with no match does NOT commit and does NOT advance', () => {
+      const { instance, onChange, advanceSpy } = mountQuickInput({ mandatory: true });
+      instance.inputSearch.value = 'nonsense';
+
+      instance.resolveItems([]);
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(advanceSpy).not.toHaveBeenCalled();
+      expect(instance.inputSearch.value).toBe('nonsense');
+    });
+
+    it('an exact single match still selects that item (TC2 regression)', () => {
+      const { instance, onChange, advanceSpy } = mountQuickInput();
+
+      instance.resolveItems([realItem]);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith('someField', realItem);
+      expect(instance.inputSearch.value).toBe('KT x 18 KG');
+      expect(advanceSpy).toHaveBeenCalled();
+    });
+  });
+
   describe('handleInputEmptyStatus guard (non-primary sub-fields receive no function)', () => {
     const item = { key: '1000123', caption: 'KT x 18 KG' };
 

--- a/frontend/src/components/widget/Lookup/RawLookup.js
+++ b/frontend/src/components/widget/Lookup/RawLookup.js
@@ -423,6 +423,7 @@ export class RawLookup extends Component {
 
     const query = this.inputSearch.value;
     if (!query || !query.trim()) {
+      this.commitEmptyValueAndAdvance();
       return;
     }
 
@@ -463,11 +464,38 @@ export class RawLookup extends Component {
         }
       }
     } else {
-      // No match
+      // No match: on a non-mandatory sub-field, confirm the empty entry and advance
+      // instead of dead-ending the keyboard flow (TC8). Mandatory fields keep the beep.
+      if (this.commitEmptyValueAndAdvance()) {
+        return;
+      }
+
       if (this.props.beepOnInvalidProduct) {
         playBeep();
       }
     }
+  };
+
+  /**
+   * @method commitEmptyValueAndAdvance
+   * @summary Quick input: confirm the empty ("none") entry and advance focus — the same
+   * outcome `Tab` already produces on this field, and the same payload the mouse sends when
+   * the synthetic empty row is clicked (`handleSelect_RegularItem` normalises it to `null`).
+   *
+   * Only for NON-MANDATORY sub-fields: `!mandatory` is exactly the condition under which that
+   * synthetic empty row is offered at all (see `handleValueChanged`), so a mandatory field
+   * (the quick-input product, `MandatoryLogic.TRUE`) keeps beeping and holding focus.
+   *
+   * @return {boolean} true when the Enter was handled here, false when the caller must fall
+   *                   back to its previous no-match behaviour.
+   */
+  commitEmptyValueAndAdvance = () => {
+    if (this.props.mandatory) {
+      return false;
+    }
+
+    this.handleAutoSelectAndAdvance(null);
+    return true;
   };
 
   /**


### PR DESCRIPTION
## Problem

Keyboard-only order-line entry in the sales-order quick input was still blocked when the
product has **no** `M_HU_PI_Item_Product` at all. The packing-instruction dropdown then offers
only the synthetic empty row, and `Enter` was a **silent no-op**: focus stayed in the lookup, so
the quantity digits landed in that text box and no line was ever created. `Tab` already worked,
which was the only escape without reaching for the mouse.

Reproduced over nine keyboard cases against a local stack; zero `pageerror` / `console.error` in
all of them, which is why the console-error contract of the earlier scenarios could not catch it.

## Root cause

Two paths dead-ended, both in `RawLookup.js`:

- `resolveAndSelectOnEnter` returned early when the input text was empty.
- `resolveItems` only played a beep when nothing matched.

## Fix

Both paths now confirm the empty entry and advance focus, through
`handleAutoSelectAndAdvance(null)` — the same `null` payload the mouse already sends when that
row is clicked (`handleSelect_RegularItem` normalises the none item to `null`).

Scoped to **non-mandatory** sub-fields. `!mandatory` is exactly the condition under which the
synthetic empty row is offered at all, so the quick-input product field
(`MandatoryLogic.TRUE`) keeps beeping and holding focus, and `Enter` on the primary sub-field is
unchanged. Verified by the existing invalid-product scenario, which asserts focus does not advance.

Typed text that matches nothing now also commits empty and advances, making `Enter`
`Tab`-identical for the no-match case. This is a deliberate decision: `Tab` already discards such
text silently and defaults the line, measured on a local stack before choosing.

## Tests

- **Jest** (`RawLookup.test.js`) — 6 cases: the three no-match shapes (empty input with the
  dropdown closed, only the synthetic empty row, typed text matching nothing), the
  mandatory-field control that must NOT commit or advance, and the single-match regression.
- **Playwright** (`quick-input.spec.js`, TEST 9) — enters four lines in one order from the same
  masterdata. The `Tab` line is the control; the three `Enter` shapes must carry the **same**
  packing instruction as it, asserted by equality rather than a hard-coded id. The quantity is
  typed without clicking, so the assertion that it lands in `Menge` is the proof focus advanced.

### Local verification (2026-09-09, from-source stack on offset ports 18282/18080/13000)

| Layer | Result |
|---|---|
| Jest, `Lookup/` suites | 22/22 pass |
| Jest, whole frontend suite unfiltered | 65 suites, 364 pass, 0 fail |
| Playwright `quick-input.spec.js`, full file | 17/18 — see "Known unrelated failure" below |
| `yarn lintfix` | 0 errors |

TEST 9 was confirmed RED before the fix (quantity never reached `Menge`) and GREEN after.

---

## Follow-up commits (test-only, no production change)

**The equality assertion was passing vacuously — fixed.** TEST 9 stored the field *wrapper*
returned by the grid API and then read `.key` off it, but the lookup id lives at `.value.key`. Every
comparison was therefore `undefined === undefined`, so the test would have passed even with the
packing instruction missing from every line. It now reads `.value`, matching
`expectSingleLineWithPackingInstruction` in the same file, and the control line is pinned non-empty
first so two broken paths can no longer agree by mutual absence. Verified independently against the
database: all four created lines really carry `M_HU_PI_Item_Product_ID=101 "No Packing Item"`.

**Step instrumentation.** The four keyboard beats are wrapped in `test.step(...)` so the UAT video's
captions can be generated from the run's trace; without steps the captions covered only login and
setup and left the entire proof silent. `test.step` adds no runtime.

**Naming.** `enterOneLine`'s label parameter no longer shadows the outer language label.

## Known unrelated failure

`quick-input.spec.js` currently runs **17/18** locally: the German keyboard-only case intermittently
fails with an uncaught `Cannot read properties of undefined (reading 'getBoundingClientRect')`.

That is a **pre-existing production defect in `SelectionDropdown`, not from this PR**.
`optionToRef` is keyed by option object identity and cleared whenever `listHash` changes, while
`handleKeyDown` stays registered on `window` — so an arrow key handled between the clear and the
re-populate finds nothing, and `navigate()` passes that `undefined` straight into `scrollIntoView`,
which dereferences it. Unguarded since 2018. This PR touches only `RawLookup`'s Enter/no-match path
— never `SelectionDropdown`, `listHash`, or arrow navigation — and the error fires *before* any
commit in the failing scenario.

The new scenario is simply the first spec that arrow-navigates a lookup dropdown while its option
list is being rebuilt (the synthetic empty row is a fresh object on every rebuild, so its identity
changes). Tracked as flaky case 100. A one-line guard in `scrollIntoView` fixes it at the root and
is awaiting a decision, since it is production code outside this PR's approved scope.
