### PR TITLE
CostDifferenceDistribution reversal: recreate every leg, not just the first

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
@@ -400,10 +400,7 @@ public class CostingService implements ICostingService
 			throw new AdempiereException("Initial document has no cost details: " + reversalRequest);
 		}
 
-		// NOTE: matched by (costElementId, amtType), NOT costElementId alone: a CostDifferenceDistribution
-		// collector persists three rows (MAIN/ADJUSTMENT/ALREADY_SHIPPED) that all share the same cost element,
-		// so a costElementId-only lookup could return the wrong leg's row - or, once a genuine repost finds all
-		// three already persisted, collide trying to key a map by costElementId alone.
+		// matched by (costElementId, amtType): a distribution collector's 3 legs share one cost element.
 		final List<CostDetail> existingCostDetailsList = costDetailsService
 				.getAllForDocumentAndAcctSchemaId(reversalRequest.getReversalDocumentRef(), reversalRequest.getAcctSchemaId());
 

--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
@@ -400,7 +400,9 @@ public class CostingService implements ICostingService
 			throw new AdempiereException("Initial document has no cost details: " + reversalRequest);
 		}
 
-		// matched by (costElementId, amtType): a distribution collector's 3 legs share one cost element.
+		// matched by (costElementId, amtType), NOT costElementId alone: a distribution collector's 3 legs
+		// share one cost element, so a costElementId-keyed map would either return the wrong leg or (once
+		// a repost finds all 3 already persisted) throw on the duplicate key while building the map.
 		final List<CostDetail> existingCostDetailsList = costDetailsService
 				.getAllForDocumentAndAcctSchemaId(reversalRequest.getReversalDocumentRef(), reversalRequest.getAcctSchemaId());
 

--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
@@ -1,7 +1,6 @@
 package de.metas.costing.impl;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Range;
@@ -39,6 +38,7 @@ import de.metas.costing.ICurrentCostsRepository;
 import de.metas.costing.IProductCostingBL;
 import de.metas.costing.MoveCostsRequest;
 import de.metas.costing.MoveCostsResult;
+import de.metas.costing.methods.CostAmountType;
 import de.metas.costing.methods.CostingMethodHandler;
 import de.metas.costing.methods.CostingMethodHandlerUtils;
 import de.metas.costrevaluation.CostRevaluationLineId;
@@ -400,19 +400,23 @@ public class CostingService implements ICostingService
 			throw new AdempiereException("Initial document has no cost details: " + reversalRequest);
 		}
 
