### PR TITLE
Product Proposals — filter to products with delivery history

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5823770_sys_product_proposal_delivered_filter_message.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5823770_sys_product_proposal_delivered_filter_message.sql
@@ -1,0 +1,28 @@
+-- IDs allocated from idserver.metas.de on 2026-09-10:
+--   AD_Message_ID 545833 (OnlyProductsWithDeliveryHistory filter label)
+
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545833 /*From ID Server*/,0,TO_TIMESTAMP('2026-09-10 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Nur Produkte mit Lieferhistorie','I',TO_TIMESTAMP('2026-09-10 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'OnlyProductsWithDeliveryHistory')
+;
+
+-- Seed all active system languages with the German base text
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Message_ID=545833
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- Update German translations (de_DE and de_CH) to mark as translated
+UPDATE AD_Message_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-10 10:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='de_DE' AND AD_Message_ID=545833
+;
+
+UPDATE AD_Message_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-10 10:00:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='de_CH' AND AD_Message_ID=545833
+;
+
+-- Override en_US with the English translation
+UPDATE AD_Message_Trl SET MsgText='Only products with delivery history', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-10 10:00:03','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545833
+;

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/filters/OrderProductsProposalViewFilters.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/filters/OrderProductsProposalViewFilters.java
@@ -69,7 +69,7 @@ public class OrderProductsProposalViewFilters
 				.build();
 	}
 
-	private static ITranslatableString getOnlyDeliveredCaption()
+	static ITranslatableString getOnlyDeliveredCaption()
 	{
 		return Services.get(IMsgBL.class).getTranslatableMsgText(ProductsProposalViewFilter.PARAM_OnlyDelivered);
 	}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/filters/OrderProductsProposalViewFilters.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/filters/OrderProductsProposalViewFilters.java
@@ -1,0 +1,91 @@
+package de.metas.ui.web.order.products_proposal.filters;
+
+import de.metas.i18n.IMsgBL;
+import de.metas.i18n.ITranslatableString;
+import de.metas.ui.web.document.filter.DocumentFilter;
+import de.metas.ui.web.document.filter.DocumentFilterDescriptor;
+import de.metas.ui.web.document.filter.DocumentFilterInlineRenderMode;
+import de.metas.ui.web.document.filter.DocumentFilterList;
+import de.metas.ui.web.document.filter.DocumentFilterParamDescriptor;
+import de.metas.ui.web.document.filter.provider.DocumentFilterDescriptorsProvider;
+import de.metas.ui.web.document.filter.provider.ImmutableDocumentFilterDescriptorsProvider;
+import de.metas.ui.web.view.json.JSONFilterViewRequest;
+import de.metas.ui.web.window.descriptor.DocumentFieldWidgetType;
+import de.metas.util.Services;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
+/*
+ * #%L
+ * metasfresh-webui-api
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * Filter descriptors for the {@code orderProductsProposal} view ("Produktvorschläge") only.
+ * <p>
+ * Kept deliberately separate from {@link ProductsProposalViewFilters} so that the sibling
+ * "Andere Produkte" sub-view ({@code basePLVProductsProposal}) gains no new filter parameter.
+ */
+@UtilityClass
+public class OrderProductsProposalViewFilters
+{
+	public static final String FILTER_ID = "onlyDeliveredFilter";
+
+	public static DocumentFilterDescriptorsProvider getDescriptors()
+	{
+		return ImmutableDocumentFilterDescriptorsProvider.builder()
+				.addDescriptor(createOnlyDeliveredFilterDescriptor())
+				.build();
+	}
+
+	private static DocumentFilterDescriptor createOnlyDeliveredFilterDescriptor()
+	{
+		return DocumentFilterDescriptor.builder()
+				.setFilterId(FILTER_ID)
+				.setFrequentUsed(true)
+				.setInlineRenderMode(DocumentFilterInlineRenderMode.INLINE_PARAMETERS)
+				.setDisplayName(getOnlyDeliveredCaption())
+				.addParameter(DocumentFilterParamDescriptor.builder()
+						.fieldName(ProductsProposalViewFilter.PARAM_OnlyDelivered)
+						.displayName(getOnlyDeliveredCaption())
+						.widgetType(DocumentFieldWidgetType.YesNo))
+				.build();
+	}
+
+	private static ITranslatableString getOnlyDeliveredCaption()
+	{
+		return Services.get(IMsgBL.class).getTranslatableMsgText(ProductsProposalViewFilter.PARAM_OnlyDelivered);
+	}
+
+	public static ProductsProposalViewFilter extractFilter(@NonNull final JSONFilterViewRequest filterViewRequest)
+	{
+		final DocumentFilterList filters = filterViewRequest.getFiltersUnwrapped(getDescriptors());
+		return filters.getFilterById(FILTER_ID)
+				.map(OrderProductsProposalViewFilters::toProductsProposalViewFilterValue)
+				.orElse(ProductsProposalViewFilter.ANY);
+	}
+
+	private static ProductsProposalViewFilter toProductsProposalViewFilterValue(final DocumentFilter filter)
+	{
+		return ProductsProposalViewFilter.builder()
+				.onlyDelivered(filter.getParameterValueAsBoolean(ProductsProposalViewFilter.PARAM_OnlyDelivered, false))
+				.build();
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/filters/ProductsProposalViewFilter.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/filters/ProductsProposalViewFilter.java
@@ -33,6 +33,8 @@ public class ProductsProposalViewFilter
 
 	public static final String FILTER_ID = "defaultFilter";
 	static final String PARAM_ProductName = "ProductName";
+	public static final String PARAM_OnlyDelivered = "OnlyProductsWithDeliveryHistory";
 
 	String productName;
+	boolean onlyDelivered;
 }

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/filters/ProductsProposalViewFilters.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/filters/ProductsProposalViewFilters.java
@@ -115,6 +115,7 @@ public class ProductsProposalViewFilters
 		{
 			documentFilters.add(DocumentFilter.builder()
 					.setFilterId(OrderProductsProposalViewFilters.FILTER_ID)
+					.setCaption(OrderProductsProposalViewFilters.getOnlyDeliveredCaption())
 					.addParameter(DocumentFilterParam.ofNameEqualsValue(ProductsProposalViewFilter.PARAM_OnlyDelivered, Boolean.TRUE))
 					.build());
 		}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/filters/ProductsProposalViewFilters.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/filters/ProductsProposalViewFilters.java
@@ -1,5 +1,6 @@
 package de.metas.ui.web.order.products_proposal.filters;
 
+import com.google.common.collect.ImmutableList;
 import de.metas.i18n.IMsgBL;
 import de.metas.i18n.ITranslatableString;
 import de.metas.ui.web.document.filter.DocumentFilter;
@@ -104,11 +105,20 @@ public class ProductsProposalViewFilters
 			builder.addParameter(DocumentFilterParam.ofNameEqualsValue(ProductsProposalViewFilter.PARAM_ProductName, filter.getProductName()));
 		}
 
-		if (!builder.hasParameters())
+		final ImmutableList.Builder<DocumentFilter> documentFilters = ImmutableList.builder();
+		if (builder.hasParameters())
 		{
-			return DocumentFilterList.EMPTY;
+			documentFilters.add(builder.build());
 		}
 
-		return DocumentFilterList.of(builder.build());
+		if (filter.isOnlyDelivered())
+		{
+			documentFilters.add(DocumentFilter.builder()
+					.setFilterId(OrderProductsProposalViewFilters.FILTER_ID)
+					.addParameter(DocumentFilterParam.ofNameEqualsValue(ProductsProposalViewFilter.PARAM_OnlyDelivered, Boolean.TRUE))
+					.build());
+		}
+
+		return DocumentFilterList.ofList(documentFilters.build());
 	}
 }

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRow.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRow.java
@@ -284,6 +284,14 @@ public class ProductsProposalRow implements IViewRow
 		// (ProductsProposalRowsData#getAllRowsIncludingFilteredOut), which is what actually guarantees
 		// no typed quantity is lost.
 		//
+		// Because qty is editable, this is the first criterion whose outcome an edit can change. Row
+		// membership is recomputed only when a filter is applied (ProductsProposalRowsData#filter), NOT
+		// on every row change, so clearing a quantity back to zero while the filter is on leaves that
+		// row on screen until the filter is re-applied. That is deliberate: making a row vanish from
+		// under the cursor mid-edit is worse than showing one row too many, and nothing is lost either
+		// way - OrderLinesFromProductProposalsProducer gates on the same isQtySet() predicate, so a
+		// cleared row produces no order line however long it stays visible.
+		//
 		// The exemption deliberately does NOT cover the product-name search: that search is the only
 		// filter the "Andere Produkte" view offers, and this predicate is shared with it, so exempting
 		// typed-quantity rows from the name search would silently change that view's results - which

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRow.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRow.java
@@ -276,8 +276,19 @@ public class ProductsProposalRow implements IViewRow
 
 	public boolean isMatching(@NonNull final ProductsProposalViewFilter filter)
 	{
+		return isMatchingProductName(filter)
+				&& isMatchingOnlyDelivered(filter);
+	}
+
+	private boolean isMatchingProductName(@NonNull final ProductsProposalViewFilter filter)
+	{
 		return Check.isEmpty(filter.getProductName())
 				|| getProductName().toLowerCase().contains(filter.getProductName().toLowerCase());
+	}
+
+	private boolean isMatchingOnlyDelivered(@NonNull final ProductsProposalViewFilter filter)
+	{
+		return !filter.isOnlyDelivered() || lastShipmentDays != null;
 	}
 
 	public ProductsProposalRow withExistingOrderLine(@Nullable final OrderLine existingOrderLine)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRow.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRow.java
@@ -276,8 +276,20 @@ public class ProductsProposalRow implements IViewRow
 
 	public boolean isMatching(@NonNull final ProductsProposalViewFilter filter)
 	{
+		// A row the user has already typed a quantity into is never hidden by the DELIVERY-HISTORY
+		// criterion, so that quantity can still be seen and corrected instead of vanishing. It gates on
+		// the same predicate OrderLinesFromProductProposalsProducer uses to decide which rows become
+		// order lines, so visibility and line production stay in lockstep - and it is not a substitute
+		// for creating those lines from the unfiltered rows
+		// (ProductsProposalRowsData#getAllRowsIncludingFilteredOut), which is what actually guarantees
+		// no typed quantity is lost.
+		//
+		// The exemption deliberately does NOT cover the product-name search: that search is the only
+		// filter the "Andere Produkte" view offers, and this predicate is shared with it, so exempting
+		// typed-quantity rows from the name search would silently change that view's results - which
+		// this change must not do.
 		return isMatchingProductName(filter)
-				&& isMatchingOnlyDelivered(filter);
+				&& (isQtySet() || isMatchingOnlyDelivered(filter));
 	}
 
 	private boolean isMatchingProductName(@NonNull final ProductsProposalViewFilter filter)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowsData.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowsData.java
@@ -172,6 +172,24 @@ public class ProductsProposalRowsData implements IEditableRowsData<ProductsPropo
 		return getTopLevelRows();
 	}
 
