### PR TITLE
cucumber: emit Allure results (port the Allure adapter to big_coconut_uat)

### DIFF
--- a/backend/de.metas.cucumber/pom.xml
+++ b/backend/de.metas.cucumber/pom.xml
@@ -42,6 +42,23 @@
         <testcontainers.version>1.17.6</testcontainers.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Pin the whole io.cucumber artifact set (incl. io.cucumber:messages) to one
+                 consistent version. Without this, grafting allure-cucumber7-jvm leaves
+                 io.cucumber:messages unmanaged: Maven then fetches messages/maven-metadata.xml
+                 and resolves several versions, which makes go-offline-maven-plugin hang for
+                 the whole cucumber image build. Pinned to the branch's own cucumber version. -->
+            <dependency>
+                <groupId>io.cucumber</groupId>
+                <artifactId>cucumber-bom</artifactId>
+                <version>${cucumber.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/backend/de.metas.cucumber/pom.xml
+++ b/backend/de.metas.cucumber/pom.xml
@@ -119,6 +119,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Allure reporting for Cucumber tests -->
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-cucumber7-jvm</artifactId>
+            <version>2.25.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/RunCucumberTest.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/RunCucumberTest.java
@@ -41,7 +41,8 @@ import org.junit.runner.RunWith;
 				"html:target/cucumber.html",
 				"json:target/cucumber.1json" /* this json-output is needed for the Jenkins plugin that's supposed to publish it */,
 				"junit:target/cucumber-junit.xml" /* thx to https://stackoverflow.com/a/52676659/1012103 */,
-				"message:target/cucumber.message"
+				"message:target/cucumber.message",
+				"io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm" /* writes allure-results, picked up by the CI Allure report */
 		})
 public class RunCucumberTest
 {

--- a/backend/de.metas.cucumber/src/test/resources/allure.properties
+++ b/backend/de.metas.cucumber/src/test/resources/allure.properties
@@ -1,0 +1,5 @@
+# Allure reporting configuration for Cucumber tests
+allure.results.directory=target/allure-results
+
+# Link template for GitHub issues
+allure.link.issue.pattern=https://github.com/metasfresh/metasfresh/issues/{}

--- a/docker-builds/cucumber/entrypoint.sh
+++ b/docker-builds/cucumber/entrypoint.sh
@@ -16,3 +16,4 @@ echo "==================="
 
 cp target/*.xml /reports
 cp target/*.html /reports
+cp -r target/allure-results /reports/ 2>/dev/null || true


### PR DESCRIPTION
Ports the Cucumber Allure adapter to this branch, so cucumber runs emit `allure-results`.

### Why

The CI Allure report job on this line is currently green but inert: the cucumber image never writes `allure-results`, so the report job finds nothing (`has_results=false`) and every publish step skips. Nothing is reported. This branch has neither the Allure adapter dependency nor the results export, so no build-version bump can fix it — the code simply is not on the branch.

### Changes

- `backend/de.metas.cucumber/pom.xml` — add `io.qameta.allure:allure-cucumber7-jvm:2.25.0` (test scope). `cucumber.version` on this branch is `7.5.0`, so the cucumber7 adapter is the matching one.
- `backend/de.metas.cucumber/src/test/java/de/metas/cucumber/RunCucumberTest.java` — register `io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm` in the `@CucumberOptions` `plugin` list. Note this branch still uses the **JUnit 4** runner (`@RunWith(Cucumber.class)`), so registration goes in the annotation rather than the `@ConfigurationParameter(Constants.PLUGIN_PROPERTY_NAME, …)` form used on `new_dawn_uat`. Same plugin class either way.
- `backend/de.metas.cucumber/src/test/resources/allure.properties` — new; sets `allure.results.directory=target/allure-results` plus the issue link pattern.
- `docker-builds/cucumber/entrypoint.sh` — export `target/allure-results` to `/reports` alongside the existing xml/html exports (`|| true`, so a run that produced none does not trip `set -o errexit`).

Mirrors the adapter introduced in https://github.com/metasfresh/metasfresh/pull/25240 and already present on `new_dawn_uat`.

### Validation

`pom.xml` parses, `entrypoint.sh` passes `bash -n`. The real check is this build: the cucumber image must build with the new dependency and the run must leave `allure-results` in `/reports`.
