### PR TITLE
Lookup dropdown: do not crash on arrow navigation when an option ref is missing

### DIFF
--- a/frontend/src/__tests__/components/widget/SelectionDropdown.test.js
+++ b/frontend/src/__tests__/components/widget/SelectionDropdown.test.js
@@ -129,6 +129,58 @@ describe('SelectionDropdown component', () => {
     expect(onCancelSpy).toHaveBeenCalled();
   });
 
+  // The ref Map is keyed by option object identity and is cleared whenever `listHash`
+  // changes, while `handleKeyDown` stays registered on `window`. An arrow key handled
+  // while the Map holds no entry for the newly-selected option therefore reached
+  // `scrollIntoView(undefined)`, which dereferenced it and threw an uncaught
+  // "Cannot read properties of undefined (reading 'getBoundingClientRect')".
+  // Navigation itself must still happen — the guard skips scrolling, not selecting.
+  describe('arrow navigation when the option ref is missing', () => {
+    const arm = () => {
+      const map = {};
+      window.addEventListener = jest.fn((event, cb) => {
+        map[event] = cb;
+      });
+      return map;
+    };
+    const eventProps = () => ({
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    });
+
+    it('does not throw and still selects when the ref map was cleared', () => {
+      const onChangeSpy = jest.fn();
+      const props = createDummyProps(
+        {
+          ...fixtures.widgetData1,
+          selected: fixtures.data1.options[0],
+          onChange: onChangeSpy,
+        },
+        fixtures.data1.options
+      );
+      const map = arm();
+      const wrapper = mount(<SelectionDropdown {...props} />);
+
+      // the state the listHash change leaves behind
+      wrapper.instance().optionToRef.clear();
+
+      expect(() => map.keydown({ ...eventProps(), key: 'ArrowDown' })).not.toThrow();
+      expect(onChangeSpy).toHaveBeenCalledWith(fixtures.data1.options[1]);
+    });
+
+    it('scrollIntoView tolerates a missing element', () => {
+      const props = createDummyProps(
+        { ...fixtures.widgetData1, selected: fixtures.data1.options[0] },
+        fixtures.data1.options
+      );
+      arm();
+      const instance = mount(<SelectionDropdown {...props} />).instance();
+
+      expect(() => instance.scrollIntoView(undefined, false)).not.toThrow();
+      expect(() => instance.scrollIntoView(null, false)).not.toThrow();
+    });
+  });
+
   it('properly handles keyboard events and selects options', () => {
     const onSelectSpy = jest.fn();
     const onChangeSpy = jest.fn();

--- a/frontend/src/components/widget/SelectionDropdown.js
+++ b/frontend/src/components/widget/SelectionDropdown.js
@@ -66,6 +66,15 @@ class SelectionDropdown extends Component {
    * @param {*} up
    */
   scrollIntoView(element, up) {
+    // `optionToRef` is keyed by option object identity and is cleared whenever `listHash`
+    // changes, while `handleKeyDown` stays registered on `window`. An arrow key handled
+    // before the refs are re-populated resolves to no element, and dereferencing it threw
+    // an uncaught "Cannot read properties of undefined (reading 'getBoundingClientRect')".
+    // Only the scrolling is skipped — `navigate` still selects the option.
+    if (!element) {
+      return;
+    }
+
     const { top: topMax, bottom: bottomMax } =
       this.wrapper.getBoundingClientRect();
     const { top, bottom } = element.getBoundingClientRect();


### PR DESCRIPTION
## Problem

Arrowing through a lookup dropdown could raise an uncaught
`Cannot read properties of undefined (reading 'getBoundingClientRect')`. There is no visible
breakage — the keypress is simply swallowed — but the console carries an uncaught error and any
test asserting a clean console fails.

## Root cause

In `frontend/src/components/widget/SelectionDropdown.js`:

1. `optionToRef` is a `Map` keyed by **option object identity**, filled by the per-option render
   ref callback.
2. `UNSAFE_componentWillReceiveProps` **clears** that map whenever `listHash` changes; the entries
   only come back on the following render.
3. `handleKeyDown` is registered on **`window`**, so an arrow key can be handled while the map holds
   no entry for the option being selected.
4. `navigate()` then reads `optionToRef.get(selectedNew)` unguarded and passes the result to
   `scrollIntoView`, which dereferences it. `navigateToAlphanumeric` reaches the same call site.

Unguarded since `cd61442e7562` (2018).

## Fix

`scrollIntoView` returns early when it has no element. Only the scrolling is skipped — `navigate()`
still selects the option, which the test asserts explicitly, so the guard cannot silently turn a
navigation into a no-op.

The guard is deliberately scoped to `element`, the value that was demonstrably undefined. No
speculative check was added around the sibling `this.wrapper` dereference.

## How it was found

The sales-order quick-input keyboard-only scenario
(`e2e/frontend-webui/tests/spec/quick-input.spec.js`, added for a product with no packing
instruction) is the first spec that arrow-navigates a lookup dropdown while its option list is being
rebuilt: the synthetic empty ("leer") row is a fresh object literal on every rebuild, so its
identity changes, `listHash` flips and the ref map is dropped.

## Tests

Two Jest cases in `SelectionDropdown.test.js`, both confirmed **RED before** the guard (failing at
`SelectionDropdown.js:71`, the `getBoundingClientRect` line) and **GREEN after**:

- an arrow keydown with a cleared ref map does not throw **and still selects** the next option
- `scrollIntoView` tolerates a missing element (`undefined` and `null`)

### Local verification (from-source stack on offset ports 18282/18080/13000)

| Layer | Result |
|---|---|
| Jest `SelectionDropdown.test.js` | RED 2/7 before → 7/7 after |
| Jest, whole frontend suite unfiltered | 65 suites, 366 pass, 0 fail |
| Playwright, the scenario that reproduced the crash | 4/4 pass, including the English→German order that triggered it |
| `yarn lintfix` | 0 errors |

Before the guard that Playwright scenario failed roughly whenever the German case ran after the
English one; it was tracked as flaky case 100.