+	/**
+	 * All rows, ignoring the current filter - i.e. built from {@code rowIdsOrdered} instead of
+	 * {@code rowIdsOrderedAndFiltered}.
+	 *
+	 * <p>
+	 * Needed because everything a user typed into a row has to survive filtering: a quantity entered
+	 * on a row that a later filter hides is still a quantity the user asked for. {@link #getAllRows()}
+	 * streams the filtered ids, so callers that turn rows into persistent records - notably creating
+	 * the order lines when the view is closed with DONE - must use this method, or the hidden rows are
+	 * silently dropped.
+	 */
+	public synchronized ImmutableList<ProductsProposalRow> getAllRowsIncludingFilteredOut()
+	{
+		return rowIdsOrdered.stream()
+				.map(rowsById::get)
+				.collect(ImmutableList.toImmutableList());
+	}
+
 	@Override
 	public DocumentIdsSelection getDocumentIdsToInvalidate(final TableRecordReferenceSet recordRefs)
 	{

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowsData.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowsData.java
@@ -320,6 +320,12 @@ public class ProductsProposalRowsData implements IEditableRowsData<ProductsPropo
 
 	private synchronized void addRow(final ProductsProposalRow row)
 	{
+		// Deliberately added to the FILTERED list too, without consulting the active filter: a product
+		// the user just picked from "Andere Produkte" must appear, or it would vanish on arrival (a
+		// freshly added row carries no quantity yet, so the delivery-history criterion alone would
+		// exclude it) and there would be no row to type a quantity into. It is dropped again the next
+		// time the filter is applied, which costs nothing: a row with no quantity produces no order
+		// line either way (OrderLinesFromProductProposalsProducer gates on isQtySet()).
 		rowIdsOrderedAndFiltered.add(0, row.getId()); // add first
 		rowIdsOrdered.add(0, row.getId()); // add first
 

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowsData.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowsData.java
@@ -166,6 +166,14 @@ public class ProductsProposalRowsData implements IEditableRowsData<ProductsPropo
 				.collect(ImmutableList.toImmutableList());
 	}
 
+	/**
+	 * Only the rows the current filter keeps - this is what the grid renders.
+	 *
+	 * <p>
+	 * A caller that turns rows into persistent records (creating the order lines, an export, a bulk
+	 * action) must NOT use this: a row the filter hides would be silently dropped. Use
+	 * {@link #getAllRowsIncludingFilteredOut()} there.
+	 */
 	@Override
 	public ImmutableList<ProductsProposalRow> getAllRows()
 	{

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/view/OrderProductsProposalViewFactory.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/view/OrderProductsProposalViewFactory.java
@@ -216,7 +216,9 @@ public class OrderProductsProposalViewFactory extends ProductsProposalViewFactor
 	{
 		OrderLinesFromProductProposalsProducer.builder()
 				.orderId(view.getOrderId().get())
-				.rows(view.getAllRows())
+				// NOT getAllRows(): that one is filtered, so a quantity typed on a row the user then
+				// hid with a filter would never become an order line.
+				.rows(view.getAllRowsIncludingFilteredOut())
 				.build()
 				.produce();
 	}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/view/OrderProductsProposalViewFactory.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/view/OrderProductsProposalViewFactory.java
@@ -10,6 +10,7 @@ import de.metas.pricing.rules.campaign_price.CampaignPriceService;
 import de.metas.process.RelatedProcessDescriptor;
 import de.metas.ui.web.order.products_proposal.campaign_price.CampaignPriceProvider;
 import de.metas.ui.web.order.products_proposal.campaign_price.CampaignPriceProviders;
+import de.metas.ui.web.order.products_proposal.filters.OrderProductsProposalViewFilters;
 import de.metas.ui.web.order.products_proposal.model.ProductsProposalRow;
 import de.metas.ui.web.order.products_proposal.model.ProductsProposalRowsLoader;
 import de.metas.ui.web.order.products_proposal.process.WEBUI_Order_ProductsProposal_Launcher;
@@ -20,11 +21,14 @@ import de.metas.ui.web.order.products_proposal.process.WEBUI_ProductsProposal_Sh
 import de.metas.ui.web.order.products_proposal.service.Order;
 import de.metas.ui.web.order.products_proposal.service.OrderLinesFromProductProposalsProducer;
 import de.metas.ui.web.order.products_proposal.service.OrderProductProposalsService;
+import de.metas.ui.web.view.IView;
+import de.metas.ui.web.view.IViewsRepository;
 import de.metas.ui.web.view.ViewCloseAction;
 import de.metas.ui.web.view.ViewFactory;
 import de.metas.ui.web.view.ViewId;
 import de.metas.ui.web.view.descriptor.ViewLayout;
 import de.metas.ui.web.view.descriptor.annotation.ViewColumnHelper.ClassViewColumnOverrides;
+import de.metas.ui.web.view.json.JSONFilterViewRequest;
 import de.metas.ui.web.window.datatypes.WindowId;
 import de.metas.ui.web.window.model.lookup.LookupDataSourceFactory;
 import de.metas.util.Services;
@@ -34,6 +38,7 @@ import org.compiere.model.I_C_Order;
 import org.compiere.util.TimeUtil;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 /*
  * #%L
@@ -94,6 +99,7 @@ public class OrderProductsProposalViewFactory extends ProductsProposalViewFactor
 				.setCaption(caption)
 				.allowViewCloseAction(ViewCloseAction.CANCEL)
 				.allowViewCloseAction(ViewCloseAction.DONE)
+				.setFilters(OrderProductsProposalViewFilters.getDescriptors().getAll())
 				//
 				.setFocusOnFieldName(ProductsProposalRow.FIELD_Qty)
 				.addElementsFromViewRowClassAndFieldNames(
@@ -180,6 +186,17 @@ public class OrderProductsProposalViewFactory extends ProductsProposalViewFactor
 				createProcessDescriptor(WEBUI_ProductsProposal_ShowProductsToAddFromBasePriceList.class),
 				createProcessDescriptor(WEBUI_ProductsProposal_ShowProductsSoldToOtherCustomers.class),
 				createProcessDescriptor(WEBUI_ProductsProposal_Delete.class));
+	}
+
+	@Override
+	public ProductsProposalView filterView(
+			final IView view,
+			final JSONFilterViewRequest filterViewRequest,
+			final Supplier<IViewsRepository> viewsRepo)
+	{
+		final ProductsProposalView productsProposalView = ProductsProposalView.cast(view);
+		productsProposalView.filter(OrderProductsProposalViewFilters.extractFilter(filterViewRequest));
+		return productsProposalView;
 	}
 
 	@Override

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/view/ProductsProposalView.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/view/ProductsProposalView.java
@@ -173,6 +173,10 @@ public class ProductsProposalView extends AbstractCustomView<ProductsProposalRow
 				.orElseThrow(() -> new AdempiereException("@NotFound@ @M_Pricelist_Version_Base_ID@"));
 	}
 
+	/**
+	 * Only the rows the current filter keeps. A caller that must not lose a filtered-out row - anything
+	 * producing persistent records - wants {@link #getAllRowsIncludingFilteredOut()} instead.
+	 */
 	public List<ProductsProposalRow> getAllRows()
 	{
 		return ImmutableList.copyOf(getRows());

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/view/ProductsProposalView.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/view/ProductsProposalView.java
@@ -178,6 +178,12 @@ public class ProductsProposalView extends AbstractCustomView<ProductsProposalRow
 		return ImmutableList.copyOf(getRows());
 	}
 
+	/** All rows, ignoring the current filter - see {@link ProductsProposalRowsData#getAllRowsIncludingFilteredOut()}. */
+	public List<ProductsProposalRow> getAllRowsIncludingFilteredOut()
+	{
+		return rowsData.getAllRowsIncludingFilteredOut();
+	}
+
 	public void addOrUpdateRows(@NonNull final List<ProductsProposalRowAddRequest> requests)
 	{
 		rowsData.addOrUpdateRows(requests);

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowTest.java
@@ -1,6 +1,7 @@
 package de.metas.ui.web.order.products_proposal.model;
 
 import de.metas.currency.Amount;
+import java.math.BigDecimal;
 import de.metas.currency.CurrencyCode;
 import de.metas.ui.web.order.products_proposal.filters.ProductsProposalViewFilter;
 import de.metas.ui.web.window.datatypes.DocumentId;
@@ -64,7 +65,47 @@ public class ProductsProposalRowTest
 		assertThat(row(null).isMatching(filter)).isFalse();
 	}
 
+	@Test
+	public void isMatching_onlyDeliveredSet_rowWithoutLastShipmentDaysButWithQty_matches()
+	{
+		final ProductsProposalViewFilter filter = ProductsProposalViewFilter.builder()
+				.onlyDelivered(true)
+				.build();
+
+		// A quantity the user typed must not vanish behind the filter.
+		assertThat(rowWithQty(null, BigDecimal.ONE).isMatching(filter)).isTrue();
+	}
+
+	@Test
+	public void isMatching_onlyDeliveredSet_rowWithoutLastShipmentDaysAndZeroQty_doesNotMatch()
+	{
+		final ProductsProposalViewFilter filter = ProductsProposalViewFilter.builder()
+				.onlyDelivered(true)
+				.build();
+
+		// Zero is not a typed quantity - it is what an untouched row holds once it has been visited.
+		assertThat(rowWithQty(null, BigDecimal.ZERO).isMatching(filter)).isFalse();
+	}
+
+	@Test
+	public void isMatching_productNameSearch_isNotExemptedByQty()
+	{
+		// The product-name search is the only filter the "Andere Produkte" view offers, and it shares
+		// this predicate: a typed quantity must NOT keep a non-matching row in that view's results.
+		final ProductsProposalViewFilter filter = ProductsProposalViewFilter.builder()
+				.productName("something-else")
+				.build();
+
+		assertThat(rowWithQty(null, BigDecimal.ONE).isMatching(filter)).isFalse();
+		assertThat(rowWithQty(5, BigDecimal.ONE).isMatching(filter)).isFalse();
+	}
+
 	private static ProductsProposalRow row(final Integer lastShipmentDays)
+	{
+		return rowWithQty(lastShipmentDays, null);
+	}
+
+	private static ProductsProposalRow rowWithQty(final Integer lastShipmentDays, final BigDecimal qty)
 	{
 		return ProductsProposalRow.builder()
 				.id(DocumentId.of(1))
@@ -72,7 +113,7 @@ public class ProductsProposalRowTest
 				.price(ProductProposalPrice.builder()
 						.priceListPrice(Amount.of(10, CurrencyCode.EUR))
 						.build())
-				.qty(null)
+				.qty(qty)
 				.lastShipmentDays(lastShipmentDays)
 				.seqNo(10)
 				.build();

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowTest.java
@@ -1,0 +1,80 @@
+package de.metas.ui.web.order.products_proposal.model;
+
+import de.metas.currency.Amount;
+import de.metas.currency.CurrencyCode;
+import de.metas.ui.web.order.products_proposal.filters.ProductsProposalViewFilter;
+import de.metas.ui.web.window.datatypes.DocumentId;
+import de.metas.ui.web.window.datatypes.LookupValue.IntegerLookupValue;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * #%L
+ * metasfresh-webui-api
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+public class ProductsProposalRowTest
+{
+	@Test
+	public void isMatching_onlyDeliveredNotSet_matchesRegardlessOfLastShipmentDays()
+	{
+		final ProductsProposalViewFilter filter = ProductsProposalViewFilter.builder()
+				.onlyDelivered(false)
+				.build();
+
+		assertThat(row(null).isMatching(filter)).isTrue();
+		assertThat(row(5).isMatching(filter)).isTrue();
+	}
+
+	@Test
+	public void isMatching_onlyDeliveredSet_rowWithLastShipmentDays_matches()
+	{
+		final ProductsProposalViewFilter filter = ProductsProposalViewFilter.builder()
+				.onlyDelivered(true)
+				.build();
+
+		assertThat(row(5).isMatching(filter)).isTrue();
+	}
+
+	@Test
+	public void isMatching_onlyDeliveredSet_rowWithoutLastShipmentDays_doesNotMatch()
+	{
+		final ProductsProposalViewFilter filter = ProductsProposalViewFilter.builder()
+				.onlyDelivered(true)
+				.build();
+
+		assertThat(row(null).isMatching(filter)).isFalse();
+	}
+
+	private static ProductsProposalRow row(final Integer lastShipmentDays)
+	{
+		return ProductsProposalRow.builder()
+				.id(DocumentId.of(1))
+				.product(IntegerLookupValue.of(1, "product-1"))
+				.price(ProductProposalPrice.builder()
+						.priceListPrice(Amount.of(10, CurrencyCode.EUR))
+						.build())
+				.qty(null)
+				.lastShipmentDays(lastShipmentDays)
+				.seqNo(10)
+				.build();
+	}
+}

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowsDataTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowsDataTest.java
@@ -1,0 +1,109 @@
+package de.metas.ui.web.order.products_proposal.model;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.currency.Amount;
+import de.metas.currency.CurrencyCode;
+import de.metas.ui.web.order.products_proposal.filters.ProductsProposalViewFilter;
+import de.metas.ui.web.window.datatypes.DocumentId;
+import de.metas.ui.web.window.datatypes.DocumentIdIntSequence;
+import de.metas.ui.web.window.datatypes.LookupValue.IntegerLookupValue;
+import de.metas.lang.SOTrx;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * #%L
+ * metasfresh-webui-api
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * Pins the guarantee that order-line creation cannot lose a row to a filter: closing the view with DONE
+ * builds the lines from {@link ProductsProposalRowsData#getAllRowsIncludingFilteredOut()}, never from the
+ * filtered {@link ProductsProposalRowsData#getAllRows()}.
+ *
+ * <p>
+ * The UI can no longer present that situation - a row with a typed quantity is exempt from the
+ * delivery-history criterion, so it stays visible - which is exactly why the guarantee needs a test of
+ * its own here rather than relying on an end-to-end scenario.
+ */
+public class ProductsProposalRowsDataTest
+{
+	@Test
+	public void getAllRowsIncludingFilteredOut_returnsRowsTheFilterRemoved()
+	{
+		final ProductsProposalRow delivered = row(1, "delivered-product", 5, null);
+		final ProductsProposalRow neverDelivered = row(2, "never-delivered-product", null, null);
+
+		final ProductsProposalRowsData rowsData = rowsData(delivered, neverDelivered);
+
+		rowsData.filter(ProductsProposalViewFilter.builder().onlyDelivered(true).build());
+
+		assertThat(rowsData.getAllRows())
+				.as("the filtered accessor must drop the row the filter removed")
+				.containsExactly(delivered);
+
+		assertThat(rowsData.getAllRowsIncludingFilteredOut())
+				.as("order lines are built from this accessor, so it must keep every row")
+				.containsExactly(delivered, neverDelivered);
+	}
+
+	@Test
+	public void getAllRowsIncludingFilteredOut_keepsTheLoadedOrder()
+	{
+		final ProductsProposalRow first = row(1, "product-a", null, null);
+		final ProductsProposalRow second = row(2, "product-b", null, null);
+
+		final ProductsProposalRowsData rowsData = rowsData(first, second);
+
+		assertThat(rowsData.getAllRowsIncludingFilteredOut()).containsExactly(first, second);
+	}
+
+	private static ProductsProposalRowsData rowsData(final ProductsProposalRow... rows)
+	{
+		return ProductsProposalRowsData.builder()
+				.nextRowIdSequence(DocumentIdIntSequence.newInstance())
+				.bpartnerId(BPartnerId.ofRepoId(1))
+				.soTrx(SOTrx.SALES)
+				.rows(Arrays.asList(rows))
+				.build();
+	}
+
+	private static ProductsProposalRow row(
+			final int id,
+			final String productName,
+			final Integer lastShipmentDays,
+			final BigDecimal qty)
+	{
+		return ProductsProposalRow.builder()
+				.id(DocumentId.of(id))
+				.product(IntegerLookupValue.of(id, productName))
+				.price(ProductProposalPrice.builder()
+						.priceListPrice(Amount.of(10, CurrencyCode.EUR))
+						.build())
+				.qty(qty)
+				.lastShipmentDays(lastShipmentDays)
+				.seqNo(id)
+				.build();
+	}
+}

--- a/e2e/frontend-webui/WIDGET_PATTERNS.md
+++ b/e2e/frontend-webui/WIDGET_PATTERNS.md
@@ -63,11 +63,15 @@ handleMouseDown(option) {
 - **Input field**: `#lookup_C_BPartner_ID input.input-field`
 - **Dropdown list**: `.input-dropdown-list`
 - **Dropdown options**: `.input-dropdown-list-option`
-- **Loading spinner**: `#lookup_C_BPartner_ID .rotating`
+- **Loading spinner**: none — `#lookup_C_BPartner_ID .rotating` and `.indicator-pending` are **never rendered** by the frontend (verified: `grep -rn "indicator-pending\|rotating" frontend/src frontend/scss` matches only `window-indicator.scss`'s `@keyframes`/`animation-name`, never a class on an element). A `waitFor({ state: 'detached' })` on either resolves on the first poll and proves nothing. See [claude-docs/selectors-and-gotchas.md](claude-docs/selectors-and-gotchas.md) § "Dead Settle-Wait" — the authoritative writeup, with the worked `page.waitForResponse` replacement.
 
 **Working Interaction Pattern**:
 ```javascript
-// CORRECT PATTERN - Verified against frontend source code
+// Debounce timeout + dropdown-visibility wait below are the real, verified signals this
+// interaction depends on. Earlier versions of this pattern also waited on `#lookup_${fieldName}
+// .rotating` / `.indicator-pending` / `networkidle` as "loading" signals — none of those are ever
+// emitted by the frontend (see claude-docs/selectors-and-gotchas.md § "Dead Settle-Wait" for why
+// and for the page.waitForResponse pattern this suite actually uses instead); removed here.
 static async selectLookupValue(fieldName, searchText, optionText) {
   const page = getPage();
 
@@ -78,63 +82,46 @@ static async selectLookupValue(fieldName, searchText, optionText) {
   // 2. Click to focus the field
   await lookupInput.click();
 
-  // 3. Wait for any initial loading to complete
-  await page.locator(`#lookup_${fieldName} .rotating`).waitFor({
-    state: 'detached',
-    timeout: 10000,
-  }).catch(() => {});
-
-  // 4. Clear and type search text
+  // 3. Clear and type search text
   await lookupInput.fill('');
   await page.waitForTimeout(200);
   await lookupInput.fill(searchText);
 
-  // 5. Wait for dropdown to load (debounce + API call)
+  // 4. Wait for dropdown to load (debounce + API call), then for options to render
   await page.waitForTimeout(500);
-  await page.locator(`#lookup_${fieldName} .rotating`).waitFor({
-    state: 'detached',
-    timeout: 10000,
-  }).catch(() => {});
-
-  // 6. Wait for dropdown options to appear
   const dropdownList = page.locator('.input-dropdown-list');
   await dropdownList.waitFor({ state: 'visible', timeout: 10000 });
 
-  // 7. Find the specific option (use filter for partial match)
+  // 5. Find the specific option (use filter for partial match)
   const option = page.locator('.input-dropdown-list-option')
     .filter({ hasText: optionText })
     .first();
 
-  // 8. Verify option exists
+  // 6. Verify option exists
   const optionCount = await option.count();
   if (optionCount === 0) {
     const allOptions = await page.locator('.input-dropdown-list-option').allTextContents();
     throw new Error(`Option "${optionText}" not found. Available: ${allOptions.join(', ')}`);
   }
 
-  // 9. Click the option (triggers onMouseDown → handleSelect)
+  // 7. Click the option (triggers onMouseDown → handleSelect)
   await option.click();
 
-  // 10. Wait for dropdown to close
+  // 8. Wait for dropdown to close
   await dropdownList.waitFor({ state: 'detached', timeout: 5000 }).catch(() => {});
 
-  // 11. Press Tab to confirm and trigger save
+  // 9. Press Tab to confirm and trigger save
   await page.keyboard.press('Tab');
 
-  // 12. Wait for save to complete
+  // 10. Wait for save to complete — for a real save-completion signal, wait on the
+  // page.waitForResponse for the field's PATCH/edit call (see claude-docs/selectors-and-gotchas.md
+  // § "Dead Settle-Wait" for the worked example), not on a fixed timeout.
   await page.waitForTimeout(300);
-  await page.locator('.rotating, .indicator-pending').waitFor({
-    state: 'detached',
-    timeout: 10000,
-  }).catch(() => {});
-
-  // 13. Wait for network idle (auto-save)
-  await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 }
 ```
 
 **Common Pitfalls**:
-1. **Not waiting for spinner**: The lookup makes API calls - always wait for `.rotating` to detach
+1. **`.rotating`/`.indicator-pending` are not real signals**: never rendered by the frontend — a `waitFor({ state: 'detached' })` on either resolves instantly and proves nothing. Wait on the debounce timeout + dropdown visibility, or better, `page.waitForResponse` on the actual network call (see [claude-docs/selectors-and-gotchas.md](claude-docs/selectors-and-gotchas.md) § "Dead Settle-Wait")
 2. **Clicking too fast**: Allow 500ms debounce after typing before clicking option
 3. **Not pressing Tab**: Selection commits on blur - Tab ensures the save triggers
 4. **Wrong selector scope**: Dropdown list is NOT inside `#lookup_X`, it's a separate element

--- a/e2e/frontend-webui/tests/spec/product-proposal-delivered-filter.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-proposal-delivered-filter.spec.js
@@ -1,0 +1,315 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import { DashboardPage } from '../utils/pages/DashboardPage';
+import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
+import { ShipmentSchedulePage } from '../utils/pages/ShipmentSchedulePage';
+import { ProductProposalPage } from '../utils/pages/ProductProposalPage';
+import { FRONTEND_BASE_URL, SLOW_ACTION_TIMEOUT } from '../utils/common';
+import { SALES_ORDER_WINDOW_ID } from '../utils/WindowIds';
+
+/**
+ * Product Proposals (Produktvorschläge) - "delivered-only" filter E2E (TC1-TC4).
+ *
+ * The overlay lists every product of the active price-list version. This spec proves the
+ * real-world case: a salesperson re-ordering a regular customer's assortment restricts the list
+ * to the products this partner has already had delivered, instead of scanning past products the
+ * customer has never bought.
+ *
+ * Fixture (shared across all four cases):
+ * 1. One partner (CUSTOMER_WITH_HISTORY) gets a real order -> shipment -> completion for
+ *    Product1 + Product2. Product3 is never shipped to them.
+ * 2. A second partner (CUSTOMER_NO_HISTORY) never receives anything (TC4).
+ * 3. `C_BPartner_Product_Stats` is populated asynchronously after shipment completion
+ *    (interceptor/M_InOut.java:58 -> BPartnerProductStatsEventSender -> distributed event bus ->
+ *    BPartnerProductStatsEventHandler). The overlay's loader only attaches lastShipmentDays at
+ *    view-construction time, so the spec polls by repeatedly opening a FRESH overlay until the
+ *    value appears - asserting immediately would be a guaranteed flake.
+ *
+ * All assertions read row content from the rendered UI (product cells / row count), never via
+ * page.request, per the workspace E2E conventions.
+ */
+
+// Same overlay scoping ProductProposalPage.js uses internally (not exported): the overlay is a
+// raw-modal panel layered over the still-mounted order window, so an unscoped `table tbody tr`
+// would also match the order lines grid behind it.
+const OVERLAY_ROWS = '.raw-modal .panel-modal table tbody tr';
+const OVERLAY_FILTER_CHECKBOX =
+  '.raw-modal .panel-modal .filters-frequent .inline-filters label.input-checkbox input[type="checkbox"]';
+
+// Named so a poll timeout points straight at the mechanism, not just "value never appeared".
+const STATS_ASYNC_MECHANISM =
+  'BPartnerProductStatsEventSender (distributed C_BPartner_Product_Stats event topic, ' +
+  'consumed by BPartnerProductStatsEventHandler)';
+
+const DAYS_PATTERN = /^\d+$/;
+const hasDeliveryValue = (lastShipmentDaysText) => DAYS_PATTERN.test((lastShipmentDaysText || '').trim());
+
+/**
+ * Read every row of the currently-rendered overlay grid: product cell text (which contains the
+ * product's code - the same signal other specs in this suite match on, e.g.
+ * `inline-edit.spec.js` matching `masterdata.products.Product1.productCode` in rendered text) and
+ * the raw "Tage vergangen" (lastShipmentDays) cell text ('' when the value is null).
+ */
+async function readOverlayRows(page) {
+  const rows = page.locator(OVERLAY_ROWS);
+  const count = await rows.count();
+
+  const result = [];
+  for (let i = 0; i < count; i += 1) {
+    const row = rows.nth(i);
+    const product = (await row.locator('td[data-cy="cell-product"]').innerText()).trim();
+    const lastShipmentDays = (await row.locator('td[data-cy="cell-lastShipmentDays"]').innerText()).trim();
+    result.push({ product, lastShipmentDays });
+  }
+
+  return result;
+}
+
+test.describe('Product Proposals - delivered-only filter', () => {
+  test('Filter Produktvorschläge to products already delivered to this partner (TC1-TC4)', async ({ page }) => {
+    allure.epic('E0100: Sales');
+    allure.tag('F00140: Sales Order - Product Proposals');
+    allure.story('Produktvorschläge: restrict to products already delivered');
+    allure.severity('critical');
+
+    allure.description(`
+## F00140: Sales Order - Product Proposals
+
+### Test Scenario (TC1, TC2, TC3, TC4)
+
+A salesperson re-ordering a regular customer's assortment restricts the *Produktvorschläge*
+overlay to the products this partner has already had delivered, instead of scanning past products
+the customer has never bought.
+
+1. Build delivery history for Product1 + Product2 via a real order -> shipment -> completion;
+   Product3 is never shipped (fixture).
+2. Poll for the async \`C_BPartner_Product_Stats\` update before asserting anything (fixture).
+3. **TC2** - a freshly opened overlay lists all three products with the filter present but off.
+4. **TC1** - switching the filter on narrows the list to Product1 + Product2.
+5. **TC3** - switching it back off restores the full list.
+6. **TC4** - a partner with no delivery history at all sees an empty list with the filter on, and
+   no error.
+    `);
+
+    test.setTimeout(300000); // the order -> shipment -> completion chain is slow
+
+    // === CREATE TEST DATA ===
+    // Both bpartners share the SAME M_PriceList_Version - CreateBPartnerCommand reuses the unique
+    // PricingSystemId already in the masterdata context instead of creating a second one - so both
+    // partners see the same 3 products in the overlay; only their delivery history differs.
+    const masterdata = await Backend.createMasterdata({
+      request: {
+        login: {
+          user: { language: 'en_US', firstname: 'first', lastname: 'last' },
+        },
+        bpartners: {
+          CUSTOMER_WITH_HISTORY: {
+            isVendor: false,
+            isCustomer: true,
+            isSoPriceList: true,
+            name: 'CustomerWithHistory',
+          },
+          CUSTOMER_NO_HISTORY: {
+            isVendor: false,
+            isCustomer: true,
+            isSoPriceList: true,
+            name: 'CustomerNoHistory',
+          },
+        },
+        products: {
+          Product1: {
+            name: 'DeliveredFirst',
+            type: 'Item',
+            prices: [{ price: 10.0, currencyCode: 'EUR' }],
+          },
+          Product2: {
+            name: 'DeliveredSecond',
+            type: 'Item',
+            prices: [{ price: 20.0, currencyCode: 'EUR' }],
+          },
+          Product3: {
+            name: 'NeverDelivered',
+            type: 'Item',
+            prices: [{ price: 30.0, currencyCode: 'EUR' }],
+          },
+        },
+      },
+    });
+
+    allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+
+    const customerWithHistoryCode = masterdata.bpartners.CUSTOMER_WITH_HISTORY.bpartnerCode;
+    const customerNoHistoryCode = masterdata.bpartners.CUSTOMER_NO_HISTORY.bpartnerCode;
+    const product1Code = masterdata.products.Product1.productCode;
+    const product2Code = masterdata.products.Product2.productCode;
+    const product3Code = masterdata.products.Product3.productCode;
+
+    // === LOGIN ===
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await DashboardPage.expectVisible();
+
+    // === FIXTURE STEP 1: deliver Product1 + Product2 to CUSTOMER_WITH_HISTORY; Product3 never ===
+    await test.step('Fixture - deliver Product1 + Product2 to CUSTOMER_WITH_HISTORY (Product3 never)', async () => {
+      await SalesOrderPage.goto();
+      await SalesOrderPage.clickNew();
+      const historyOrderId = await SalesOrderPage.selectCustomer(customerWithHistoryCode);
+
+      await SalesOrderPage.addOrderLine({
+        product: product1Code,
+        quantity: '5',
+        recordId: historyOrderId,
+      });
+
+      // Reload before adding the second line. SalesOrderPage.addOrderLine() reuses the same
+      // batch-entry toggle button across calls; back-to-back calls on one order can leave that
+      // toggle in a state where the second click closes an already-open panel instead of opening
+      // it, so the second line silently never reaches the server (known sharp edge of the shared
+      // helper - see compensation-group-bundle.spec.js's own note on addOrderLine's fragility). A
+      // full reload guarantees the batch-entry panel starts closed for the second call.
+      await page.goto(`${FRONTEND_BASE_URL}/window/${SALES_ORDER_WINDOW_ID}/${historyOrderId}`);
+      await page.locator('.rotating, .panel-spaced-lg').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+      await page.waitForTimeout(1000);
+
+      await SalesOrderPage.addOrderLine({
+        product: product2Code,
+        quantity: '5',
+        recordId: historyOrderId,
+      });
+
+      await SalesOrderPage.complete();
+      console.log(`History order completed: record=${historyOrderId}`);
+
+      // Wait for async schedule creation (same pattern as document-references.spec.js)
+      await page.waitForTimeout(5000);
+
+      await SalesOrderPage.openRelatedShipmentCandidate({
+        maxRetries: 10,
+        retryDelay: 3000,
+        refreshOnRetry: true,
+      });
+      await ShipmentSchedulePage.expectVisible();
+      await ShipmentSchedulePage.createShipment();
+      console.log('Shipment created and completed for Product1 + Product2');
+    });
+
+    // === FIXTURE STEP 2: the second, fresh sales order TC1/TC2/TC3 run against ===
+    await test.step('Fixture - create a second, fresh order for CUSTOMER_WITH_HISTORY', async () => {
+      await SalesOrderPage.goto();
+      await SalesOrderPage.clickNew();
+      const tcOrderId = await SalesOrderPage.selectCustomer(customerWithHistoryCode);
+      console.log(`TC order created: record=${tcOrderId}`);
+    });
+
+    // === FIXTURE STEP 3: wait for the async C_BPartner_Product_Stats update ===
+    // Shipment completion only ENQUEUES the stats update; the overlay's loader attaches
+    // lastShipmentDays only at view-construction time, so every poll attempt must open a
+    // genuinely FRESH overlay (close + reopen), not just re-read an already-open one.
+    await test.step('Fixture - wait for C_BPartner_Product_Stats (async) before any filter assertion', async () => {
+      await expect
+        .poll(
+          async () => {
+            await ProductProposalPage.openFromSalesOrder(page);
+            const rows = await readOverlayRows(page);
+            await ProductProposalPage.closeWithDone(page);
+
+            const row1 = rows.find((r) => r.product.includes(product1Code));
+            const row2 = rows.find((r) => r.product.includes(product2Code));
+
+            return Boolean(
+              row1 && hasDeliveryValue(row1.lastShipmentDays) && row2 && hasDeliveryValue(row2.lastShipmentDays)
+            );
+          },
+          {
+            timeout: 120000,
+            message:
+              'Tage vergangen (lastShipmentDays) never appeared for Product1/Product2 - the async stats update ' +
+              `(${STATS_ASYNC_MECHANISM}) was not consumed within the timeout`,
+          }
+        )
+        .toBe(true);
+    });
+
+    // === TC2: freshly opened overlay - filter present, off, full row set ===
+    await test.step('TC2 - overlay opens with the filter present but not active; all three products listed', async () => {
+      await ProductProposalPage.openFromSalesOrder(page);
+
+      expect(await ProductProposalPage.getRowCount(page)).toBe(3);
+
+      const rows = await readOverlayRows(page);
+      const row1 = rows.find((r) => r.product.includes(product1Code));
+      const row2 = rows.find((r) => r.product.includes(product2Code));
+      const row3 = rows.find((r) => r.product.includes(product3Code));
+
+      expect(row1, 'Product1 row missing from the unfiltered overlay').toBeTruthy();
+      expect(row2, 'Product2 row missing from the unfiltered overlay').toBeTruthy();
+      expect(row3, 'Product3 row missing from the unfiltered overlay').toBeTruthy();
+      expect(hasDeliveryValue(row1.lastShipmentDays)).toBe(true);
+      expect(hasDeliveryValue(row2.lastShipmentDays)).toBe(true);
+      expect(hasDeliveryValue(row3.lastShipmentDays)).toBe(false); // Product3 was never shipped
+
+      // The filter control itself must be present, and unchecked (AC2, AC3)
+      const filterCheckbox = page.locator(OVERLAY_FILTER_CHECKBOX).first();
+      await expect(filterCheckbox).toBeAttached();
+      await expect(filterCheckbox).not.toBeChecked();
+    });
+
+    // === TC1: switch the filter on - only the delivered products remain ===
+    await test.step('TC1 - filter on narrows the list to the delivered products', async () => {
+      await ProductProposalPage.setFilter(page, true);
+
+      expect(await ProductProposalPage.getRowCount(page)).toBe(2);
+
+      const rows = await readOverlayRows(page);
+      const productsShown = rows.map((r) => r.product);
+
+      expect(productsShown.some((p) => p.includes(product1Code))).toBe(true);
+      expect(productsShown.some((p) => p.includes(product2Code))).toBe(true);
+      expect(productsShown.some((p) => p.includes(product3Code))).toBe(false);
+
+      for (const row of rows) {
+        expect(hasDeliveryValue(row.lastShipmentDays), `row for ${row.product} has no Tage vergangen value`).toBe(
+          true
+        );
+      }
+    });
+
+    // === TC3: switch the filter off again - the full list returns ===
+    await test.step('TC3 - filter off restores the full list', async () => {
+      await ProductProposalPage.setFilter(page, false);
+
+      expect(await ProductProposalPage.getRowCount(page)).toBe(3);
+
+      const rows = await readOverlayRows(page);
+      const productsShown = rows.map((r) => r.product);
+      expect(productsShown.some((p) => p.includes(product1Code))).toBe(true);
+      expect(productsShown.some((p) => p.includes(product2Code))).toBe(true);
+      expect(productsShown.some((p) => p.includes(product3Code))).toBe(true);
+    });
+
+    await ProductProposalPage.closeWithDone(page);
+
+    // === TC4: a partner with no delivery history at all ===
+    await test.step('TC4 - partner with no delivery history: filter on yields an empty list, no error', async () => {
+      await SalesOrderPage.goto();
+      await SalesOrderPage.clickNew();
+      await SalesOrderPage.selectCustomer(customerNoHistoryCode);
+
+      await ProductProposalPage.openFromSalesOrder(page);
+
+      // Sanity: same shared price list, unfiltered - all three products are still offered; the
+      // difference from CUSTOMER_WITH_HISTORY is purely the (absent) delivery history.
+      expect(await ProductProposalPage.getRowCount(page)).toBe(3);
+
+      await ProductProposalPage.setFilter(page, true);
+
+      expect(await ProductProposalPage.getRowCount(page)).toBe(0);
+
+      const errorToast = page.locator('.Toastify div[role="alert"].Toastify__toast-body');
+      await expect(errorToast).toHaveCount(0);
+    });
+  });
+});

--- a/e2e/frontend-webui/tests/spec/product-proposal-delivered-filter.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-proposal-delivered-filter.spec.js
@@ -6,7 +6,11 @@ import { LoginPage } from '../utils/pages/LoginPage';
 import { DashboardPage } from '../utils/pages/DashboardPage';
 import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
 import { ShipmentSchedulePage } from '../utils/pages/ShipmentSchedulePage';
-import { ProductProposalPage } from '../utils/pages/ProductProposalPage';
+import {
+  ProductProposalPage,
+  ROWS as OVERLAY_ROWS,
+  FILTER_CHECKBOX as OVERLAY_FILTER_CHECKBOX,
+} from '../utils/pages/ProductProposalPage';
 import { FRONTEND_BASE_URL, SLOW_ACTION_TIMEOUT } from '../utils/common';
 import { SALES_ORDER_WINDOW_ID } from '../utils/WindowIds';
 
@@ -32,12 +36,6 @@ import { SALES_ORDER_WINDOW_ID } from '../utils/WindowIds';
  * page.request, per the workspace E2E conventions.
  */
 
-// Same overlay scoping ProductProposalPage.js uses internally (not exported): the overlay is a
-// raw-modal panel layered over the still-mounted order window, so an unscoped `table tbody tr`
-// would also match the order lines grid behind it.
-const OVERLAY_ROWS = '.raw-modal .panel-modal table tbody tr';
-const OVERLAY_FILTER_CHECKBOX =
-  '.raw-modal .panel-modal .filters-frequent .inline-filters label.input-checkbox input[type="checkbox"]';
 
 // Named so a poll timeout points straight at the mechanism, not just "value never appeared".
 const STATS_ASYNC_MECHANISM =
@@ -163,19 +161,6 @@ the customer has never bought.
         quantity: '5',
         recordId: historyOrderId,
       });
-
-      // Reload before adding the second line. SalesOrderPage.addOrderLine() reuses the same
-      // batch-entry toggle button across calls; back-to-back calls on one order can leave that
-      // toggle in a state where the second click closes an already-open panel instead of opening
-      // it, so the second line silently never reaches the server (known sharp edge of the shared
-      // helper - see compensation-group-bundle.spec.js's own note on addOrderLine's fragility). A
-      // full reload guarantees the batch-entry panel starts closed for the second call.
-      await page.goto(`${FRONTEND_BASE_URL}/window/${SALES_ORDER_WINDOW_ID}/${historyOrderId}`);
-      // Deterministic readiness signal instead of a fixed pause: addOrderLine's very first action is
-      // to scroll to and click this toggle, so the page is ready exactly when the toggle is visible.
-      await page
-        .getByTestId('batch-entry-toggle')
-        .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
 
       await SalesOrderPage.addOrderLine({
         product: product2Code,
@@ -311,11 +296,12 @@ the customer has never bought.
 
       expect(await ProductProposalPage.getRowCount(page)).toBe(0);
 
-      // A negative assertion needs a settle window, otherwise it passes simply because nothing has
-      // rendered yet: toHaveCount(0) matches an empty DOM immediately. Give the filter round-trip
-      // time to surface a toast, then assert none did.
+      // Zero rows + no toast alone would also be the signature of a filter round-trip that threw
+      // and left the grid empty, so first assert the overlay is still in a valid rendered state
+      // (column header present, spinners detached). That is also the settle window the negative
+      // toast assertion needs - toHaveCount(0) matches an empty DOM immediately.
+      await ProductProposalPage.expectVisible(page);
       const errorToast = page.locator('.Toastify div[role="alert"].Toastify__toast-body');
-      await page.waitForTimeout(3000);
       await expect(errorToast).toHaveCount(0);
     });
   });

--- a/e2e/frontend-webui/tests/spec/product-proposal-delivered-filter.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-proposal-delivered-filter.spec.js
@@ -67,7 +67,7 @@ async function readOverlayRows(page) {
 }
 
 test.describe('Product Proposals - delivered-only filter', () => {
-  test('Filter Produktvorschläge to products already delivered to this partner (TC1-TC4)', async ({ page }) => {
+  test('Filter Produktvorschläge to products already delivered to this partner', async ({ page }) => {
     allure.epic('E0100: Sales');
     allure.tag('F00140');
     allure.tag('F00140: Sales Order - Product Proposals');

--- a/e2e/frontend-webui/tests/spec/product-proposal-delivered-filter.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-proposal-delivered-filter.spec.js
@@ -69,6 +69,7 @@ async function readOverlayRows(page) {
 test.describe('Product Proposals - delivered-only filter', () => {
   test('Filter Produktvorschläge to products already delivered to this partner (TC1-TC4)', async ({ page }) => {
     allure.epic('E0100: Sales');
+    allure.tag('F00140');
     allure.tag('F00140: Sales Order - Product Proposals');
     allure.story('Produktvorschläge: restrict to products already delivered');
     allure.severity('critical');

--- a/e2e/frontend-webui/tests/spec/product-proposal-delivered-filter.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-proposal-delivered-filter.spec.js
@@ -171,8 +171,11 @@ the customer has never bought.
       // helper - see compensation-group-bundle.spec.js's own note on addOrderLine's fragility). A
       // full reload guarantees the batch-entry panel starts closed for the second call.
       await page.goto(`${FRONTEND_BASE_URL}/window/${SALES_ORDER_WINDOW_ID}/${historyOrderId}`);
-      await page.locator('.rotating, .panel-spaced-lg').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
-      await page.waitForTimeout(1000);
+      // Deterministic readiness signal instead of a fixed pause: addOrderLine's very first action is
+      // to scroll to and click this toggle, so the page is ready exactly when the toggle is visible.
+      await page
+        .getByTestId('batch-entry-toggle')
+        .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
 
       await SalesOrderPage.addOrderLine({
         product: product2Code,
@@ -308,7 +311,11 @@ the customer has never bought.
 
       expect(await ProductProposalPage.getRowCount(page)).toBe(0);
 
+      // A negative assertion needs a settle window, otherwise it passes simply because nothing has
+      // rendered yet: toHaveCount(0) matches an empty DOM immediately. Give the filter round-trip
+      // time to surface a toast, then assert none did.
       const errorToast = page.locator('.Toastify div[role="alert"].Toastify__toast-body');
+      await page.waitForTimeout(3000);
       await expect(errorToast).toHaveCount(0);
     });
   });

--- a/e2e/frontend-webui/tests/spec/product-proposal-delivered-filter.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-proposal-delivered-filter.spec.js
@@ -226,7 +226,7 @@ the customer has never bought.
     await test.step('TC2 - overlay opens with the filter present but not active; all three products listed', async () => {
       await ProductProposalPage.openFromSalesOrder(page);
 
-      expect(await ProductProposalPage.getRowCount(page)).toBe(3);
+      await expect(page.locator(OVERLAY_ROWS)).toHaveCount(3);
 
       const rows = await readOverlayRows(page);
       const row1 = rows.find((r) => r.product.includes(product1Code));
@@ -250,7 +250,7 @@ the customer has never bought.
     await test.step('TC1 - filter on narrows the list to the delivered products', async () => {
       await ProductProposalPage.setFilter(page, true);
 
-      expect(await ProductProposalPage.getRowCount(page)).toBe(2);
+      await expect(page.locator(OVERLAY_ROWS)).toHaveCount(2);
 
       const rows = await readOverlayRows(page);
       const productsShown = rows.map((r) => r.product);
@@ -270,7 +270,7 @@ the customer has never bought.
     await test.step('TC3 - filter off restores the full list', async () => {
       await ProductProposalPage.setFilter(page, false);
 
-      expect(await ProductProposalPage.getRowCount(page)).toBe(3);
+      await expect(page.locator(OVERLAY_ROWS)).toHaveCount(3);
 
       const rows = await readOverlayRows(page);
       const productsShown = rows.map((r) => r.product);
@@ -291,11 +291,11 @@ the customer has never bought.
 
       // Sanity: same shared price list, unfiltered - all three products are still offered; the
       // difference from CUSTOMER_WITH_HISTORY is purely the (absent) delivery history.
-      expect(await ProductProposalPage.getRowCount(page)).toBe(3);
+      await expect(page.locator(OVERLAY_ROWS)).toHaveCount(3);
 
       await ProductProposalPage.setFilter(page, true);
 
-      expect(await ProductProposalPage.getRowCount(page)).toBe(0);
+      await expect(page.locator(OVERLAY_ROWS)).toHaveCount(0);
 
       // Zero rows + no toast alone would also be the signature of a filter round-trip that threw
       // and left the grid empty, so first assert the overlay is still in a valid rendered state
@@ -304,6 +304,47 @@ the customer has never bought.
       await ProductProposalPage.expectVisible(page);
       const errorToast = page.locator('.Toastify div[role="alert"].Toastify__toast-body');
       await expect(errorToast).toHaveCount(0);
+    });
+
+    // === TC9: a row the user typed a quantity into stays visible under the filter ===
+    // Nothing the user has typed may vanish behind a filter: a quantity entered on a
+    // never-delivered product is still a quantity they asked for, and they must be able to see and
+    // correct it. (The order line for such a row is guaranteed separately, by creating the lines
+    // from the unfiltered rows - the exemption is not a substitute for that.)
+    await test.step('TC9 - a row with a typed quantity stays listed when the filter is on', async () => {
+      await SalesOrderPage.goto();
+      await SalesOrderPage.clickNew();
+      const qtyOrderId = await SalesOrderPage.selectCustomer(customerWithHistoryCode);
+      console.log(`TC9 order created: record=${qtyOrderId}`);
+
+      await ProductProposalPage.openFromSalesOrder(page);
+      await expect(page.locator(OVERLAY_ROWS)).toHaveCount(3);
+
+      const typedQty = '4';
+      await ProductProposalPage.enterQty(page, product3Code, typedQty);
+
+      await ProductProposalPage.setFilter(page, true);
+
+      // Product1 + Product2 qualify on delivery history, Product3 only because of its quantity.
+      await expect(page.locator(OVERLAY_ROWS)).toHaveCount(3);
+
+      const rows = await readOverlayRows(page);
+      const product3Row = rows.find((r) => r.product.includes(product3Code));
+      expect(product3Row, 'the row with a typed quantity was hidden by the filter').toBeTruthy();
+      expect(hasDeliveryValue(product3Row.lastShipmentDays)).toBe(false);
+
+      // The quantity is still there, and still editable - the point of keeping the row.
+      const product3QtyCell = page
+        .locator(OVERLAY_ROWS)
+        .filter({ has: page.locator('td[data-cy="cell-product"]', { hasText: product3Code }) })
+        .first()
+        .locator('td[data-cy="cell-qty"]');
+      await expect(product3QtyCell).toContainText(typedQty);
+
+      await ProductProposalPage.enterQty(page, product3Code, '6');
+      await expect(product3QtyCell).toContainText('6');
+
+      await ProductProposalPage.closeWithDone(page);
     });
   });
 });

--- a/e2e/frontend-webui/tests/spec/product-proposal-qty-survives-filter.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-proposal-qty-survives-filter.spec.js
@@ -1,0 +1,237 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import { DashboardPage } from '../utils/pages/DashboardPage';
+import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
+import { ShipmentSchedulePage } from '../utils/pages/ShipmentSchedulePage';
+import { ProductProposalPage } from '../utils/pages/ProductProposalPage';
+import { SLOW_ACTION_TIMEOUT } from '../utils/common';
+
+/**
+ * Product Proposals (Produktvorschläge) - the order line a typed quantity produces must not
+ * depend on the filter state when the overlay is closed with DONE (TC8, AC7).
+ *
+ * `ProductsProposalRowsData.getAllRows()` streams the *filtered* row id list
+ * (`rowIdsOrderedAndFiltered`), yet `OrderProductsProposalViewFactory.createOrderLines` reads the
+ * order lines to write from exactly that accessor. A row hidden by the delivery-history filter at
+ * the moment DONE is pressed is therefore silently dropped - no order line, no error. This spec
+ * proves the fix: a quantity typed on a row that the filter is currently hiding still becomes an
+ * order line.
+ *
+ * Fixture: one partner gets a real order -> shipment -> completion for Product1 + Product2;
+ * Product3 is never shipped, so the delivery-history filter hides it once it is turned on.
+ */
+
+const STATS_ASYNC_MECHANISM =
+  'BPartnerProductStatsEventSender (distributed C_BPartner_Product_Stats event topic, ' +
+  'consumed by BPartnerProductStatsEventHandler)';
+
+const DAYS_PATTERN = /^\d+$/;
+const hasDeliveryValue = (lastShipmentDaysText) => DAYS_PATTERN.test((lastShipmentDaysText || '').trim());
+
+async function readOverlayRows(page) {
+  const rows = page.locator('.raw-modal .panel-modal table tbody tr');
+  const count = await rows.count();
+
+  const result = [];
+  for (let i = 0; i < count; i += 1) {
+    const row = rows.nth(i);
+    const product = (await row.locator('td[data-cy="cell-product"]').innerText()).trim();
+    const lastShipmentDays = (await row.locator('td[data-cy="cell-lastShipmentDays"]').innerText()).trim();
+    result.push({ product, lastShipmentDays });
+  }
+
+  return result;
+}
+
+test.describe('Product Proposals - quantity survives the filter (AC7)', () => {
+  test('A typed quantity becomes an order line even if the filter hides that row on DONE (TC8)', async ({
+    page,
+  }) => {
+    allure.epic('E0100: Sales');
+    allure.tag('F00140');
+    allure.tag('F00140: Sales Order - Product Proposals');
+    allure.story('Produktvorschläge: order lines must not depend on the filter state');
+    allure.severity('critical');
+
+    allure.description(`
+## F00140: Sales Order - Product Proposals
+
+### Test Scenario (TC8)
+
+A quantity typed on a row that the delivery-history filter is currently hiding still becomes an
+order line when the overlay is closed with DONE - the filter is a view concern, not a data-loss
+mechanism.
+
+1. Build delivery history for Product1 + Product2 via a real order -> shipment -> completion;
+   Product3 is never shipped (fixture), so the filter hides Product3 once turned on.
+2. On a fresh order: enter a qty on Product3, turn the filter on (Product3 disappears from the
+   grid), then close with DONE.
+3. Reload the order and confirm an order line for Product3 exists with the typed quantity.
+    `);
+
+    test.setTimeout(300000); // the order -> shipment -> completion chain is slow
+
+    // === CREATE TEST DATA ===
+    const masterdata = await Backend.createMasterdata({
+      request: {
+        login: {
+          user: { language: 'en_US', firstname: 'first', lastname: 'last' },
+        },
+        bpartners: {
+          CUSTOMER_WITH_HISTORY: {
+            isVendor: false,
+            isCustomer: true,
+            isSoPriceList: true,
+            name: 'CustomerWithHistoryQtySurvives',
+          },
+        },
+        products: {
+          Product1: {
+            name: 'DeliveredFirstQtySurvives',
+            type: 'Item',
+            prices: [{ price: 10.0, currencyCode: 'EUR' }],
+          },
+          Product2: {
+            name: 'DeliveredSecondQtySurvives',
+            type: 'Item',
+            prices: [{ price: 20.0, currencyCode: 'EUR' }],
+          },
+          Product3: {
+            name: 'NeverDeliveredQtySurvives',
+            type: 'Item',
+            prices: [{ price: 30.0, currencyCode: 'EUR' }],
+          },
+        },
+      },
+    });
+
+    allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+
+    const customerCode = masterdata.bpartners.CUSTOMER_WITH_HISTORY.bpartnerCode;
+    const product1Code = masterdata.products.Product1.productCode;
+    const product2Code = masterdata.products.Product2.productCode;
+    const product3Code = masterdata.products.Product3.productCode;
+
+    // === LOGIN ===
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await DashboardPage.expectVisible();
+
+    // === FIXTURE: deliver Product1 + Product2; Product3 never ===
+    await test.step('Fixture - deliver Product1 + Product2 to the partner (Product3 never)', async () => {
+      await SalesOrderPage.goto();
+      await SalesOrderPage.clickNew();
+      const historyOrderId = await SalesOrderPage.selectCustomer(customerCode);
+
+      await SalesOrderPage.addOrderLine({
+        product: product1Code,
+        quantity: '5',
+        recordId: historyOrderId,
+      });
+
+      await SalesOrderPage.addOrderLine({
+        product: product2Code,
+        quantity: '5',
+        recordId: historyOrderId,
+      });
+
+      await SalesOrderPage.complete();
+      console.log(`History order completed: record=${historyOrderId}`);
+
+      await page.waitForTimeout(5000);
+
+      await SalesOrderPage.openRelatedShipmentCandidate({
+        maxRetries: 10,
+        retryDelay: 3000,
+        refreshOnRetry: true,
+      });
+      await ShipmentSchedulePage.expectVisible();
+      await ShipmentSchedulePage.createShipment();
+      console.log('Shipment created and completed for Product1 + Product2');
+    });
+
+    // === FIXTURE: the fresh order TC8 runs against ===
+    let tcOrderId;
+    await test.step('Fixture - create a second, fresh order for the partner', async () => {
+      await SalesOrderPage.goto();
+      await SalesOrderPage.clickNew();
+      tcOrderId = await SalesOrderPage.selectCustomer(customerCode);
+      console.log(`TC order created: record=${tcOrderId}`);
+    });
+
+    // === FIXTURE: wait for the async C_BPartner_Product_Stats update ===
+    await test.step('Fixture - wait for C_BPartner_Product_Stats (async) before applying the filter', async () => {
+      await expect
+        .poll(
+          async () => {
+            await ProductProposalPage.openFromSalesOrder(page);
+            const rows = await readOverlayRows(page);
+            await ProductProposalPage.closeWithDone(page);
+
+            const row1 = rows.find((r) => r.product.includes(product1Code));
+            const row2 = rows.find((r) => r.product.includes(product2Code));
+
+            return Boolean(
+              row1 && hasDeliveryValue(row1.lastShipmentDays) && row2 && hasDeliveryValue(row2.lastShipmentDays)
+            );
+          },
+          {
+            timeout: 120000,
+            message:
+              'Tage vergangen (lastShipmentDays) never appeared for Product1/Product2 - the async stats update ' +
+              `(${STATS_ASYNC_MECHANISM}) was not consumed within the timeout`,
+          }
+        )
+        .toBe(true);
+    });
+
+    const product3Qty = '7';
+
+    // === TC8: type a qty on Product3, hide it with the filter, close with DONE ===
+    await test.step('TC8 - enter qty on the never-delivered product, hide it with the filter, close with DONE', async () => {
+      await ProductProposalPage.openFromSalesOrder(page);
+
+      await ProductProposalPage.enterQty(page, product3Code, product3Qty);
+
+      await ProductProposalPage.setFilter(page, true);
+
+      // Sanity: the filter actually hides Product3 at the moment of closing - otherwise this test
+      // would not exercise the data-loss path at all.
+      const rowsAfterFilter = await readOverlayRows(page);
+      expect(
+        rowsAfterFilter.some((r) => r.product.includes(product3Code)),
+        'Product3 is still visible after turning the filter on - the fixture does not exercise the hidden-row path'
+      ).toBe(false);
+
+      await ProductProposalPage.closeWithDone(page);
+    });
+
+    // === Assert the order line was created despite the row being hidden at close time ===
+    await test.step('Assert an order line for Product3 exists with the typed quantity', async () => {
+      // Read the result back from the reloaded order, not from in-page state.
+      await page.reload();
+      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+      await page.locator('.rotating, .indicator-pending').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+
+      await SalesOrderPage.goToOrderLineTab();
+
+      const orderLineRow = page
+        .locator('table tbody tr')
+        .filter({ has: page.locator('[data-cy="cell-M_Product_ID"]', { hasText: product3Code }) })
+        .first();
+
+      await expect(
+        orderLineRow,
+        `No order line for ${product3Code} was found - the row was hidden by the filter when DONE was pressed ` +
+          'and its typed quantity was silently dropped'
+      ).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+
+      const qtyCell = orderLineRow.locator('[data-cy="cell-QtyOrdered"], [data-cy="cell-QtyEntered"]').first();
+      const qtyText = (await qtyCell.innerText()).trim();
+      expect(qtyText.replace(/[.,]00$/, '').replace(/,/g, '')).toBe(product3Qty);
+    });
+  });
+});

--- a/e2e/frontend-webui/tests/spec/product-proposal-qty-survives-filter.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-proposal-qty-survives-filter.spec.js
@@ -191,25 +191,29 @@ mechanism.
     const product3Qty = '7';
 
     // === TC8: type a qty on Product3, hide it with the filter, close with DONE ===
-    await test.step('TC8 - enter qty on the never-delivered product, hide it with the filter, close with DONE', async () => {
+    await test.step('TC8 - enter qty on the never-delivered product, turn the filter on, close with DONE', async () => {
       await ProductProposalPage.openFromSalesOrder(page);
 
       await ProductProposalPage.enterQty(page, product3Code, product3Qty);
 
       await ProductProposalPage.setFilter(page, true);
 
-      // Sanity: the filter actually hides Product3 at the moment of closing - otherwise this test
-      // would not exercise the data-loss path at all.
+      // Product3 has no delivery history, so the filter's criterion alone would hide it - but a row
+      // carrying a typed quantity is exempt from that criterion precisely so the quantity stays
+      // visible and correctable. Assert that exemption holds here, because it is what the user sees.
       const rowsAfterFilter = await readOverlayRows(page);
       expect(
         rowsAfterFilter.some((r) => r.product.includes(product3Code)),
-        'Product3 is still visible after turning the filter on - the fixture does not exercise the hidden-row path'
-      ).toBe(false);
+        'the row carrying a typed quantity was hidden by the filter'
+      ).toBe(true);
 
       await ProductProposalPage.closeWithDone(page);
     });
 
-    // === Assert the order line was created despite the row being hidden at close time ===
+    // The order line must exist regardless of the filter state at close time. Note this spec can no
+    // longer, through the UI, present a hidden row carrying a quantity - the exemption above prevents
+    // it. That the lines are built from the UNFILTERED rows (so no filter could ever drop one) is
+    // pinned separately by ProductsProposalRowsDataTest.
     await test.step('Assert an order line for Product3 exists with the typed quantity', async () => {
       // Read the result back from the reloaded order, not from in-page state.
       await page.reload();

--- a/e2e/frontend-webui/tests/spec/product-proposal-qty-survives-filter.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-proposal-qty-survives-filter.spec.js
@@ -6,7 +6,7 @@ import { LoginPage } from '../utils/pages/LoginPage';
 import { DashboardPage } from '../utils/pages/DashboardPage';
 import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
 import { ShipmentSchedulePage } from '../utils/pages/ShipmentSchedulePage';
-import { ProductProposalPage } from '../utils/pages/ProductProposalPage';
+import { ProductProposalPage, ROWS as OVERLAY_ROWS } from '../utils/pages/ProductProposalPage';
 import { SLOW_ACTION_TIMEOUT } from '../utils/common';
 
 /**
@@ -32,7 +32,7 @@ const DAYS_PATTERN = /^\d+$/;
 const hasDeliveryValue = (lastShipmentDaysText) => DAYS_PATTERN.test((lastShipmentDaysText || '').trim());
 
 async function readOverlayRows(page) {
-  const rows = page.locator('.raw-modal .panel-modal table tbody tr');
+  const rows = page.locator(OVERLAY_ROWS);
   const count = await rows.count();
 
   const result = [];
@@ -47,7 +47,7 @@ async function readOverlayRows(page) {
 }
 
 test.describe('Product Proposals - quantity survives the filter (AC7)', () => {
-  test('A typed quantity becomes an order line even if the filter hides that row on DONE (TC8)', async ({
+  test('A typed quantity becomes an order line whatever the filter is set to', async ({
     page,
   }) => {
     allure.epic('E0100: Sales');
@@ -59,7 +59,7 @@ test.describe('Product Proposals - quantity survives the filter (AC7)', () => {
     allure.description(`
 ## F00140: Sales Order - Product Proposals
 
-### Test Scenario (TC8)
+### Test Scenario
 
 A quantity typed on a row that the delivery-history filter is currently hiding still becomes an
 order line when the overlay is closed with DONE - the filter is a view concern, not a data-loss

--- a/e2e/frontend-webui/tests/spec/product-proposal-qty-survives-filter.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-proposal-qty-survives-filter.spec.js
@@ -17,11 +17,11 @@ import { SLOW_ACTION_TIMEOUT } from '../utils/common';
  * (`rowIdsOrderedAndFiltered`), yet `OrderProductsProposalViewFactory.createOrderLines` reads the
  * order lines to write from exactly that accessor. A row hidden by the delivery-history filter at
  * the moment DONE is pressed is therefore silently dropped - no order line, no error. This spec
- * proves the fix: a quantity typed on a row that the filter is currently hiding still becomes an
- * order line.
+ * proves the fix: a quantity typed on a never-delivered product still becomes an order line when the
+ * delivery-history filter is on.
  *
- * Fixture: one partner gets a real order -> shipment -> completion for Product1 + Product2;
- * Product3 is never shipped, so the delivery-history filter hides it once it is turned on.
+ * Fixture: one partner gets a real order -> shipment -> completion for Product1;
+ * Product3 is never shipped, so it only qualifies for the filter through the typed quantity.
  */
 
 const STATS_ASYNC_MECHANISM =
@@ -61,14 +61,15 @@ test.describe('Product Proposals - quantity survives the filter (AC7)', () => {
 
 ### Test Scenario
 
-A quantity typed on a row that the delivery-history filter is currently hiding still becomes an
-order line when the overlay is closed with DONE - the filter is a view concern, not a data-loss
-mechanism.
+A quantity typed on a never-delivered product still becomes an order line when the overlay is
+closed with DONE while the delivery-history filter is on - the filter is a view concern, not a
+data-loss mechanism. (The lines are built from the unfiltered rows, so no filter state can drop one;
+that guarantee is pinned directly by ProductsProposalRowsDataTest.)
 
-1. Build delivery history for Product1 + Product2 via a real order -> shipment -> completion;
-   Product3 is never shipped (fixture), so the filter hides Product3 once turned on.
-2. On a fresh order: enter a qty on Product3, turn the filter on (Product3 disappears from the
-   grid), then close with DONE.
+1. Build delivery history for Product1 via a real order -> shipment -> completion;
+   Product3 is never shipped (fixture), so only the typed quantity keeps it in the list.
+2. On a fresh order: enter a qty on Product3, turn the filter on (Product3 stays, exempt because it
+   carries a quantity), then close with DONE.
 3. Reload the order and confirm an order line for Product3 exists with the typed quantity.
     `);
 
@@ -112,7 +113,6 @@ mechanism.
 
     const customerCode = masterdata.bpartners.CUSTOMER_WITH_HISTORY.bpartnerCode;
     const product1Code = masterdata.products.Product1.productCode;
-    const product2Code = masterdata.products.Product2.productCode;
     const product3Code = masterdata.products.Product3.productCode;
 
     // === LOGIN ===
@@ -120,20 +120,21 @@ mechanism.
     await LoginPage.login(masterdata.login.user);
     await DashboardPage.expectVisible();
 
-    // === FIXTURE: deliver Product1 + Product2; Product3 never ===
-    await test.step('Fixture - deliver Product1 + Product2 to the partner (Product3 never)', async () => {
+    // === FIXTURE: deliver Product1; Product3 never ===
+    // Only ONE delivered product is needed here: this spec is about a quantity typed on a
+    // NEVER-delivered product, so a single product with delivery history is enough to make the filter
+    // meaningful. Deliberately not adding a second line - each extra addOrderLine call on the same
+    // order is a further chance for the shared quick-input helper to fail (measured: it occasionally
+    // cannot add a second line at all, three retries included), and a fixture step that the assertions
+    // do not need is pure flakiness surface. The sibling spec that asserts the row COUNT narrowing
+    // does keep two delivered products, because there the second one is load-bearing.
+    await test.step('Fixture - deliver Product1 to the partner (Product2, Product3 never)', async () => {
       await SalesOrderPage.goto();
       await SalesOrderPage.clickNew();
       const historyOrderId = await SalesOrderPage.selectCustomer(customerCode);
 
       await SalesOrderPage.addOrderLine({
         product: product1Code,
-        quantity: '5',
-        recordId: historyOrderId,
-      });
-
-      await SalesOrderPage.addOrderLine({
-        product: product2Code,
         quantity: '5',
         recordId: historyOrderId,
       });
@@ -150,7 +151,7 @@ mechanism.
       });
       await ShipmentSchedulePage.expectVisible();
       await ShipmentSchedulePage.createShipment();
-      console.log('Shipment created and completed for Product1 + Product2');
+      console.log('Shipment created and completed for Product1');
     });
 
     // === FIXTURE: the fresh order TC8 runs against ===
@@ -172,17 +173,14 @@ mechanism.
             await ProductProposalPage.closeWithDone(page);
 
             const row1 = rows.find((r) => r.product.includes(product1Code));
-            const row2 = rows.find((r) => r.product.includes(product2Code));
 
-            return Boolean(
-              row1 && hasDeliveryValue(row1.lastShipmentDays) && row2 && hasDeliveryValue(row2.lastShipmentDays)
-            );
+            return Boolean(row1 && hasDeliveryValue(row1.lastShipmentDays));
           },
           {
             timeout: 120000,
             message:
-              'Tage vergangen (lastShipmentDays) never appeared for Product1/Product2 - the async stats update ' +
-              `(${STATS_ASYNC_MECHANISM}) was not consumed within the timeout`,
+              'Tage vergangen (lastShipmentDays) never appeared for the delivered product - the async ' +
+              `stats update (${STATS_ASYNC_MECHANISM}) was not consumed within the timeout`,
           }
         )
         .toBe(true);

--- a/e2e/frontend-webui/tests/utils/pages/ProductProposalPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/ProductProposalPage.js
@@ -100,16 +100,19 @@ export class ProductProposalPage {
       const overlay = page.locator(OVERLAY);
       await overlay.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
 
-      // Wait for the view's own spinners to settle before anything is read
-      await page
-        .locator(`${OVERLAY} .rotating, ${OVERLAY} .indicator-pending`)
-        .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
-        .catch(() => {});
-
-      // The product column proves the view layout (not just the modal frame) is rendered
+      // The product column proves the view layout (not just the modal frame) is rendered...
       await expect(page.locator(`${OVERLAY} th[data-testid="column-product"]`)).toBeVisible({
         timeout: SLOW_ACTION_TIMEOUT,
       });
+
+      // Deliberately NOT also asserting that a data row is present: a filtered view is allowed to be
+      // legitimately empty, and a caller that needs rows asserts on them itself (web-first, so it
+      // retries). Nor is there a spinner to wait on here - this overlay renders no loading
+      // affordance, and `.rotating`/`.indicator-pending` (waited on at this spot previously) are not
+      // classes the frontend emits at all: `indicator-pending` exists only as a @keyframes name in
+      // frontend/src/assets/css/window-indicator.scss, so that wait resolved on the first poll and
+      // protected nothing. What does synchronise a filter change is the round-trip wait in
+      // `setFilter`.
     });
   }
 

--- a/e2e/frontend-webui/tests/utils/pages/ProductProposalPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/ProductProposalPage.js
@@ -29,7 +29,15 @@ const OVERLAY = '.raw-modal .panel-modal';
 /** Data rows of the overlay grid. */
 const ROWS = `${OVERLAY} table tbody tr`;
 
-/** Buttons of the order lines tab's filter line - the included-tab top actions come last. */
+/**
+ * Buttons of the order lines tab's filter line - the included-tab top actions come last.
+ *
+ * NOTE: consumers select `.last()` here, which assumes the tab's own buttons ("Add new",
+ * batch entry) always render BEFORE the included-tab top actions, and that this tab has
+ * exactly one top action. Both hold today, but neither is enforced anywhere: if a button
+ * is ever added after the top actions, `.last()` silently targets the wrong element with
+ * no error. Prefer the `Alt+Z` shortcut path; this is only the fallback.
+ */
 const TOP_ACTION_BUTTONS = '.table-filter-line .filter-panel-buttons button';
 
 export class ProductProposalPage {
@@ -176,6 +184,11 @@ export class ProductProposalPage {
    * ProductsProposalRow#FIELD_Qty) and the overlay opens with the focus in it
    * (`setFocusOnFieldName(ProductsProposalRow.FIELD_Qty)`). The typed value is only
    * persisted once the cell is blurred, so `Tab` is pressed to commit the edit.
+   *
+   * NO PERSISTENCE GUARANTEE: this method types and commits, but does not read the value
+   * back, so it does not prove the quantity stuck. A spec that depends on the quantity
+   * having persisted must assert that itself - e.g. by re-reading the cell, or by checking
+   * the resulting order line after the overlay is closed with DONE.
    *
    * @param {import('@playwright/test').Page} page - Playwright page
    * @param {string} productName - Product name of the row to edit

--- a/e2e/frontend-webui/tests/utils/pages/ProductProposalPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/ProductProposalPage.js
@@ -1,0 +1,244 @@
+import { expect } from '@playwright/test';
+import { test } from '../../../playwright.config';
+import { getPage, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT } from '../common';
+
+/**
+ * Page object for the Products Proposal overlay (Produktvorschläge).
+ *
+ * The overlay is launched from the sales order *order lines* tab as an included-tab top action
+ * (AD_Table_Process.WEBUI_IncludedTabTopAction='Y' for AD_Tab_ID=187 / AD_Window_ID=143), keyboard
+ * shortcut `Alt-Z` (AD_Table_Process.WEBUI_Shortcut).
+ *
+ * It is a custom view with windowId `orderProductsProposal`
+ * (OrderProductsProposalViewFactory.WINDOW_ID_STRING) opened as a modal overlay
+ * (ViewOpenTarget.ModalOverlay -> frontend `SAME_TAB_OVERLAY` -> `openRawModal`), so it renders in the
+ * raw-modal panel (`.raw-modal .panel-modal`) and the browser URL keeps pointing at the sales order —
+ * `openRawModal` (frontend/src/actions/WindowActions.js) does not push a history entry.
+ *
+ * Displayed columns (OrderProductsProposalViewFactory#createViewLayout): product, qty, PackDescription,
+ * asi, lastShipmentDays ("Tage vergangen"), price, currency, isCampaignPrice. Grid cells carry
+ * `data-cy="cell-<fieldName>"` (frontend/src/components/table/TableCell.js).
+ */
+
+/** windowId of the overlay view (a string window id, not an AD_Window_ID). */
+export const PRODUCT_PROPOSAL_WINDOW_ID = 'orderProductsProposal';
+
+/** Container of the overlay (raw modal panel). */
+const OVERLAY = '.raw-modal .panel-modal';
+
+/** Data rows of the overlay grid. */
+const ROWS = `${OVERLAY} table tbody tr`;
+
+/** Buttons of the order lines tab's filter line - the included-tab top actions come last. */
+const TOP_ACTION_BUTTONS = '.table-filter-line .filter-panel-buttons button';
+
+export class ProductProposalPage {
+  /**
+   * Open the overlay from a sales order that is showing its order lines tab.
+   * Uses the `Alt+Z` shortcut, falling back to a click on the top action button.
+   *
+   * @param {import('@playwright/test').Page} page - Playwright page
+   */
+  static async openFromSalesOrder(page = getPage()) {
+    return await test.step('ProductProposalPage - Open overlay from sales order (Alt+Z)', async () => {
+      const overlay = page.locator(OVERLAY);
+
+      // Focus the document body so the shortcut is not swallowed by an input
+      await page.locator('body').click();
+      await page.waitForTimeout(200);
+
+      await page.keyboard.press('Alt+Z');
+
+      const openedByShortcut = await overlay
+        .waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT })
+        .then(() => true)
+        .catch(() => false);
+
+      if (!openedByShortcut) {
+        console.log('Alt+Z did not open the overlay - clicking the Products Proposal top action');
+
+        // Language-independent: the included-tab top actions are the LAST buttons rendered in
+        // `.filter-panel-buttons` - after "Add new" and the batch-entry toggle
+        // (frontend/src/components/table/TableFilter.js). The order lines tab has exactly one top
+        // action (Produktvorschläge / AD_Process 541038), so its button is the last one.
+        // The caption itself is localized and must not be used as a selector.
+        const topAction = page.locator(TOP_ACTION_BUTTONS).last();
+        await topAction.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+        await topAction.click();
+      }
+
+      await this.expectVisible(page);
+    });
+  }
+
+  /**
+   * Assert the overlay is open and its grid has finished loading.
+   *
+   * @param {import('@playwright/test').Page} page - Playwright page
+   */
+  static async expectVisible(page = getPage()) {
+    return await test.step('ProductProposalPage - Expect overlay visible', async () => {
+      const overlay = page.locator(OVERLAY);
+      await overlay.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+      // Wait for the view's own spinners to settle before anything is read
+      await page
+        .locator(`${OVERLAY} .rotating, ${OVERLAY} .indicator-pending`)
+        .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+        .catch(() => {});
+
+      // The product column proves the view layout (not just the modal frame) is rendered
+      await expect(page.locator(`${OVERLAY} th[data-testid="column-product"]`)).toBeVisible({
+        timeout: SLOW_ACTION_TIMEOUT,
+      });
+    });
+  }
+
+  /**
+   * Read the product names of all rows currently rendered in the overlay grid.
+   *
+   * @param {import('@playwright/test').Page} page - Playwright page
+   * @returns {Promise<string[]>} Product names in grid order
+   */
+  static async getRowProductNames(page = getPage()) {
+    return await test.step('ProductProposalPage - Get row product names', async () => {
+      const productCells = page.locator(`${ROWS} td[data-cy="cell-product"]`);
+      const count = await productCells.count();
+
+      const names = [];
+      for (let i = 0; i < count; i += 1) {
+        const text = await productCells.nth(i).innerText();
+        names.push(text.trim());
+      }
+
+      console.log(`Overlay rows (${names.length}): ${JSON.stringify(names)}`);
+      return names;
+    });
+  }
+
+  /**
+   * Count the rows currently rendered in the overlay grid.
+   *
+   * @param {import('@playwright/test').Page} page - Playwright page
+   * @returns {Promise<number>} Number of rows
+   */
+  static async getRowCount(page = getPage()) {
+    return await test.step('ProductProposalPage - Get row count', async () => {
+      return await page.locator(ROWS).count();
+    });
+  }
+
+  /**
+   * Turn the delivery-history filter on or off.
+   *
+   * The filter is a frequently-used, inline-rendered (`INLINE_PARAMETERS`) `YesNo` filter parameter, so
+   * the frontend renders it via InlineFilterItem -> Checkbox as
+   * `.filter-wrapper.filters-frequent .inline-filters label.input-checkbox input[type="checkbox"]`
+   * (frontend/src/components/filters/FiltersNotIncluded.js, components/widget/Checkbox.js). Toggling the
+   * checkbox patches the filter parameter and re-applies the filter, which reloads the view.
+   *
+   * @param {import('@playwright/test').Page} page - Playwright page
+   * @param {boolean} on - true to activate the filter, false to deactivate it
+   */
+  static async setFilter(page = getPage(), on = true) {
+    return await test.step(`ProductProposalPage - Set delivery-history filter: ${on}`, async () => {
+      const filterLabel = page
+        .locator(`${OVERLAY} .filters-frequent .inline-filters label.input-checkbox`)
+        .first();
+      const checkbox = filterLabel.locator('input[type="checkbox"]');
+
+      await checkbox.waitFor({ state: 'attached', timeout: SLOW_ACTION_TIMEOUT });
+
+      const isChecked = await checkbox.isChecked();
+      if (isChecked === on) {
+        console.log(`Delivery-history filter already ${on ? 'on' : 'off'} - nothing to toggle`);
+        return;
+      }
+
+      // The <input> is visually replaced by .input-checkbox-tick, so click the label wrapper
+      await filterLabel.click();
+
+      // The toggle triggers a filter patch + view reload
+      await page
+        .locator(`${OVERLAY} .rotating, ${OVERLAY} .indicator-pending`)
+        .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+        .catch(() => {});
+      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+
+      await expect(checkbox).toBeChecked({ checked: on, timeout: SLOW_ACTION_TIMEOUT });
+    });
+  }
+
+  /**
+   * Type a quantity into the Qty cell of the row of the given product and commit it.
+   *
+   * Qty is an always-on editor cell (`editor = ViewEditorRenderMode.ALWAYS` on
+   * ProductsProposalRow#FIELD_Qty) and the overlay opens with the focus in it
+   * (`setFocusOnFieldName(ProductsProposalRow.FIELD_Qty)`). The typed value is only
+   * persisted once the cell is blurred, so `Tab` is pressed to commit the edit.
+   *
+   * @param {import('@playwright/test').Page} page - Playwright page
+   * @param {string} productName - Product name of the row to edit
+   * @param {string|number} qty - Quantity to type
+   */
+  static async enterQty(page = getPage(), productName, qty) {
+    return await test.step(`ProductProposalPage - Enter qty ${qty} for ${productName}`, async () => {
+      const row = page
+        .locator(ROWS)
+        .filter({ has: page.locator('td[data-cy="cell-product"]', { hasText: productName }) })
+        .first();
+
+      await row.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+      const qtyCell = row.locator('td[data-cy="cell-qty"]');
+      const qtyInput = qtyCell.locator('input').first();
+
+      const inputRendered = await qtyInput
+        .waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT })
+        .then(() => true)
+        .catch(() => false);
+
+      if (!inputRendered) {
+        // Not in edit mode yet - a click on the cell renders the always-on editor
+        await qtyCell.click();
+        await qtyInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      }
+
+      await qtyInput.click();
+      await qtyInput.fill(qty.toString());
+
+      // Blur commits the cell - an uncommitted edit is discarded
+      await page.keyboard.press('Tab');
+
+      await page
+        .locator(`${OVERLAY} .rotating, ${OVERLAY} .indicator-pending`)
+        .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+        .catch(() => {});
+    });
+  }
+
+  /**
+   * Close the overlay with its DONE close action, which is what creates the order lines
+   * (ViewCloseAction.DONE, allowed by OrderProductsProposalViewFactory#createViewLayout).
+   *
+   * @param {import('@playwright/test').Page} page - Playwright page
+   */
+  static async closeWithDone(page = getPage()) {
+    return await test.step('ProductProposalPage - Close overlay with DONE', async () => {
+      // ModalButton renders data-testid="modal-<name.toLowerCase()>" - language-independent
+      const doneButton = page.locator(`${OVERLAY} [data-testid="modal-done"]`);
+      await doneButton.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await doneButton.click();
+
+      await page
+        .locator(OVERLAY)
+        .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+        .catch(async () => {
+          await expect(page.locator(OVERLAY)).toBeHidden({ timeout: SLOW_ACTION_TIMEOUT });
+        });
+
+      // The order lines are created on close - wait for the parent view to settle
+      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+    });
+  }
+}

--- a/e2e/frontend-webui/tests/utils/pages/ProductProposalPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/ProductProposalPage.js
@@ -30,11 +30,15 @@ export const OVERLAY = '.raw-modal .panel-modal';
 export const ROWS = `${OVERLAY} table tbody tr`;
 
 /**
- * The delivery-history flag filter's checkbox in the overlay's inline (frequent-used) filter line.
- * Exported so a spec asserting on the control itself uses the same selector `setFilter` toggles,
- * instead of keeping its own copy that can drift.
+ * The delivery-history flag filter in the overlay's inline (frequent-used) filter line.
+ *
+ * The <input> is visually replaced by `.input-checkbox-tick`, so the LABEL is what gets clicked
+ * while the INPUT is what carries the checked state - hence both constants. `FILTER_CHECKBOX` is
+ * derived from `FILTER_LABEL` (not written out a second time) so `setFilter` and any spec asserting
+ * on the control cannot drift apart when the markup changes.
  */
-export const FILTER_CHECKBOX = `${OVERLAY} .filters-frequent .inline-filters label.input-checkbox input[type="checkbox"]`;
+export const FILTER_LABEL = `${OVERLAY} .filters-frequent .inline-filters label.input-checkbox`;
+export const FILTER_CHECKBOX = `${FILTER_LABEL} input[type="checkbox"]`;
 
 /**
  * Buttons of the order lines tab's filter line - the included-tab top actions come last.
@@ -157,9 +161,7 @@ export class ProductProposalPage {
    */
   static async setFilter(page = getPage(), on = true) {
     return await test.step(`ProductProposalPage - Set delivery-history filter: ${on}`, async () => {
-      const filterLabel = page
-        .locator(`${OVERLAY} .filters-frequent .inline-filters label.input-checkbox`)
-        .first();
+      const filterLabel = page.locator(FILTER_LABEL).first();
       const checkbox = filterLabel.locator('input[type="checkbox"]');
 
       await checkbox.waitFor({ state: 'attached', timeout: SLOW_ACTION_TIMEOUT });
@@ -170,7 +172,6 @@ export class ProductProposalPage {
         return;
       }
 
-      // The <input> is visually replaced by .input-checkbox-tick, so click the label wrapper
       await filterLabel.click();
 
       // The toggle triggers a filter patch + view reload

--- a/e2e/frontend-webui/tests/utils/pages/ProductProposalPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/ProductProposalPage.js
@@ -172,14 +172,40 @@ export class ProductProposalPage {
         return;
       }
 
+      // Toggling runs DocumentListContainer's isNewFilter flow (handleFilterChange ->
+      // fetchLayoutAndData -> filterCurrentView): a layout GET, then POST .../filter, then
+      // GET .../<viewId>?firstRow=... - and only that last GET repaints the grid, so that is the
+      // thing to wait for. Both promises must be created BEFORE the click or a fast response is
+      // missed.
+      //
+      // Neither a spinner wait nor `networkidle` can substitute here:
+      //  - this overlay renders NO loading affordance during the round-trip (`.spinner` from
+      //    components/app/SpinnerOverlay.js never attaches, and `.rotating`/`.indicator-pending`
+      //    are not classes the frontend emits at all - `indicator-pending` exists only as a
+      //    @keyframes name in src/assets/css/window-indicator.scss), so a `detached` wait on
+      //    either resolves on the very first poll;
+      //  - `waitForLoadState('networkidle')` resolves immediately on an already-loaded page and
+      //    does not track XHRs started after the call.
+      // Measured on C_Order_ID=1000030: with those two waits the row read landed before the
+      // repaint in 3 of 8 toggles - checkbox already on, grid still showing the unfiltered rows.
+      const filterApplied = page.waitForResponse(
+        (response) =>
+          /\/documentView\/[^/]+\/[^/]+\/filter$/.test(response.url()) &&
+          response.request().method() === 'POST',
+        { timeout: SLOW_ACTION_TIMEOUT }
+      );
+      const rowsReloaded = page.waitForResponse(
+        (response) =>
+          /\/documentView\/[^/]+\/[^/]+\?firstRow=/.test(response.url()) &&
+          response.request().method() === 'GET',
+        { timeout: SLOW_ACTION_TIMEOUT }
+      );
+
       await filterLabel.click();
 
-      // The toggle triggers a filter patch + view reload
-      await page
-        .locator(`${OVERLAY} .rotating, ${OVERLAY} .indicator-pending`)
-        .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
-        .catch(() => {});
-      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+      const filterResponse = await filterApplied;
+      expect(filterResponse.status(), 'the filter round-trip must succeed').toBe(200);
+      await rowsReloaded;
 
       await expect(checkbox).toBeChecked({ checked: on, timeout: SLOW_ACTION_TIMEOUT });
     });
@@ -215,26 +241,58 @@ export class ProductProposalPage {
       const qtyInput = qtyCell.locator('input').first();
 
       const inputRendered = await qtyInput
-        .waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT })
+        .waitFor({ state: 'attached', timeout: FAST_ACTION_TIMEOUT })
         .then(() => true)
         .catch(() => false);
 
       if (!inputRendered) {
-        // Not in edit mode yet - a click on the cell renders the always-on editor
+        // Not in edit mode yet. A click alone only FOCUSES an "always-editor" cell -
+        // TableRow#_editProperty (components/table/TableRow.js) only swaps in the input widget
+        // on Enter/F2 (`handleKeyDown_Enter`), never on a bare click or dblclick; confirmed by
+        // inspecting the cell's DOM before/after each of click, dblclick and click+Enter. So
+        // focus the cell, then press Enter to render the input.
         await qtyCell.click();
-        await qtyInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+        await page.keyboard.press('Enter');
+        await qtyInput.waitFor({ state: 'attached', timeout: SLOW_ACTION_TIMEOUT });
       }
 
-      await qtyInput.click();
+      // Do NOT click qtyInput here: Enter already rendered the widget with real DOM/browser
+      // focus on it (confirmed: outerHTML shows `input-focused` immediately after Enter, and
+      // `isEditable()`/`isEnabled()`/`isVisible()` are all true). An extra click on the
+      // already-focused input collapses the cell straight back to display mode - the DOM
+      // reverts to the plain `cell-text-wrapper` (no `<input>`) in the same tick, so the
+      // subsequent `.fill()` waits forever for an `input` that no longer exists (that is the
+      // "times out at locator.fill" symptom). Reproduced live: click -> Enter -> input attached,
+      // visible/enabled/editable, boundingBox present; one more `.click()` on that same input ->
+      // cell reverts to `<div class="cell-text-wrapper quantity-cell"></div>`, input gone.
+      // `.fill()` does not click (it focuses + sets the value directly), so it is safe to call
+      // right after the input is attached.
       await qtyInput.fill(qty.toString());
 
-      // Blur commits the cell - an uncommitted edit is discarded
+      // Blur commits the cell - an uncommitted edit is discarded. The commit is a
+      // PATCH .../documentView/<windowId>/<viewId>/<rowId>/edit
+      // (ViewRowEditRestController.ENDPOINT, patchRow), which is the only reliable signal that the
+      // value reached the server: the cell re-renders optimistically, and the overlay shows no
+      // spinner while the request is in flight. Arm the wait BEFORE the blur or a fast response is
+      // missed. (The previous wait here - `.rotating, .indicator-pending` detached - was a no-op:
+      // the frontend emits neither as a class; `indicator-pending` exists only as a @keyframes
+      // name in frontend/src/assets/css/window-indicator.scss.)
+      const qtyCommitted = page.waitForResponse(
+        (response) =>
+          /\/documentView\/[^/]+\/[^/]+\/[^/]+\/edit$/.test(response.url()) &&
+          response.request().method() === 'PATCH',
+        { timeout: SLOW_ACTION_TIMEOUT }
+      );
+
       await page.keyboard.press('Tab');
 
-      await page
-        .locator(`${OVERLAY} .rotating, ${OVERLAY} .indicator-pending`)
-        .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
-        .catch(() => {});
+      const commitResponse = await qtyCommitted;
+      expect(commitResponse.status(), `committing qty ${qty} for ${productName} must succeed`).toBe(200);
+
+      // ... and the committed value must be what is now rendered in the cell.
+      await expect(qtyCell).toContainText(qty.toString().replace(/\.0+$/, ''), {
+        timeout: SLOW_ACTION_TIMEOUT,
+      });
     });
   }
 

--- a/e2e/frontend-webui/tests/utils/pages/ProductProposalPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/ProductProposalPage.js
@@ -24,10 +24,17 @@ import { getPage, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT } from '../common';
 export const PRODUCT_PROPOSAL_WINDOW_ID = 'orderProductsProposal';
 
 /** Container of the overlay (raw modal panel). */
-const OVERLAY = '.raw-modal .panel-modal';
+export const OVERLAY = '.raw-modal .panel-modal';
 
 /** Data rows of the overlay grid. */
-const ROWS = `${OVERLAY} table tbody tr`;
+export const ROWS = `${OVERLAY} table tbody tr`;
+
+/**
+ * The delivery-history flag filter's checkbox in the overlay's inline (frequent-used) filter line.
+ * Exported so a spec asserting on the control itself uses the same selector `setFilter` toggles,
+ * instead of keeping its own copy that can drift.
+ */
+export const FILTER_CHECKBOX = `${OVERLAY} .filters-frequent .inline-filters label.input-checkbox input[type="checkbox"]`;
 
 /**
  * Buttons of the order lines tab's filter line - the included-tab top actions come last.

--- a/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
@@ -1,5 +1,5 @@
 import { test } from '../../../playwright.config';
-import { FAST_ACTION_TIMEOUT, FRONTEND_BASE_URL, getPage, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../common';
+import { FRONTEND_BASE_URL, getPage, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../common';
 import { SALES_ORDER_WINDOW_ID } from '../WindowIds';
 import { waitForRecordSaved, waitForTabAllowsNew } from '../WebAPIValidation';
 import { PdfDownloader } from '../PdfDownloader';
@@ -220,8 +220,23 @@ export class SalesOrderPage {
 
       console.log(`Sales Order Lines tab ready for record ${effectiveRecordId}`);
 
+      // Matches the grid row for the product this call is adding. Used both to confirm success and -
+      // before every retry - to make the retry idempotent.
+      const productRow = () =>
+        page
+          .locator('table tbody tr')
+          .filter({ has: page.locator('[data-cy="cell-M_Product_ID"]', { hasText: product }) })
+          .first();
+
       for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         console.log(`addOrderLine attempt ${attempt}/${maxAttempts}`);
+
+        // A previous attempt may have succeeded on the server and only rendered after this method
+        // gave up waiting. Re-adding then would silently duplicate the line, so check first.
+        if (attempt > 1 && (await productRow().isVisible().catch(() => false))) {
+          console.log(`Order line for ${product} is present after all - not adding it again`);
+          return;
+        }
 
         // Scroll to batch entry button (may be below the fold in single-section layout)
         const batchEntryButton = page.getByTestId('batch-entry-toggle');
@@ -321,13 +336,11 @@ export class SalesOrderPage {
         // selection on a second call would be reported as success and leave the requested product off
         // the order - measured at ~10% of runs, where a two-line fixture ended up with one line and
         // the downstream assertions failed far from the cause.
-        const gridRows = page.locator('table tbody tr');
-        const rowCount = await gridRows.count();
-        const addedProductRow = gridRows
-          .filter({ has: page.locator('[data-cy="cell-M_Product_ID"]', { hasText: product }) })
-          .first();
-        const addedProductRowPresent = await addedProductRow
-          .waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT })
+        const rowCount = await page.locator('table tbody tr').count();
+        // Waited on with the SLOW timeout deliberately: a miss here costs a full reload-and-retry
+        // cycle, so being impatient is more expensive than waiting a little longer.
+        const addedProductRowPresent = await productRow()
+          .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT })
           .then(() => true)
           .catch(() => false);
         if (addedProductRowPresent) {

--- a/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
@@ -1,5 +1,5 @@
 import { test } from '../../../playwright.config';
-import { FRONTEND_BASE_URL, getPage, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../common';
+import { FAST_ACTION_TIMEOUT, FRONTEND_BASE_URL, getPage, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../common';
 import { SALES_ORDER_WINDOW_ID } from '../WindowIds';
 import { waitForRecordSaved, waitForTabAllowsNew } from '../WebAPIValidation';
 import { PdfDownloader } from '../PdfDownloader';
@@ -316,15 +316,28 @@ export class SalesOrderPage {
           await page.waitForTimeout(1000);
         }
 
-        // Verify that at least one order line was added
+        // Verify THIS product's line was added. `rowCount > 0` is not enough: it is already true
+        // whenever an earlier addOrderLine call added a DIFFERENT line, so a silently-failed dropdown
+        // selection on a second call would be reported as success and leave the requested product off
+        // the order - measured at ~10% of runs, where a two-line fixture ended up with one line and
+        // the downstream assertions failed far from the cause.
         const gridRows = page.locator('table tbody tr');
         const rowCount = await gridRows.count();
-        if (rowCount > 0) {
-          console.log(`Order line added successfully on attempt ${attempt} (${rowCount} row(s))`);
+        const addedProductRow = gridRows
+          .filter({ has: page.locator('[data-cy="cell-M_Product_ID"]', { hasText: product }) })
+          .first();
+        const addedProductRowPresent = await addedProductRow
+          .waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT })
+          .then(() => true)
+          .catch(() => false);
+        if (addedProductRowPresent) {
+          console.log(
+            `Order line added successfully on attempt ${attempt} (${rowCount} row(s), ${product} present)`
+          );
           return;
         }
 
-        console.log(`No order lines found after attempt ${attempt}, reloading page...`);
+        console.log(`Order line for ${product} not found after attempt ${attempt}, reloading page...`);
         await page.keyboard.press('F5');
         await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
         await page.waitForTimeout(2000);

--- a/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
@@ -1,5 +1,5 @@
 import { test } from '../../../playwright.config';
-import { FRONTEND_BASE_URL, getPage, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../common';
+import { FAST_ACTION_TIMEOUT, FRONTEND_BASE_URL, getPage, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../common';
 import { SALES_ORDER_WINDOW_ID } from '../WindowIds';
 import { waitForRecordSaved, waitForTabAllowsNew } from '../WebAPIValidation';
 import { PdfDownloader } from '../PdfDownloader';
@@ -199,6 +199,12 @@ export class SalesOrderPage {
    * IMPORTANT: Parent record must be saved before calling this method.
    * Use waitForTabAllowsNew() or call selectCustomer() first which waits for save.
    *
+   * CONSTRAINT: do NOT call this twice with the same `product` on the same order. Success, and the
+   * retry's idempotency guard, are both decided by "a grid row for this product exists" - which
+   * cannot tell one call's row from another's. A second call for the same product would therefore
+   * see the first call's row and report success without adding anything. A spec that genuinely needs
+   * two lines of one product must drive batch entry itself.
+   *
    * @param {Object} params - Order line parameters
    * @param {string} params.product - Product code or name
    * @param {string|number} params.quantity - Quantity to order
@@ -232,8 +238,16 @@ export class SalesOrderPage {
         console.log(`addOrderLine attempt ${attempt}/${maxAttempts}`);
 
         // A previous attempt may have succeeded on the server and only rendered after this method
-        // gave up waiting. Re-adding then would silently duplicate the line, so check first.
-        if (attempt > 1 && (await productRow().isVisible().catch(() => false))) {
+        // gave up waiting. Re-adding then would silently duplicate the line, so check first - with a
+        // short wait rather than an instantaneous read, because the reload that precedes this may
+        // still be settling.
+        const alreadyPresent =
+          attempt > 1 &&
+          (await productRow()
+            .waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT })
+            .then(() => true)
+            .catch(() => false));
+        if (alreadyPresent) {
           console.log(`Order line for ${product} is present after all - not adding it again`);
           return;
         }

--- a/frontend/src/components/filters/InlineFilterItem.js
+++ b/frontend/src/components/filters/InlineFilterItem.js
@@ -36,15 +36,35 @@ const InlineFilterItem = ({
     setParameterValue(value ? value : '');
   };
 
-  const handleApply = () => {
+  // `handlePatch` (passed to the widget as `handlePatch={handleApply}`) is called by some widgets
+  // (e.g. Checkbox for a YesNo filter) directly with the freshly toggled value, WITHOUT having gone
+  // through `setValue`/`onChange` first - Checkbox only wires `handlePatch`, never `onChange`. So the
+  // value actually being applied must be the one passed in here when present, falling back to the
+  // locally tracked `parameterValue` (kept up to date by `onChange`-driven widgets, e.g. Text on
+  // Enter/Tab) only when no value was passed. Also keep `parameterValue` itself in sync so a second
+  // toggle (e.g. turning the filter back off) does not read a stale value on the next call.
+  //
+  // Checkbox additionally expects `handlePatch(...)` to return a thenable - same contract as the
+  // redux `patch` action creator used for regular document fields - so this must return a Promise,
+  // never `undefined`.
+  const handleApply = (property, valueFromPatch) => {
+    const nextValue =
+      valueFromPatch !== undefined ? valueFromPatch : parameterValue;
+
+    if (valueFromPatch !== undefined) {
+      setValue(property, valueFromPatch);
+    }
+
     const filter = mergeParameterValueToFilter(
       filterProp,
       parameterName,
-      parameterValue
+      nextValue
     );
 
     clearFilters(filter, true);
     applyFilters(filter);
+
+    return Promise.resolve();
   };
 
   const widgetFields = useMemo(

--- a/frontend/src/components/filters/InlineFilterItem.js
+++ b/frontend/src/components/filters/InlineFilterItem.js
@@ -36,12 +36,13 @@ const InlineFilterItem = ({
     setParameterValue(value ? value : '');
   };
 
-  // `handlePatch` (passed to the widget as `handlePatch={handleApply}`) is called by some widgets
-  // (e.g. Checkbox for a YesNo filter) directly with the freshly toggled value, WITHOUT having gone
-  // through `setValue`/`onChange` first - Checkbox only wires `handlePatch`, never `onChange`. So the
-  // value actually being applied must be the one passed in here when present, falling back to the
-  // locally tracked `parameterValue` (kept up to date by `onChange`-driven widgets, e.g. Text on
-  // Enter/Tab) only when no value was passed. Also keep `parameterValue` itself in sync so a second
+  // `handlePatch` (passed to the widget as `handlePatch={handleApply}`) is called with the freshly
+  // produced value, WITHOUT that value having gone through `setValue`/`onChange` first. A Checkbox
+  // (a YesNo filter) only ever wires `handlePatch`, so for it that is the ONLY way the value
+  // arrives; a Text filter reaches the same path on Enter/blur (RawWidget#handleKeyDown /
+  // #handleBlurWithParams -> #handlePatch), where the value happens to match what `onChange` already
+  // tracked. So the value actually applied must be the one passed in here when present, falling back
+  // to the locally tracked `parameterValue` only when no value was passed. Also keep `parameterValue` itself in sync so a second
   // toggle (e.g. turning the filter back off) does not read a stale value on the next call.
   //
   // Checkbox additionally expects `handlePatch(...)` to return a thenable - same contract as the


### PR DESCRIPTION
Adds a user-toggled flag filter to the sales-order *Produktvorschläge* overlay that restricts the
list to products the business partner has already had delivered.

### Behaviour
- New frequent-used `YesNo` filter in the overlay, captioned from a new `AD_Message`
  (`OnlyProductsWithDeliveryHistory` — DE "Nur Produkte mit Lieferhistorie", EN "Only products with
  delivery history"). It renders as a filter **button** whose dropdown panel carries the flag
  (`DocumentFilterInlineRenderMode.BUTTON`) — inline rendering is reserved for search fields, whose
  caption fits inside the input; a checkbox rendered inline gets no caption at all, because the
  Checkbox widget never renders one.
- **Off by default**: the overlay still opens with the full assortment; the salesperson opts in.
- The criterion is the row's existing *Tage vergangen* (`lastShipmentDays`) signal, i.e. **delivered**
  (on a purchase order: received), not merely ordered.
- Rows carrying a typed quantity stay visible when the filter is switched on, so no entered quantity
  is ever hidden — and the order lines created on DONE do not depend on the filter state.
- *Andere Produkte* is untouched: the order view gets its **own** filter descriptor, so that view
  gains no new parameter.
- Row ordering is unchanged.

### Not included, deliberately
No `AD_SysConfig` switch. The filter is visible and toggleable by the user, which makes a
global/per-org on/off flag redundant.

### Tests
- Playwright E2E (`product-proposal-delivered-filter.spec.js`) — filter present-but-off, narrowing,
  restoring, and a partner with no delivery history at all.
- Playwright E2E (`product-proposal-qty-survives-filter.spec.js`) — a typed quantity survives the
  filter and still reaches the order line.
- `ProductsProposalRowTest` — the row-matching predicate.
- `ProductsProposalRowsDataTest` — the unfiltered row set the order lines are built from.

### Also in this branch
`InlineFilterItem#handleApply` applied the locally tracked value instead of the one it was handed,
and returned `undefined` where the Checkbox widget expects a thenable — so an inline `YesNo` filter
applied a stale value and broke the widget's patch contract. The fix is independent of the filter
above (which no longer renders inline) and still applies to every inline filter the Application
Dictionary can configure via `AD_Field.IsShowFilterInline`; no spec in this branch exercises it.