-		final ImmutableMap<CostElementId, CostDetail> existingCostDetails = costDetailsService
-				.getAllForDocumentAndAcctSchemaId(reversalRequest.getReversalDocumentRef(), reversalRequest.getAcctSchemaId())
-				.stream()
-				.collect(ImmutableMap.toImmutableMap(
-						CostDetail::getCostElementId,
-						costDetail -> costDetail));
+		// NOTE: matched by (costElementId, amtType), NOT costElementId alone: a CostDifferenceDistribution
+		// collector persists three rows (MAIN/ADJUSTMENT/ALREADY_SHIPPED) that all share the same cost element,
+		// so a costElementId-only lookup could return the wrong leg's row - or, once a genuine repost finds all
+		// three already persisted, collide trying to key a map by costElementId alone.
+		final List<CostDetail> existingCostDetailsList = costDetailsService
+				.getAllForDocumentAndAcctSchemaId(reversalRequest.getReversalDocumentRef(), reversalRequest.getAcctSchemaId());
 
 		final ArrayList<CostDetailCreateResult> costDetailCreateResults = new ArrayList<>();
 
 		for (final CostDetail initialDocCostDetail : initialDocCostDetails)
 		{
 			final CostElementId costElementId = initialDocCostDetail.getCostElementId();
-			final CostDetail existingCostDetail = existingCostDetails.get(costElementId);
+			final CostAmountType amtType = initialDocCostDetail.getAmtType();
+			final CostDetail existingCostDetail = existingCostDetailsList.stream()
+					.filter(existing -> Objects.equals(existing.getCostElementId(), costElementId) && existing.getAmtType() == amtType)
+					.findFirst()
+					.orElse(null);
 			if (existingCostDetail != null)
 			{
 				final CostDetailCreateResult result = utils.toCostDetailCreateResult(existingCostDetail);

--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
@@ -414,7 +414,7 @@ public class CostingService implements ICostingService
 			final CostElementId costElementId = initialDocCostDetail.getCostElementId();
 			final CostAmountType amtType = initialDocCostDetail.getAmtType();
 			final CostDetail existingCostDetail = existingCostDetailsList.stream()
-					.filter(existing -> Objects.equals(existing.getCostElementId(), costElementId) && existing.getAmtType() == amtType)
+					.filter(existing -> CostElementId.equals(existing.getCostElementId(), costElementId) && existing.getAmtType() == amtType)
 					.findFirst()
 					.orElse(null);
 			if (existingCostDetail != null)

--- a/backend/de.metas.business/src/main/java/de/metas/costing/methods/CostingMethodHandlerUtils.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/methods/CostingMethodHandlerUtils.java
@@ -168,6 +168,25 @@ public class CostingMethodHandlerUtils
 		return costDetailsService.getExistingCostDetails(request);
 	}
 
+	/**
+	 * Whether {@code costDetails} already contains a row of the given {@code amtType}. This is the manufacturing
+	 * costing-method handlers' "was THIS leg already persisted" guard on top of {@link #getExistingCostDetails}.
+	 * <p>
+	 * On a {@code CostDifferenceDistribution} reversal, {@code CostingService.createReversalCostDetailsOrEmpty}
+	 * invokes {@code createOrUpdateCost} once PER ORIGINAL LEG (MAIN, then ADJUSTMENT, then ALREADY_SHIPPED) for
+	 * the very same reversal document. {@link #getExistingCostDetails} matches on document + cost element only
+	 * (intentionally, so a genuine repost recovers every leg at once - see its javadoc), so once the first call
+	 * persists the MAIN leg, it already returns a non-empty list for the second and third calls even though THEIR
+	 * leg is still missing. Checking emptiness alone would wrongly treat that as an idempotent repost and hand
+	 * back the MAIN leg's row again instead of creating the ADJUSTMENT/ALREADY_SHIPPED rows - checking for the
+	 * requested type specifically tells "already reposted" apart from "a sibling leg of this same document was
+	 * created a moment ago".
+	 */
+	public boolean containsAmtType(@NonNull final List<CostDetail> costDetails, @NonNull final CostAmountType amtType)
+	{
+		return costDetails.stream().anyMatch(costDetail -> costDetail.getAmtType() == amtType);
+	}
+
 	public List<CostDetail> getExistingCostDetails(@NonNull final CostDetailQuery query)
 	{
 		return costDetailsService.stream(query).collect(ImmutableList.toImmutableList());

--- a/backend/de.metas.business/src/main/java/de/metas/costing/methods/CostingMethodHandlerUtils.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/methods/CostingMethodHandlerUtils.java
@@ -168,20 +168,7 @@ public class CostingMethodHandlerUtils
 		return costDetailsService.getExistingCostDetails(request);
 	}
 
-	/**
-	 * Whether {@code costDetails} already contains a row of the given {@code amtType}. This is the manufacturing
-	 * costing-method handlers' "was THIS leg already persisted" guard on top of {@link #getExistingCostDetails}.
-	 * <p>
-	 * On a {@code CostDifferenceDistribution} reversal, {@code CostingService.createReversalCostDetailsOrEmpty}
-	 * invokes {@code createOrUpdateCost} once PER ORIGINAL LEG (MAIN, then ADJUSTMENT, then ALREADY_SHIPPED) for
-	 * the very same reversal document. {@link #getExistingCostDetails} matches on document + cost element only
-	 * (intentionally, so a genuine repost recovers every leg at once - see its javadoc), so once the first call
-	 * persists the MAIN leg, it already returns a non-empty list for the second and third calls even though THEIR
-	 * leg is still missing. Checking emptiness alone would wrongly treat that as an idempotent repost and hand
-	 * back the MAIN leg's row again instead of creating the ADJUSTMENT/ALREADY_SHIPPED rows - checking for the
-	 * requested type specifically tells "already reposted" apart from "a sibling leg of this same document was
-	 * created a moment ago".
-	 */
+	/** Narrower than an emptiness check: a distribution reversal persists its 3 legs via separate same-document calls, so a sibling leg's row must not be mistaken for this one's. */
 	public boolean containsAmtType(@NonNull final List<CostDetail> costDetails, @NonNull final CostAmountType amtType)
 	{
 		return costDetails.stream().anyMatch(costDetail -> costDetail.getAmtType() == amtType);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Cost_Collector_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Cost_Collector_StepDef.java
@@ -42,6 +42,8 @@ import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_Fact_Acct;
 import org.compiere.model.I_M_Product;
 import org.eevolution.api.CostCollectorType;
+import org.eevolution.api.IPPCostCollectorBL;
+import org.eevolution.api.PPCostCollectorId;
 import org.eevolution.model.I_PP_Cost_Collector;
 import org.eevolution.model.I_PP_Order;
 import org.eevolution.model.I_PP_Order_BOMLine;
@@ -65,6 +67,7 @@ public class PP_Cost_Collector_StepDef
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	private final IDocumentBL documentBL = Services.get(IDocumentBL.class);
+	private final IPPCostCollectorBL ppCostCollectorBL = Services.get(IPPCostCollectorBL.class);
 
 	@NonNull private final PP_Order_StepDefData ppOrderTable;
 	@NonNull private final PP_Cost_Collector_StepDefData ppCostCollectorTable;
@@ -221,7 +224,8 @@ public class PP_Cost_Collector_StepDef
 		InterfaceWrapperHelper.refresh(costCollector);
 		documentBL.processEx(costCollector, IDocument.ACTION_Reverse_Correct, IDocument.STATUS_Reversed);
 
-		final I_PP_Cost_Collector reversal = InterfaceWrapperHelper.load(costCollector.getReversal_ID(), I_PP_Cost_Collector.class);
+		final PPCostCollectorId reversalId = PPCostCollectorId.ofRepoId(costCollector.getReversal_ID());
+		final I_PP_Cost_Collector reversal = ppCostCollectorBL.getById(reversalId);
 		ppCostCollectorTable.put(reversalIdentifier, reversal);
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Cost_Collector_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Cost_Collector_StepDef.java
@@ -29,6 +29,7 @@ import de.metas.cucumber.stepdefs.StepDefConstants;
 import de.metas.cucumber.stepdefs.StepDefUtil;
 import de.metas.cucumber.stepdefs.accounting.AccountingCucumberHelper;
 import de.metas.document.engine.IDocument;
+import de.metas.document.engine.IDocumentBL;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
@@ -36,6 +37,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_Fact_Acct;
 import org.compiere.model.I_M_Product;
@@ -62,6 +64,7 @@ import static org.eevolution.model.I_PP_Cost_Collector.COLUMNNAME_PP_Cost_Collec
 public class PP_Cost_Collector_StepDef
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	private final IDocumentBL documentBL = Services.get(IDocumentBL.class);
 
 	@NonNull private final PP_Order_StepDefData ppOrderTable;
 	@NonNull private final PP_Cost_Collector_StepDefData ppCostCollectorTable;
@@ -92,6 +95,10 @@ public class PP_Cost_Collector_StepDef
 	 *   receipt). If omitted, only PP_Order_ID and DocStatus are used to match the record.</li>
 	 *   <li>{@code CostCollectorType} — (optional) {@link CostCollectorType} enum name; narrows the match when one
 	 *   PP_Order has several completed cost collectors for the same product.</li>
+	 *   <li>{@code Reversal_ID.Identifier} — (optional) identifier of an already-known PP_Cost_Collector;
+	 *   matches the record whose {@code Reversal_ID} points to it. Needed to tell a reversed cost collector
+	 *   apart from its reversal: both carry the same PP_Order_ID/M_Product_ID/CostCollectorType/DocStatus
+	 *   ('RE'), so those columns alone match two rows.</li>
 	 * </ul>
 	 *
 	 * <p>Example:
@@ -176,6 +183,15 @@ public class PP_Cost_Collector_StepDef
 			queryBuilder.addEqualsFilter(COLUMNNAME_CostCollectorType, CostCollectorType.valueOf(costCollectorTypeName).getCode());
 		}
 
