### PR TITLE
Cost monitor: Nr. + Belegart off the grid, Belegart and the dates grouped right, Lager promoted left

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823710_sys_gh30811_CostMonitor_layout_refine.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823710_sys_gh30811_CostMonitor_layout_refine.sql
@@ -1,0 +1,47 @@
+-- Cost-monitor window 542175, tab 549352 — layout refinement requested by the controller.
+--
+-- Nr. (DocumentNo) loses its grid column but deliberately STAYS a filter — a window-scoped exception
+-- to "a filter column is also shown in the grid"; the order number stays reachable via the
+-- Produktionsauftrag zoom column (654728). Grid removal is applied on both grid layers
+-- (AD_UI_Element = WebUI, AD_Field = legacy Swing), as in 5814720/5814990 for this tab.
+-- Surviving siblings are not renumbered: SeqNo/SeqNoGrid are relative, so the vacated numbers
+-- leave no visible gap.
+--
+-- IDs allocated from idserver.metas.de: AD_UI_ElementGroup 555768
+
+-- Nr. + Belegart out of the grid
+UPDATE AD_UI_Element SET IsDisplayedGrid='N', SeqNoGrid=0,
+    Updated=TO_TIMESTAMP('2026-09-10 09:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_UI_Element_ID IN (652681 /* DocumentNo */, 652682 /* C_DocType_ID */)
+;
+
+UPDATE AD_Field SET IsDisplayedGrid='N', SeqNoGrid=0,
+    Updated=TO_TIMESTAMP('2026-09-10 09:00:05','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID IN (781750 /* DocumentNo */, 781751 /* C_DocType_ID */)
+;
+
+-- New group in the right column (549605), between the flags group (SeqNo 10) and Sektion/Mandant (SeqNo 20)
+INSERT INTO AD_UI_ElementGroup (AD_UI_ElementGroup_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_UI_Column_ID, SeqNo, UIStyle, Name)
+VALUES (555768 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-09-10 09:00:10','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-09-10 09:00:10','YYYY-MM-DD HH24:MI:SS'), 100, 549605, 15, NULL, 'default')
+;
+
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=555768, SeqNo=10,
+    Updated=TO_TIMESTAMP('2026-09-10 09:00:15','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_UI_Element_ID=652682 /* C_DocType_ID */
+;
+
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=555768, SeqNo=20,
+    Updated=TO_TIMESTAMP('2026-09-10 09:00:20','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_UI_Element_ID=652688 /* DatePromised */
+;
+
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=555768, SeqNo=30,
+    Updated=TO_TIMESTAMP('2026-09-10 09:00:25','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_UI_Element_ID=652689 /* DateFinishSchedule */
+;
+
+-- Lager into the left column's primary group (555514), after Kostendifferenz (SeqNo 40)
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=555514, SeqNo=50,
+    Updated=TO_TIMESTAMP('2026-09-10 09:00:30','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_UI_Element_ID=652690 /* M_Warehouse_ID */
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823720_sys_gh30811_CostMonitor_hide_DocStatus_field.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823720_sys_gh30811_CostMonitor_hide_DocStatus_field.sql
@@ -7,15 +7,16 @@
 -- ElementsLine.js renders as null. Meanwhile the AD metadata claimed IsDisplayed='Y', which is what
 -- the AD-driven layout renderers show, and that mismatch has already misled a design review.
 --
--- Hidden, not deleted: the AD_Field row stays for callouts/legacy paths. The AD_Field layer is set
--- alongside AD_UI_Element to match this tab's own convention for hidden fields (HasCostDifference,
--- AD_UI_Element 654725 / AD_Field 784959). Grid column (SeqNoGrid 110) and filter are kept.
+-- Hidden, not deleted: the AD_Field row stays for callouts/legacy paths. Both layers get
+-- IsDisplayed='N' + SeqNo=0, which is this tab's convention for a hidden field — HasCostDifference
+-- zeroes SeqNo on both AD_UI_Element 654725 and AD_Field 784959 (5823080). Grid column
+-- (SeqNoGrid 110) and filter are kept.
 --
 -- Consequently there is nothing for a Playwright assertion to discriminate here: the rendered DOM is
 -- identical before and after. The proof is the window-layout REST payload, where the empty
 -- elementsLine disappears.
 
-UPDATE AD_UI_Element SET IsDisplayed='N',
+UPDATE AD_UI_Element SET IsDisplayed='N', SeqNo=0,
     Updated=TO_TIMESTAMP('2026-09-10 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_UI_Element_ID=652691 /* DocStatus */
 ;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823720_sys_gh30811_CostMonitor_hide_DocStatus_field.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823720_sys_gh30811_CostMonitor_hide_DocStatus_field.sql
@@ -1,0 +1,26 @@
+-- Cost-monitor window 542175, tab 549352: make the AD metadata tell the truth about Belegstatus.
+--
+-- NO user-visible change, and that is the point. `DocStatus` was never rendered as a form field on
+-- this (or any) window: LayoutFactory hoists DocStatus + DocAction into the document-header
+-- ActionButton (SpecialDocumentFieldsCollector claims both column names), so the served window
+-- layout carried element 652691 as an element LINE WITH NO ELEMENTS — dead layout, which
+-- ElementsLine.js renders as null. Meanwhile the AD metadata claimed IsDisplayed='Y', which is what
+-- the AD-driven layout renderers show, and that mismatch has already misled a design review.
+--
+-- Hidden, not deleted: the AD_Field row stays for callouts/legacy paths. The AD_Field layer is set
+-- alongside AD_UI_Element to match this tab's own convention for hidden fields (HasCostDifference,
+-- AD_UI_Element 654725 / AD_Field 784959). Grid column (SeqNoGrid 110) and filter are kept.
+--
+-- Consequently there is nothing for a Playwright assertion to discriminate here: the rendered DOM is
+-- identical before and after. The proof is the window-layout REST payload, where the empty
+-- elementsLine disappears.
+
+UPDATE AD_UI_Element SET IsDisplayed='N',
+    Updated=TO_TIMESTAMP('2026-09-10 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_UI_Element_ID=652691 /* DocStatus */
+;
+
+UPDATE AD_Field SET IsDisplayed='N', SeqNo=0,
+    Updated=TO_TIMESTAMP('2026-09-10 10:00:05','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=781760 /* DocStatus */
+;

--- a/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
+++ b/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
@@ -321,4 +321,96 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
       `Manufacturing order ${documentNo} zoomed from monitor ${COST_IMBALANCE_WINDOW_ID} into window ${PRODUCTION_ORDER_WINDOW_ID}`
     );
   });
+  test('Grid drops Nr. and Belegart; the detail form regroups Belegart, the dates and Lager', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    allure.epic('E0226: Costing');
+    allure.tag('F1500: Costing');
+    allure.tag('F1500');
+    allure.story('Cost-monitor layout: Nr. and Belegart off the grid, Belegart + dates grouped right, Lager promoted left');
+    allure.severity('normal');
+    allure.description(
+      'Verifies the three layout changes the controller asked for: Nr. (DocumentNo) and Belegart ' +
+        '(C_DocType_ID) are no longer grid columns while Nr. still works as a filter; in the detail ' +
+        'view Belegart and the two date fields share one new group in the right column, below the ' +
+        'Aktiv group and above Sektion/Mandant; and Lager sits in the left column primary group. ' +
+        'Group assertions go on DOM ancestry, not captions, so they hold in either language.'
+    );
+
+    const { masterdata, documentNo } = await seedCompletedManufacturingOrder();
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await DashboardPage.expectVisible();
+
+    await MasterWindowPage.goto(COST_IMBALANCE_WINDOW_ID);
+    await MasterWindowPage.expectWindowLoaded();
+    await MasterWindowPage.waitForTableData();
+
+    await test.step('Nr. and Belegart are gone from the grid, the cost columns stay', async () => {
+      // Control: on a grid that rendered headers, a zero count means removed, not "not rendered yet".
+      await expect(page.locator('th[data-testid="column-CostDifference"]')).toHaveCount(1);
+      await expect(page.locator('th[data-testid="column-M_Product_ID"]')).toHaveCount(1);
+
+      await expect(page.locator('th[data-testid="column-DocumentNo"]')).toHaveCount(0);
+      await expect(page.locator('th[data-testid="column-C_DocType_ID"]')).toHaveCount(0);
+    });
+
+    await test.step('Nr. survives as a filter even though it lost its grid column', async () => {
+      const panel = await openFilterPanel({ page });
+      await expect(panel.locator('.form-field-DocumentNo')).toHaveCount(1);
+    });
+
+    await applyMonitorFilter({ page, documentNo });
+    await expect(page.locator(TABLE_ROWS)).toHaveCount(1);
+
+    // The regrouping exists in the single-row view only.
+    await MasterWindowPage.clickRow(0);
+
+    const columns = page.locator('.section > .row').first().locator('> div');
+    await expect(columns).toHaveCount(2);
+    const leftColumn = columns.nth(0);
+    const rightColumn = columns.nth(1);
+
+    await test.step('Lager sits in the left column primary group', async () => {
+      await expect(leftColumn.locator('.panel-primary .form-field-M_Warehouse_ID')).toHaveCount(1);
+    });
+
+    await test.step('Belegart and both date fields left the left column', async () => {
+      await expect(leftColumn.locator('.form-field-C_DocType_ID')).toHaveCount(0);
+      await expect(leftColumn.locator('.form-field-DatePromised')).toHaveCount(0);
+      await expect(leftColumn.locator('.form-field-DateFinishSchedule')).toHaveCount(0);
+    });
+
+    await test.step('... and share ONE group in the right column, below Aktiv and above Sektion', async () => {
+      const panels = rightColumn.locator('> .panel');
+      const panelIndexOf = async (selector) => {
+        const panelCount = await panels.count();
+        for (let i = 0; i < panelCount; i += 1) {
+          if ((await panels.nth(i).locator(selector).count()) > 0) {
+            return i;
+          }
+        }
+        return -1;
+      };
+
+      const activeIndex = await panelIndexOf('.form-field-IsActive');
+      const docTypeIndex = await panelIndexOf('.form-field-C_DocType_ID');
+      const orgIndex = await panelIndexOf('.form-field-AD_Org_ID');
+
+      expect(activeIndex).toBeGreaterThanOrEqual(0);
+      expect(docTypeIndex).toBeGreaterThanOrEqual(0);
+
+      // One group, not three.
+      expect(await panelIndexOf('.form-field-DatePromised')).toBe(docTypeIndex);
+      expect(await panelIndexOf('.form-field-DateFinishSchedule')).toBe(docTypeIndex);
+
+      expect(docTypeIndex).toBeGreaterThan(activeIndex);
+      expect(orgIndex).toBeGreaterThan(docTypeIndex);
+    });
+
+    console.log(
+      `Cost-monitor layout verified on order ${documentNo}: Nr./Belegart off the grid, Belegart+dates grouped right, Lager left`
+    );
+  });
 });

--- a/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
+++ b/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
@@ -376,8 +376,9 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
     const leftColumn = columns.nth(0);
     const rightColumn = columns.nth(1);
 
-    // Property of every document window, not of this change: LayoutFactory hoists DocStatus and
-    // DocAction into the header ActionButton, so they are never section fields.
+    // Characterization, not a regression guard: DocStatus's absence from the form is now
+    // overdetermined - LayoutFactory hoists it into the header ActionButton AND IsDisplayed='N' -
+    // so this cannot detect the loss of either mechanism. It records the current, intended state.
     await test.step('Belegstatus is not a form field — the document header carries the status', async () => {
       await expect(page.locator('.section .form-field-DocStatus')).toHaveCount(0);
     });

--- a/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
+++ b/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
@@ -331,7 +331,8 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
     allure.severity('normal');
     allure.description(
       'Verifies the three layout changes the controller asked for: Nr. (DocumentNo) and Belegart ' +
-        '(C_DocType_ID) are no longer grid columns while Nr. still works as a filter; in the detail ' +
+        '(C_DocType_ID) are no longer grid columns while Nr. still works as a filter, and Belegstatus keeps ' +
+        'its grid column; in the detail ' +
         'view Belegart and the two date fields share one new group in the right column, below the ' +
         'Aktiv group and above Sektion/Mandant; and Lager sits in the left column primary group. ' +
         'Group assertions go on DOM ancestry, not captions, so they hold in either language.'
@@ -354,6 +355,9 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
 
       await expect(page.locator('th[data-testid="column-DocumentNo"]')).toHaveCount(0);
       await expect(page.locator('th[data-testid="column-C_DocType_ID"]')).toHaveCount(0);
+
+      // Guard for the grid edits above: Belegstatus must not be swept out with them.
+      await expect(page.locator('th[data-testid="column-DocStatus"]')).toHaveCount(1);
     });
 
     await test.step('Nr. survives as a filter even though it lost its grid column', async () => {
@@ -371,6 +375,12 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
     await expect(columns).toHaveCount(2);
     const leftColumn = columns.nth(0);
     const rightColumn = columns.nth(1);
+
+    // Property of every document window, not of this change: LayoutFactory hoists DocStatus and
+    // DocAction into the header ActionButton, so they are never section fields.
+    await test.step('Belegstatus is not a form field — the document header carries the status', async () => {
+      await expect(page.locator('.section .form-field-DocStatus')).toHaveCount(0);
+    });
 
     await test.step('Lager sits in the left column primary group', async () => {
       await expect(leftColumn.locator('.panel-primary .form-field-M_Warehouse_ID')).toHaveCount(1);


### PR DESCRIPTION
Layout refinement of the manufacturing cost-monitor window (`AD_Window` 542175, tab 549352), requested by the controller who works it.

## What changes

**Grid view**
- **Nr.** (`DocumentNo`) and **Belegart** (`C_DocType_ID`) are no longer grid columns.
- **Nr.** stays a filter (`AD_Field.IsFilterField='Y'`, `AD_Column.IsSelectionColumn='Y'` untouched). A deliberate, window-scoped exception to the house rule *"a filter column is also shown in the grid"*: the order number is still on screen in the **Produktionsauftrag** column (that zoom field renders `PP_Order.DocumentNo`), so the **Nr.** column was a duplicate.

**Detail view**
- **Belegart**, **Zugesagter Termin** (`DatePromised`) and **Datum Fertigstellung geplant** (`DateFinishSchedule`) move out of the left column into a **new group in the right column** (`AD_UI_ElementGroup` 555768, `SeqNo=15`) — below the `flags` group that starts with **Aktiv**, and above the trailing **Sektion/Mandant** group, which the design rules require to stay last.
- **Lager** (`M_Warehouse_ID`) moves up into the left column's primary group, after **Kostendifferenz**.

**Metadata honesty for Belegstatus — no rendering change**
- `DocStatus` was never a form field here: `LayoutFactory` hoists `DocStatus` + `DocAction` into the document-header ActionButton (`SpecialDocumentFieldsCollector` claims both column names), so the served layout carried `AD_UI_Element` 652691 as an **element line with no elements** — dead layout, rendered as `null` by `ElementsLine`. The AD metadata nevertheless said `IsDisplayed='Y'`, which is what the AD-driven layout renderers show; that mismatch misled a design review of this very window.
- `IsDisplayed='N'` now makes the metadata match the framework's actual behaviour and drops the empty line from the layout payload. Hidden, not deleted — the `AD_Field` row stays for callouts and legacy paths. Grid column and filter kept.

## How

Two migration scripts: `5823710` (grid + regrouping) and `5823720` (the Belegstatus metadata fix).
- grid removal applied on **both** grid layers — `AD_UI_Element` (WebUI) and `AD_Field` (legacy Swing) — the same two-layer treatment as `5814720` / `5814990` for this tab;
- surviving siblings are **not** renumbered (`SeqNo`/`SeqNoGrid` are relative sort keys, so the vacated numbers leave no visible gap);
- `AD_UI_ElementGroup` 555768 allocated from the ID server.

Core-only: no customer repository carries an override window for 542175 (re-verified against a customer-faithful local stack), so there is no companion customer-side script.

## Verification

New 4th test in `e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js` — *"Grid drops Nr. and Belegart; the detail form regroups Belegart, the dates and Lager"* — RED before `5823710`, GREEN after, on a customer-faithful local stack:
- the two grid columns are gone while `CostDifference` / `M_Product_ID` still render (control against a not-yet-rendered grid), and the `DocStatus` column is guarded against being swept out with them;
- **Nr.** is still offered as a filter **and** still narrows the list to the seeded order;
- in the single-row view: `M_Warehouse_ID` inside `.panel-primary` of the left column; `C_DocType_ID` and both dates absent from the left column and sharing **one** panel in the right column, positioned after the **Aktiv** panel and before the **Sektion** panel.

Group placement is asserted on DOM ancestry, not on captions, so the test holds in either language. All 4 tests of the spec pass together.

`5823720` carries **no** coverage claim on purpose: the rendered DOM is identical before and after it, so nothing in the browser can discriminate the two states. Its effect was verified on the window-layout REST payload, which differs only by the removed empty `elementsLine`.

A `window-designer` pass over the rendered window (de_DE + en_US) against the migrated customer-faithful stack reports no findings above pre-existing LOW.
