### PR TITLE
Add `shipment-order parcels` references to `Shipment Schedule` window

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5823910_sys_gh31910_ShipmentSchedule_To_Carrier_ShipmentOrder_Parcel_Relation.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5823910_sys_gh31910_ShipmentSchedule_To_Carrier_ShipmentOrder_Parcel_Relation.sql
@@ -1,0 +1,37 @@
+-- 1. Target AD_Reference (ValidationType 'T') ---------------------------------
+INSERT INTO AD_Reference (AD_Client_ID,AD_Org_ID,AD_Reference_ID,Created,CreatedBy,EntityType,IsActive,IsOrderByValue,Name,Updated,UpdatedBy,ValidationType)
+VALUES (0,0,542140,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','N','Carrier_ShipmentOrder_Parcel_Target_For_M_ShipmentSchedule',TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,'T')
+;
+
+INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Reference_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Reference t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Reference_ID=542140
+AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
+;
+
+-- 2. Target AD_Ref_Table: Carrier_ShipmentOrder_Parcel, filtered to the -------
+--    parcels of the shipment(s) the selected shipment schedule was shipped on.
+INSERT INTO AD_Ref_Table (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,AD_Key,AD_Window_ID,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsActive,IsValueDisplayed,ShowInactiveValues,WhereClause)
+VALUES (0,0,542140,542535,591136,541957,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','N','N',
+'exists
+(
+	select 1
+	from M_ShipmentSchedule_QtyPicked qp
+	join M_InOutLine iol on iol.M_InOutLine_ID = qp.M_InOutLine_ID
+	join M_ShippingPackage sp on sp.M_InOut_ID = iol.M_InOut_ID
+	where
+	qp.M_ShipmentSchedule_ID = @M_ShipmentSchedule_ID/-1@
+	and Carrier_ShipmentOrder_Parcel.M_Package_ID = sp.M_Package_ID
+)')
+;
+
+-- 3. Relation type: reused M_ShipmentSchedule source (540553) -> parcel target (542140)
+INSERT INTO AD_RelationType (AD_Client_ID,AD_Org_ID,AD_RelationType_ID,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsActive,Name,InternalName,IsTableRecordIDTarget,AD_Reference_Source_ID,AD_Reference_Target_ID)
+VALUES (0,0,540507,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','M_ShipmentSchedule -> Carrier Shipment Order Parcel','M_ShipmentSchedule_to_Carrier_ShipmentOrder_Parcel','N',540553,542140)
+;
+
+-- 4. Index coverage:
+CREATE INDEX IF NOT EXISTS M_ShipmentSchedule_QtyPicked_ShipmentSchedule ON M_ShipmentSchedule_QtyPicked (M_ShipmentSchedule_ID);
+CREATE INDEX IF NOT EXISTS M_ShippingPackage_InOut                       ON M_ShippingPackage (M_InOut_ID);
+CREATE INDEX IF NOT EXISTS Carrier_ShipmentOrder_Parcel_Package          ON Carrier_ShipmentOrder_Parcel (M_Package_ID);

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5823910_sys_gh31910_ShipmentSchedule_To_Carrier_ShipmentOrder_Parcel_Relation.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5823910_sys_gh31910_ShipmentSchedule_To_Carrier_ShipmentOrder_Parcel_Relation.sql
@@ -10,18 +10,19 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.
 AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
 ;
 
--- 2. Target AD_Ref_Table: Carrier_ShipmentOrder_Parcel, filtered to the -------
---    parcels of the shipment(s) the selected shipment schedule was shipped on.
+-- 2. Target AD_Ref_Table: Carrier_ShipmentOrder_Parcel, scoped to the -------
+--    parcels of the SELECTED schedule's own order line (not the whole shipment).
+--    M_ShippingPackage is the M_Package <-> C_OrderLine junction; matching its
+--    C_OrderLine_ID to the schedule's line keeps parcels of other schedules on
+--    the same shipment out (M_Package itself carries no order-line reference).
 INSERT INTO AD_Ref_Table (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,AD_Key,AD_Window_ID,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsActive,IsValueDisplayed,ShowInactiveValues,WhereClause)
 VALUES (0,0,542140,542535,591136,541957,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','N','N',
 'exists
 (
 	select 1
-	from M_ShipmentSchedule_QtyPicked qp
-	join M_InOutLine iol on iol.M_InOutLine_ID = qp.M_InOutLine_ID
-	join M_ShippingPackage sp on sp.M_InOut_ID = iol.M_InOut_ID
+	from M_ShippingPackage sp
 	where
-	qp.M_ShipmentSchedule_ID = @M_ShipmentSchedule_ID/-1@
+	sp.C_OrderLine_ID = @C_OrderLine_ID/-1@
 	and Carrier_ShipmentOrder_Parcel.M_Package_ID = sp.M_Package_ID
 )')
 ;
@@ -30,8 +31,3 @@ VALUES (0,0,542140,542535,591136,541957,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY
 INSERT INTO AD_RelationType (AD_Client_ID,AD_Org_ID,AD_RelationType_ID,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsActive,Name,InternalName,IsTableRecordIDTarget,AD_Reference_Source_ID,AD_Reference_Target_ID)
 VALUES (0,0,540507,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','M_ShipmentSchedule -> Carrier Shipment Order Parcel','M_ShipmentSchedule_to_Carrier_ShipmentOrder_Parcel','N',540553,542140)
 ;
-
--- 4. Index coverage:
-CREATE INDEX IF NOT EXISTS M_ShipmentSchedule_QtyPicked_ShipmentSchedule ON M_ShipmentSchedule_QtyPicked (M_ShipmentSchedule_ID);
-CREATE INDEX IF NOT EXISTS M_ShippingPackage_InOut                       ON M_ShippingPackage (M_InOut_ID);
-CREATE INDEX IF NOT EXISTS Carrier_ShipmentOrder_Parcel_Package          ON Carrier_ShipmentOrder_Parcel (M_Package_ID);

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5823910_sys_gh31910_ShipmentSchedule_To_Carrier_ShipmentOrder_Parcel_Relation.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5823910_sys_gh31910_ShipmentSchedule_To_Carrier_ShipmentOrder_Parcel_Relation.sql
@@ -28,4 +28,5 @@ VALUES (0,0,540507,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::
 ;
 
 -- 4. Index coverage:
-CREATE INDEX IF NOT EXISTS Carrier_ShipmentOrder_Parcel_Package ON Carrier_ShipmentOrder_Parcel (M_Package_ID);
+CREATE INDEX IF NOT EXISTS Carrier_ShipmentOrder_Parcel_M_Package_ID ON Carrier_ShipmentOrder_Parcel (M_Package_ID);
+CREATE INDEX IF NOT EXISTS M_PackageLine_M_InOutLine_ID ON M_PackageLine (M_InOutLine_ID);

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5823910_sys_gh31910_ShipmentSchedule_To_Carrier_ShipmentOrder_Parcel_Relation.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5823910_sys_gh31910_ShipmentSchedule_To_Carrier_ShipmentOrder_Parcel_Relation.sql
@@ -10,20 +10,15 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.
 AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
 ;
 
--- 2. Target AD_Ref_Table: Carrier_ShipmentOrder_Parcel, scoped to the -------
---    parcels of the SELECTED schedule's own order line (not the whole shipment).
---    M_ShippingPackage is the M_Package <-> C_OrderLine junction; matching its
---    C_OrderLine_ID to the schedule's line keeps parcels of other schedules on
---    the same shipment out (M_Package itself carries no order-line reference).
+-- 2. Target AD_Ref_Table: Carrier_ShipmentOrder_Parcel -------
 INSERT INTO AD_Ref_Table (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,AD_Key,AD_Window_ID,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsActive,IsValueDisplayed,ShowInactiveValues,WhereClause)
 VALUES (0,0,542140,542535,591136,541957,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','N','N',
-'exists
-(
-	select 1
-	from M_ShippingPackage sp
-	where
-	sp.C_OrderLine_ID = @C_OrderLine_ID/-1@
-	and Carrier_ShipmentOrder_Parcel.M_Package_ID = sp.M_Package_ID
+        'exists (
+    select 1
+    from M_PackageLine pkl
+    join M_ShipmentSchedule_QtyPicked qp on qp.M_InOutLine_ID = pkl.M_InOutLine_ID
+    where pkl.M_Package_ID = Carrier_ShipmentOrder_Parcel.M_Package_ID
+    and qp.M_ShipmentSchedule_ID = @M_ShipmentSchedule_ID/-1@
 )')
 ;
 
@@ -31,3 +26,6 @@ VALUES (0,0,542140,542535,591136,541957,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY
 INSERT INTO AD_RelationType (AD_Client_ID,AD_Org_ID,AD_RelationType_ID,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsActive,Name,InternalName,IsTableRecordIDTarget,AD_Reference_Source_ID,AD_Reference_Target_ID)
 VALUES (0,0,540507,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','M_ShipmentSchedule -> Carrier Shipment Order Parcel','M_ShipmentSchedule_to_Carrier_ShipmentOrder_Parcel','N',540553,542140)
 ;
+
+-- 4. Index coverage:
+CREATE INDEX IF NOT EXISTS Carrier_ShipmentOrder_Parcel_Package ON Carrier_ShipmentOrder_Parcel (M_Package_ID);


### PR DESCRIPTION
Adds an `AD_RelationType` so the `Lieferdisposition (M_ShipmentSchedule)` References panel offers a `Versandauftragspaket` group that jumps to the `carrier shipment-order parcels (Carrier_ShipmentOrder_Parcel)` of the shipment(s):

- Reuses the existing M_ShipmentSchedule source reference (540553); new target reference (542140) + relation type (540507).
- Filters the parcel target via M_ShipmentSchedule_QtyPicked -> M_InOutLine -> M_InOut -> M_ShippingPackage, mirroring the existing C_Order -> parcel relation (5823910 sibling of 5813280).
- Adds covering indexes for the panel query's join columns.