+		// Disambiguate a reversed cost collector from its reversal: both share PP_Order_ID/M_Product_ID/
+		// CostCollectorType/DocStatus ('RE'), so match the one whose Reversal_ID points to the given record.
+		final String reversalRefIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, I_PP_Cost_Collector.COLUMNNAME_Reversal_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (reversalRefIdentifier != null)
+		{
+			final I_PP_Cost_Collector reversalRef = ppCostCollectorTable.get(reversalRefIdentifier);
+			queryBuilder.addEqualsFilter(I_PP_Cost_Collector.COLUMNNAME_Reversal_ID, reversalRef.getPP_Cost_Collector_ID());
+		}
+
 		final Optional<I_PP_Cost_Collector> ppCostCollector = queryBuilder
 				.create()
 				.firstOnlyOptional(I_PP_Cost_Collector.class);
@@ -189,6 +205,24 @@ public class PP_Cost_Collector_StepDef
 		ppCostCollectorTable.put(ppCostCollectorIdentifier, ppCostCollector.get());
 
 		return true;
+	}
+
+	/**
+	 * Reverses (Reverse-Correct) the given PP_Cost_Collector and stores the resulting reversal
+	 * cost collector under a new identifier.
+	 *
+	 * @param identifier identifier of the already-completed PP_Cost_Collector to reverse
+	 * @param reversalIdentifier identifier under which the reversal PP_Cost_Collector is stored
+	 */
+	@And("^the PP_Cost_Collector identified by (.*) is reversed as (.*)$")
+	public void reverseCostCollector(@NonNull final String identifier, @NonNull final String reversalIdentifier)
+	{
+		final I_PP_Cost_Collector costCollector = ppCostCollectorTable.get(identifier);
+		InterfaceWrapperHelper.refresh(costCollector);
+		documentBL.processEx(costCollector, IDocument.ACTION_Reverse_Correct, IDocument.STATUS_Reversed);
+
+		final I_PP_Cost_Collector reversal = InterfaceWrapperHelper.load(costCollector.getReversal_ID(), I_PP_Cost_Collector.class);
+		ppCostCollectorTable.put(reversalIdentifier, reversal);
 	}
 
 	@And("validate I_PP_Cost_Collector")

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
@@ -523,6 +523,35 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
       | Date       | M_Product_ID | M_Warehouse_ID | Qty | Acct_CostPrice | Acct_ExpectedAmt | InventoryValueAcctAmt |
       | 2024-03-27 | finProd      | warehouseStd   | 8   | 34.0000        | 272.00           | 272.00                |
 
+    # Reverse-Correct the distribution: the residual re-opens and the price move-back should undo the
+    # capitalization, since the on-hand qty has not moved since the distribution ran.
+    And the PP_Cost_Collector identified by distributionCostCollector is reversed as reversedDistributionCostCollector
+
+    # distributionCostCollector/reversedDistributionCostCollector are already registered (above); load fresh
+    # aliases here so the DB re-check does not collide with those identifiers already bound to the same rows.
+    And after not more than 60s, PP_Cost_Collector are found:
+      | PP_Cost_Collector_ID.Identifier | PP_Order_ID.Identifier | M_Product_ID.Identifier | MovementQty | DocStatus | CostCollectorType          | Reversal_ID.Identifier            |
+      | reversalRowCheck                | ppOrder                | finProd                 | 0           | RE        | CostDifferenceDistribution | distributionCostCollector         |
+      | originalRowCheck                | ppOrder                | finProd                 | 0           | RE        | CostDifferenceDistribution | reversedDistributionCostCollector |
+    And Wait until documents reversedDistributionCostCollector are posted
+
+    # The reversal exactly undoes the distribution's legs: every account flips side, still at qty zero.
+    And Fact_Acct records are matching
+      | Record_ID                         | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr | Qty   |
+      | reversedDistributionCostCollector | P_Asset_Acct          | finProd      | 0         | 32        | 0 PCE |
+      | reversedDistributionCostCollector | P_COGS_Acct           | finProd      | 0         | 8         | 0 PCE |
+      | reversedDistributionCostCollector | P_WIP_Acct            | finProd      | 40        | 0         | 0 PCE |
+
+    # The literal answer to "does Lagerwert return after reversal?" - cost price moves back to its
+    # pre-distribution value, qty on hand unchanged.
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
+      | acctSchema      | finProd      | AveragePO        | 30 CHF           | 8 PCE      |
+
+    And expect inventory valuation report
+      | Date       | M_Product_ID | M_Warehouse_ID | Qty | Acct_CostPrice | Acct_ExpectedAmt | InventoryValueAcctAmt |
+      | 2024-03-27 | finProd      | warehouseStd   | 8   | 30.0000        | 240.00           | 240.00                |
+
   @from:cucumber
   @Id:S30811_TC4
   Scenario: Distribute discharges the residual on the MovingAverageInvoice costing method too

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
@@ -523,27 +523,22 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
       | Date       | M_Product_ID | M_Warehouse_ID | Qty | Acct_CostPrice | Acct_ExpectedAmt | InventoryValueAcctAmt |
       | 2024-03-27 | finProd      | warehouseStd   | 8   | 34.0000        | 272.00           | 272.00                |
 
