### PR TITLE
gh31771: default-sort MobileUI MFG attributes grid by SeqNo asc

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823940_sys_mobileMfgAttrGridSortBySeqNo.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823940_sys_mobileMfgAttrGridSortBySeqNo.sql
@@ -1,0 +1,8 @@
+-- MobileUI Manufacturing config — default-sort the editable-attributes child grid by SeqNo ascending.
+-- Window 541788, tab 549417 (Merkmale / MobileUI_MFG_Config_Attribute): SeqNo drives the order the
+-- attributes are presented on the mobile receive dialog, so the grid must default to SeqNo ascending.
+-- AD_Field.SortNo is the signed grid default-sort key (sign = asc(+)/desc(-), magnitude = priority);
+-- +1 = primary sort key ascending. Field 783058 = the SeqNo field on that tab.
+
+-- 2026-09-10 09:00:00
+UPDATE AD_Field SET SortNo=1, Updated=TO_TIMESTAMP('2026-09-10 09:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Field_ID=783058;


### PR DESCRIPTION
## What

UAT defect fix.

Window **541788** (MobileUI Manufacturing Configuration), child tab **549417** "Merkmale" (table `MobileUI_MFG_Config_Attribute`): the editable-attributes grid was **not** default-sorted. `SeqNo` defines the order the attributes are presented on the mobile receive dialog, so the grid must default-sort by `SeqNo` ascending.

## Fix

Migration `5823940_sys_mobileMfgAttrGridSortBySeqNo.sql` — a single `UPDATE` setting `AD_Field.SortNo=1` on the `SeqNo` field (`AD_Field_ID=783058`) of that tab. `AD_Field.SortNo` is the signed grid default-sort key (sign = asc(+)/desc(-), magnitude = priority); `+1` = primary key ascending. No new IDs, no other fields carry a conflicting SortNo.

Convention confirmed against real data: 58 shipped tabs sort their `SeqNo` field with `SortNo=1` (e.g. window 102 tab 107 — the AD_Field grid itself).

## Verification (local new_dawn_uat)

- **Before:** all 7 fields on tab 549417 had `SortNo` NULL, grid unsorted.
- **After** (migration applied): `SeqNo` field `SortNo=1`; all 6 other fields NULL, no conflict.
- window-designer verdict: **PASS** — grid default-sorts by SeqNo ascending.