-    # Reverse-Correct the distribution: the residual re-opens and the price move-back should undo the
-    # capitalization, since the on-hand qty has not moved since the distribution ran.
     And the PP_Cost_Collector identified by distributionCostCollector is reversed as reversedDistributionCostCollector
 
-    # distributionCostCollector/reversedDistributionCostCollector are already registered (above); load fresh
-    # aliases here so the DB re-check does not collide with those identifiers already bound to the same rows.
+    # new aliases: the original identifiers are already bound to these same rows.
     And after not more than 60s, PP_Cost_Collector are found:
       | PP_Cost_Collector_ID.Identifier | PP_Order_ID.Identifier | M_Product_ID.Identifier | MovementQty | DocStatus | CostCollectorType          | Reversal_ID.Identifier            |
       | reversalRowCheck                | ppOrder                | finProd                 | 0           | RE        | CostDifferenceDistribution | distributionCostCollector         |
       | originalRowCheck                | ppOrder                | finProd                 | 0           | RE        | CostDifferenceDistribution | reversedDistributionCostCollector |
     And Wait until documents reversedDistributionCostCollector are posted
 
-    # The reversal exactly undoes the distribution's legs: every account flips side, still at qty zero.
     And Fact_Acct records are matching
       | Record_ID                         | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr | Qty   |
       | reversedDistributionCostCollector | P_Asset_Acct          | finProd      | 0         | 32        | 0 PCE |
       | reversedDistributionCostCollector | P_COGS_Acct           | finProd      | 0         | 8         | 0 PCE |
       | reversedDistributionCostCollector | P_WIP_Acct            | finProd      | 40        | 0         | 0 PCE |
 
-    # The literal answer to "does Lagerwert return after reversal?" - cost price moves back to its
-    # pre-distribution value, qty on hand unchanged.
+    # Lagerwert after reversal: cost price back to its pre-distribution value.
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
       | acctSchema      | finProd      | AveragePO        | 30 CHF           | 8 PCE      |

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingAveragePOCostingMethodHandler.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingAveragePOCostingMethodHandler.java
@@ -94,7 +94,12 @@ public class ManufacturingAveragePOCostingMethodHandler implements CostingMethod
 	public CostDetailCreateResultsList createOrUpdateCost(final CostDetailCreateRequest request)
 	{
 		final List<CostDetail> existingCostDetails = utils.getExistingCostDetails(request);
-		if (!existingCostDetails.isEmpty())
+		// NOTE: checking for the requested amtType specifically - not just non-emptiness - matters on a
+		// CostDifferenceDistribution reversal: CostingService replays MAIN/ADJUSTMENT/ALREADY_SHIPPED as
+		// separate calls against the same reversal document, so after the first leg is persisted, existingCostDetails
+		// is already non-empty for the next call even though ITS leg is still missing. See
+		// CostingMethodHandlerUtils.containsAmtType.
+		if (utils.containsAmtType(existingCostDetails, request.getAmtType()))
 		{
 			// make sure DateAcct is up-to-date
 			final List<CostDetail> existingCostDetailsUpdated = utils.updateDateAcct(existingCostDetails, request.getDate());

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingAveragePOCostingMethodHandler.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingAveragePOCostingMethodHandler.java
@@ -94,11 +94,6 @@ public class ManufacturingAveragePOCostingMethodHandler implements CostingMethod
 	public CostDetailCreateResultsList createOrUpdateCost(final CostDetailCreateRequest request)
 	{
 		final List<CostDetail> existingCostDetails = utils.getExistingCostDetails(request);
-		// NOTE: checking for the requested amtType specifically - not just non-emptiness - matters on a
-		// CostDifferenceDistribution reversal: CostingService replays MAIN/ADJUSTMENT/ALREADY_SHIPPED as
-		// separate calls against the same reversal document, so after the first leg is persisted, existingCostDetails
-		// is already non-empty for the next call even though ITS leg is still missing. See
-		// CostingMethodHandlerUtils.containsAmtType.
 		if (utils.containsAmtType(existingCostDetails, request.getAmtType()))
 		{
 			// make sure DateAcct is up-to-date

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingLastPOCostingMethodHandler.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingLastPOCostingMethodHandler.java
@@ -91,11 +91,6 @@ public class ManufacturingLastPOCostingMethodHandler implements CostingMethodHan
 	public CostDetailCreateResultsList createOrUpdateCost(final CostDetailCreateRequest request)
 	{
 		final List<CostDetail> existingCostDetails = utils.getExistingCostDetails(request);
-		// NOTE: checking for the requested amtType specifically - not just non-emptiness - matters on a
-		// CostDifferenceDistribution reversal: CostingService replays MAIN/ADJUSTMENT/ALREADY_SHIPPED as
-		// separate calls against the same reversal document, so after the first leg is persisted, existingCostDetails
-		// is already non-empty for the next call even though ITS leg is still missing. See
-		// CostingMethodHandlerUtils.containsAmtType.
 		if (utils.containsAmtType(existingCostDetails, request.getAmtType()))
 		{
 			// make sure DateAcct is up-to-date

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingLastPOCostingMethodHandler.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingLastPOCostingMethodHandler.java
@@ -91,7 +91,12 @@ public class ManufacturingLastPOCostingMethodHandler implements CostingMethodHan
 	public CostDetailCreateResultsList createOrUpdateCost(final CostDetailCreateRequest request)
 	{
 		final List<CostDetail> existingCostDetails = utils.getExistingCostDetails(request);
-		if (!existingCostDetails.isEmpty())
+		// NOTE: checking for the requested amtType specifically - not just non-emptiness - matters on a
+		// CostDifferenceDistribution reversal: CostingService replays MAIN/ADJUSTMENT/ALREADY_SHIPPED as
+		// separate calls against the same reversal document, so after the first leg is persisted, existingCostDetails
+		// is already non-empty for the next call even though ITS leg is still missing. See
+		// CostingMethodHandlerUtils.containsAmtType.
+		if (utils.containsAmtType(existingCostDetails, request.getAmtType()))
 		{
 			// make sure DateAcct is up-to-date
 			final List<CostDetail> existingCostDetailsUpdated = utils.updateDateAcct(existingCostDetails, request.getDate());

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingMovingAverageInvoiceCostingMethodHandler.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingMovingAverageInvoiceCostingMethodHandler.java
@@ -57,7 +57,12 @@ public class ManufacturingMovingAverageInvoiceCostingMethodHandler implements Co
 	public CostDetailCreateResultsList createOrUpdateCost(final CostDetailCreateRequest request)
 	{
 		final List<CostDetail> existingCostDetails = utils.getExistingCostDetails(request);
-		if (!existingCostDetails.isEmpty())
+		// NOTE: checking for the requested amtType specifically - not just non-emptiness - matters on a
+		// CostDifferenceDistribution reversal: CostingService replays MAIN/ADJUSTMENT/ALREADY_SHIPPED as
+		// separate calls against the same reversal document, so after the first leg is persisted, existingCostDetails
+		// is already non-empty for the next call even though ITS leg is still missing. See
+		// CostingMethodHandlerUtils.containsAmtType.
+		if (utils.containsAmtType(existingCostDetails, request.getAmtType()))
 		{
 			// make sure DateAcct is up-to-date
 			final List<CostDetail> existingCostDetailsUpdated = utils.updateDateAcct(existingCostDetails, request.getDate());

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingMovingAverageInvoiceCostingMethodHandler.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingMovingAverageInvoiceCostingMethodHandler.java
@@ -57,11 +57,6 @@ public class ManufacturingMovingAverageInvoiceCostingMethodHandler implements Co
 	public CostDetailCreateResultsList createOrUpdateCost(final CostDetailCreateRequest request)
 	{
 		final List<CostDetail> existingCostDetails = utils.getExistingCostDetails(request);
-		// NOTE: checking for the requested amtType specifically - not just non-emptiness - matters on a
-		// CostDifferenceDistribution reversal: CostingService replays MAIN/ADJUSTMENT/ALREADY_SHIPPED as
-		// separate calls against the same reversal document, so after the first leg is persisted, existingCostDetails
-		// is already non-empty for the next call even though ITS leg is still missing. See
-		// CostingMethodHandlerUtils.containsAmtType.
 		if (utils.containsAmtType(existingCostDetails, request.getAmtType()))
 		{
 			// make sure DateAcct is up-to-date

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingStandardCostingMethodHandler.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingStandardCostingMethodHandler.java
@@ -109,6 +109,10 @@ public class ManufacturingStandardCostingMethodHandler implements CostingMethodH
 	public final CostDetailCreateResultsList createOrUpdateCost(final CostDetailCreateRequest request)
 	{
 		final List<CostDetail> existingCostDetails = utils.getExistingCostDetails(request);
+		// not the containsAmtType fix applied to the other handlers: Standard costing never accumulates
+		// PP_Order_Cost, so PPOrderCostDifferenceDistributor.distribute() never creates a
+		// CostDifferenceDistribution collector here today (COSTING_METHODS_WITH_ORDER_COSTS excludes
+		// Standard) — but if that ever changes, this reversal path would need the same fix.
 		if (!existingCostDetails.isEmpty())
 		{
 			// make sure DateAcct is up-to-date

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/costing/methods/ManufacturingRepostCostDifferenceDistributionTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/costing/methods/ManufacturingRepostCostDifferenceDistributionTest.java
@@ -243,6 +243,64 @@ class ManufacturingRepostCostDifferenceDistributionTest
 				.isEqualByComparingTo(EXPECTED_ALREADY_SHIPPED);
 	}
 
+	/**
+	 * Reverses all three legs (MAIN, ADJUSTMENT, ALREADY_SHIPPED) the way
+	 * {@code CostingService.createReversalCostDetailsOrEmpty} actually drives them: one
+	 * {@code CostingMethodHandler.createOrUpdateCost} call per leg, all against the SAME reversal document.
+	 * <p>
+	 * {@code createOrUpdateCost}'s idempotency guard used to be {@code !existingCostDetails.isEmpty()} - "does
+	 * ANY cost detail already exist for this document" - which the SECOND and THIRD calls satisfied the moment
+	 * the FIRST call persisted the MAIN leg, even though ADJUSTMENT/ALREADY_SHIPPED were never created. Each
+	 * call then returned the MAIN row again, so the reversal ended up with three copies of the MAIN amount and
+	 * none of ADJUSTMENT/ALREADY_SHIPPED - an unbalanced posting (one lone WIP line, no offsetting entry).
+	 */
+	@ParameterizedTest
+	@EnumSource(ManufacturingHandlerUnderTest.class)
+	void costDifferenceDistribution_reversal_recreatesAllThreeLegs_notJustMain(final ManufacturingHandlerUnderTest handlerUnderTest)
+	{
+		setupOrderFor(handlerUnderTest);
+
+		final CostDetailCreateRequest request = distributionRequest();
+		handler.createOrUpdateCost(request);
+		assertThat(currentCostPriceOf(request)).isEqualByComparingTo("34"); // (30 x 8 + 32) / 8
+
+		final PPCostCollectorId reversalCollectorId = createCostDifferenceDistributionCollector();
+		final CostDetailCreateRequest reversalTemplate = request.toBuilder()
+				.documentRef(CostingDocumentRef.ofCostCollectorId(reversalCollectorId))
+				.initialDocumentRef(CostingDocumentRef.ofCostCollectorId(distributionCollectorId))
+				.build();
+
+		// what CostingService hands the handler for each reversed leg: the original leg's amount and qty, negated
+		for (final CostDetail original : utils.getExistingCostDetails(request))
+		{
+			handler.createOrUpdateCost(reversalTemplate.withAmountAndTypeAndQty(
+					original.getAmt().negate(),
+					original.getAmtType(),
+					original.getQty().negate()));
+		}
+
+		assertThat(currentCostPriceOf(request)).isEqualByComparingTo(MAIN_CURRENT_COST_PRICE); // moved back
+
+		final CostDetailCreateResultsList reversalResults = utils.toCostDetailCreateResultsList(
+				utils.getExistingCostDetails(reversalTemplate));
+		final CostAmountDetailed reversed = reversalResults.getTotalAmountToPost(utils.getAcctSchemaById(acctSchemaId));
+
+		assertThat(reversed.getMainAmt().toBigDecimal())
+				.as("MAIN leg reversed")
+				.isEqualByComparingTo("-" + EXPECTED_RESIDUAL);
+		assertThat(reversed.getCostAdjustmentAmt().toBigDecimal())
+				.as("ADJUSTMENT leg must be recreated by its own call, not collapsed into MAIN")
+				.isEqualByComparingTo("-" + EXPECTED_CAPITALIZED);
+		assertThat(reversed.getAlreadyShippedAmt().toBigDecimal())
+				.as("ALREADY_SHIPPED leg must be recreated by its own call, not collapsed into MAIN")
+				.isEqualByComparingTo("-" + EXPECTED_ALREADY_SHIPPED);
+	}
+
+	private BigDecimal currentCostPriceOf(final CostDetailCreateRequest request)
+	{
+		return utils.getCurrentCost(request).getCostPrice().toBigDecimal();
+	}
+
 	//
 	//
 	// fixture

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/costing/methods/ManufacturingRepostCostDifferenceDistributionTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/costing/methods/ManufacturingRepostCostDifferenceDistributionTest.java
@@ -284,6 +284,28 @@ class ManufacturingRepostCostDifferenceDistributionTest
 		assertThat(reversed.getAlreadyShippedAmt().toBigDecimal())
 				.as("ALREADY_SHIPPED leg must be recreated by its own call, not collapsed into MAIN")
 				.isEqualByComparingTo("-" + EXPECTED_ALREADY_SHIPPED);
+
+		// repost of the reversal document itself, all 3 legs already persisted: must recover them, not
+		// crash (the pre-fix ImmutableMap.toImmutableMap keying by costElementId alone throws
+		// IllegalArgumentException: Multiple entries with same key once all 3 same-cost-element rows exist)
+		// and not duplicate them.
+		for (final CostDetail original : utils.getExistingCostDetails(request))
+		{
+			handler.createOrUpdateCost(reversalTemplate.withAmountAndTypeAndQty(
+					original.getAmt().negate(),
+					original.getAmtType(),
+					original.getQty().negate()));
+		}
+
+		assertThat(utils.getExistingCostDetails(reversalTemplate))
+				.as("repost recovers the 3 existing legs, does not duplicate them")
+				.hasSize(3);
+		final CostAmountDetailed reversedAfterRepost = utils
+				.toCostDetailCreateResultsList(utils.getExistingCostDetails(reversalTemplate))
+				.getTotalAmountToPost(utils.getAcctSchemaById(acctSchemaId));
+		assertThat(reversedAfterRepost.getMainAmt().toBigDecimal()).isEqualByComparingTo(reversed.getMainAmt().toBigDecimal());
+		assertThat(reversedAfterRepost.getCostAdjustmentAmt().toBigDecimal()).isEqualByComparingTo(reversed.getCostAdjustmentAmt().toBigDecimal());
+		assertThat(reversedAfterRepost.getAlreadyShippedAmt().toBigDecimal()).isEqualByComparingTo(reversed.getAlreadyShippedAmt().toBigDecimal());
 	}
 
 	private BigDecimal currentCostPriceOf(final CostDetailCreateRequest request)

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/costing/methods/ManufacturingRepostCostDifferenceDistributionTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/costing/methods/ManufacturingRepostCostDifferenceDistributionTest.java
@@ -243,17 +243,7 @@ class ManufacturingRepostCostDifferenceDistributionTest
 				.isEqualByComparingTo(EXPECTED_ALREADY_SHIPPED);
 	}
 
-	/**
-	 * Reverses all three legs (MAIN, ADJUSTMENT, ALREADY_SHIPPED) the way
-	 * {@code CostingService.createReversalCostDetailsOrEmpty} actually drives them: one
-	 * {@code CostingMethodHandler.createOrUpdateCost} call per leg, all against the SAME reversal document.
-	 * <p>
-	 * {@code createOrUpdateCost}'s idempotency guard used to be {@code !existingCostDetails.isEmpty()} - "does
-	 * ANY cost detail already exist for this document" - which the SECOND and THIRD calls satisfied the moment
-	 * the FIRST call persisted the MAIN leg, even though ADJUSTMENT/ALREADY_SHIPPED were never created. Each
-	 * call then returned the MAIN row again, so the reversal ended up with three copies of the MAIN amount and
-	 * none of ADJUSTMENT/ALREADY_SHIPPED - an unbalanced posting (one lone WIP line, no offsetting entry).
-	 */
+	// one createOrUpdateCost call per leg against the same reversal document, as CostingService actually drives it
 	@ParameterizedTest
 	@EnumSource(ManufacturingHandlerUnderTest.class)
 	void costDifferenceDistribution_reversal_recreatesAllThreeLegs_notJustMain(final ManufacturingHandlerUnderTest handlerUnderTest)

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/costing/methods/ManufacturingRepostCostDifferenceDistributionTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/costing/methods/ManufacturingRepostCostDifferenceDistributionTest.java
@@ -38,10 +38,15 @@ import de.metas.costing.CostingDocumentRef;
 import de.metas.costing.CostingLevel;
 import de.metas.costing.CostingMethod;
 import de.metas.costing.IProductCostingBL;
+import de.metas.costing.CostDetailReverseRequest;
+import de.metas.costing.ICostDetailService;
+import de.metas.costing.ICurrentCostsRepository;
 import de.metas.costing.impl.CostDetailRepository;
 import de.metas.costing.impl.CostDetailService;
 import de.metas.costing.impl.CostElementRepository;
+import de.metas.costing.impl.CostingService;
 import de.metas.costing.impl.CurrentCostsRepository;
+import de.metas.i18n.ExplainedOptional;
 import de.metas.currency.CurrencyCode;
 import de.metas.currency.CurrencyPrecision;
 import de.metas.currency.CurrencyRepository;
@@ -125,6 +130,8 @@ class ManufacturingRepostCostDifferenceDistributionTest
 	private ProductId componentProductId;
 
 	private CostElementRepository costElementRepo;
+	private ICostDetailService costDetailService;
+	private ICurrentCostsRepository currentCostsRepo;
 	private CostingMethodHandlerUtils utils;
 	private PPOrderCostDifferenceDistributor distributor;
 
@@ -132,6 +139,7 @@ class ManufacturingRepostCostDifferenceDistributionTest
 	private AcctSchemaId acctSchemaId;
 	private CostElement costElement;
 	private CostingMethodHandler handler;
+	private CostingService costingService;
 	private PPOrderId orderId;
 	private PPCostCollectorId distributionCollectorId;
 
@@ -198,10 +206,9 @@ class ManufacturingRepostCostDifferenceDistributionTest
 		Services.registerService(IProductCostingBL.class, new MockedProductCostingBL(CostingLevel.Client, CostingMethod.AveragePO));
 
 		costElementRepo = new CostElementRepository(ADReferenceService.newMocked());
-		utils = new CostingMethodHandlerUtils(
-				new CurrencyRepository(),
-				new CurrentCostsRepository(costElementRepo),
-				new CostDetailService(new CostDetailRepository(), costElementRepo));
+		currentCostsRepo = new CurrentCostsRepository(costElementRepo);
+		costDetailService = new CostDetailService(new CostDetailRepository(), costElementRepo);
+		utils = new CostingMethodHandlerUtils(new CurrencyRepository(), currentCostsRepo, costDetailService);
 		distributor = new PPOrderCostDifferenceDistributor(costElementRepo, utils);
 	}
 
@@ -243,7 +250,9 @@ class ManufacturingRepostCostDifferenceDistributionTest
 				.isEqualByComparingTo(EXPECTED_ALREADY_SHIPPED);
 	}
 
-	// one createOrUpdateCost call per leg against the same reversal document, as CostingService actually drives it
+	// drives CostingService.createReversalCostDetailsOrEmpty directly - the actual entry point
+	// DocLine_CostCollector calls when the reversal document itself is posted - not the manufacturing
+	// handler in isolation, so this also exercises CostingService's own (costElementId, amtType) lookup.
 	@ParameterizedTest
 	@EnumSource(ManufacturingHandlerUnderTest.class)
 	void costDifferenceDistribution_reversal_recreatesAllThreeLegs_notJustMain(final ManufacturingHandlerUnderTest handlerUnderTest)
@@ -255,24 +264,17 @@ class ManufacturingRepostCostDifferenceDistributionTest
 		assertThat(currentCostPriceOf(request)).isEqualByComparingTo("34"); // (30 x 8 + 32) / 8
 
 		final PPCostCollectorId reversalCollectorId = createCostDifferenceDistributionCollector();
-		final CostDetailCreateRequest reversalTemplate = request.toBuilder()
-				.documentRef(CostingDocumentRef.ofCostCollectorId(reversalCollectorId))
+		final CostDetailReverseRequest reversalRequest = CostDetailReverseRequest.builder()
+				.acctSchemaId(acctSchemaId)
 				.initialDocumentRef(CostingDocumentRef.ofCostCollectorId(distributionCollectorId))
+				.reversalDocumentRef(CostingDocumentRef.ofCostCollectorId(reversalCollectorId))
+				.date(request.getDate())
 				.build();
 
-		// what CostingService hands the handler for each reversed leg: the original leg's amount and qty, negated
-		for (final CostDetail original : utils.getExistingCostDetails(request))
-		{
-			handler.createOrUpdateCost(reversalTemplate.withAmountAndTypeAndQty(
-					original.getAmt().negate(),
-					original.getAmtType(),
-					original.getQty().negate()));
-		}
+		final CostDetailCreateResultsList reversalResults = costingService.createReversalCostDetailsOrEmpty(reversalRequest).orElseThrow();
 
 		assertThat(currentCostPriceOf(request)).isEqualByComparingTo(MAIN_CURRENT_COST_PRICE); // moved back
 
-		final CostDetailCreateResultsList reversalResults = utils.toCostDetailCreateResultsList(
-				utils.getExistingCostDetails(reversalTemplate));
 		final CostAmountDetailed reversed = reversalResults.getTotalAmountToPost(utils.getAcctSchemaById(acctSchemaId));
 
 		assertThat(reversed.getMainAmt().toBigDecimal())
@@ -285,24 +287,16 @@ class ManufacturingRepostCostDifferenceDistributionTest
 				.as("ALREADY_SHIPPED leg must be recreated by its own call, not collapsed into MAIN")
 				.isEqualByComparingTo("-" + EXPECTED_ALREADY_SHIPPED);
 
-		// repost of the reversal document itself, all 3 legs already persisted: must recover them, not
-		// crash (the pre-fix ImmutableMap.toImmutableMap keying by costElementId alone throws
-		// IllegalArgumentException: Multiple entries with same key once all 3 same-cost-element rows exist)
-		// and not duplicate them.
-		for (final CostDetail original : utils.getExistingCostDetails(request))
-		{
-			handler.createOrUpdateCost(reversalTemplate.withAmountAndTypeAndQty(
-					original.getAmt().negate(),
-					original.getAmtType(),
-					original.getQty().negate()));
-		}
+		// repost of the SAME reversal document: existingCostDetailsList (CostingService.java) is now
+		// fetched with all 3 legs already persisted, sharing one costElementId - the exact shape that
+		// crashed a costElementId-keyed ImmutableMap.toImmutableMap build (IllegalArgumentException:
+		// Multiple entries with same key) before the fix. Must recover, not crash or duplicate.
+		final CostDetailCreateResultsList repostResults = costingService.createReversalCostDetailsOrEmpty(reversalRequest).orElseThrow();
 
-		assertThat(utils.getExistingCostDetails(reversalTemplate))
+		assertThat(utils.getExistingCostDetails(request.toBuilder().documentRef(reversalRequest.getReversalDocumentRef()).build()))
 				.as("repost recovers the 3 existing legs, does not duplicate them")
 				.hasSize(3);
-		final CostAmountDetailed reversedAfterRepost = utils
-				.toCostDetailCreateResultsList(utils.getExistingCostDetails(reversalTemplate))
-				.getTotalAmountToPost(utils.getAcctSchemaById(acctSchemaId));
+		final CostAmountDetailed reversedAfterRepost = repostResults.getTotalAmountToPost(utils.getAcctSchemaById(acctSchemaId));
 		assertThat(reversedAfterRepost.getMainAmt().toBigDecimal()).isEqualByComparingTo(reversed.getMainAmt().toBigDecimal());
 		assertThat(reversedAfterRepost.getCostAdjustmentAmt().toBigDecimal()).isEqualByComparingTo(reversed.getCostAdjustmentAmt().toBigDecimal());
 		assertThat(reversedAfterRepost.getAlreadyShippedAmt().toBigDecimal()).isEqualByComparingTo(reversed.getAlreadyShippedAmt().toBigDecimal());
@@ -328,6 +322,7 @@ class ManufacturingRepostCostDifferenceDistributionTest
 				.build();
 		costElement = costElementRepo.getOrCreateMaterialCostElement(clientId, handlerUnderTest.costingMethod);
 		handler = handlerUnderTest.createHandler(utils, distributor);
+		costingService = new CostingService(utils, costDetailService, costElementRepo, currentCostsRepo, ImmutableList.of(handler));
 
 		orderId = createCompletedPPOrder();
 		distributionCollectorId = createCostDifferenceDistributionCollector();


### PR DESCRIPTION
## Summary

Reversing a `CostDifferenceDistribution` cost collector (Reverse-Correct) produced an unbalanced posting: the reversal document ended up with `Posted='E'` (posting error), zero `M_CostDetail` rows, and its only `Fact_Acct` line was a lone, unbalanced WIP debit with no offsetting credit — failing the posting framework's own balance check (`Invalid accounting operation structure (1 DR lines, 0 CR lines)`). As a result the finished good's current cost price never moved back after the reversal.

## Root cause

A `CostDifferenceDistribution` collector persists three cost-detail legs (MAIN, ADJUSTMENT, ALREADY_SHIPPED) that all share the same cost element. `CostingService.createReversalCostDetailsOrEmpty` reverses a collector by calling each manufacturing costing-method handler's `createOrUpdateCost` once per original leg, all against the same reversal document.

Each handler's "was this already posted" guard checked only whether *any* cost detail already existed for that document (`!existingCostDetails.isEmpty()`). Once the first call persisted the MAIN leg, the second and third calls saw a non-empty result and handed the MAIN row back again instead of creating their own ADJUSTMENT/ALREADY_SHIPPED rows. The reversal ended up with three copies of the MAIN amount and neither of the other two legs — the unbalanced posting described above.

## Change

- `ManufacturingAveragePOCostingMethodHandler`, `ManufacturingLastPOCostingMethodHandler`, `ManufacturingMovingAverageInvoiceCostingMethodHandler`: the idempotency guard now checks for the specific `amtType` being requested (via a new `CostingMethodHandlerUtils.containsAmtType` helper), not just non-emptiness, so a still-missing leg of a partially-recreated document is created instead of being short-circuited.
- `CostingService.createReversalCostDetailsOrEmpty`: replaced the costElementId-only lookup (used to detect an already-recreated leg) with a lookup on (costElementId, amtType) — a costElementId-only key cannot distinguish the three legs of one collector and would collide once all three exist.
- Extends the cucumber scenario that reproduced this defect (reverse the distribution collector and assert the reversal posts correctly and moves the cost price back).
- Adds a parameterized unit test (`ManufacturingRepostCostDifferenceDistributionTest`) covering all three affected handlers, driving the exact call sequence `CostingService` uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK7nWWPtkR9VpivCYkmL39
