### PR TITLE
Port: default-sort MobileUI MFG attributes grid by SeqNo asc to boomerang_signal_release

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823940_sys_mobileMfgAttrGridSortBySeqNo.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5823940_sys_mobileMfgAttrGridSortBySeqNo.sql
@@ -1,0 +1,8 @@
+-- MobileUI Manufacturing config — default-sort the editable-attributes child grid by SeqNo ascending.
+-- Window 541788, tab 549417 (Merkmale / MobileUI_MFG_Config_Attribute): SeqNo drives the order the
+-- attributes are presented on the mobile receive dialog, so the grid must default to SeqNo ascending.
+-- AD_Field.SortNo is the signed grid default-sort key (sign = asc(+)/desc(-), magnitude = priority);
+-- +1 = primary sort key ascending. Field 783058 = the SeqNo field on that tab.
+
+-- 2026-09-10 09:00:00
+UPDATE AD_Field SET SortNo=1, Updated=TO_TIMESTAMP('2026-09-10 09:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Field_ID=783058;


### PR DESCRIPTION
Ports the MobileUI Manufacturing editable-attributes **grid default-sort** fix to the `boomerang_signal_release` line.

## What
Migration `5823940_sys_mobileMfgAttrGridSortBySeqNo.sql` sets `AD_Field.SortNo=1` on field `783058` (the `SeqNo` field on tab 549417 / window 541788, `MobileUI_MFG_Config_Attribute` "Merkmale") so the editable-attributes child grid defaults to **SeqNo ascending** — the order the attributes are presented on the mobile receive dialog.

Cherry-pick of https://github.com/metasfresh/metasfresh/commit/18f3bc7fa9dd7db9a4b26ec58397863bd93505ca (also going to `new_dawn_uat` via PR https://github.com/metasfresh/metasfresh/pull/25914).

## Why this targets the release line
The feature itself was delivered to `boomerang_signal_release` by cherry-pick PR https://github.com/metasfresh/metasfresh/pull/25906 (field `783058` exists here via migration `5821580`), so this follow-up must land here too. Same commit lands on `new_dawn_uat` via PR https://github.com/metasfresh/metasfresh/pull/25914. A `release → new_dawn_uat` merge-through is not used because the release line is a cherry-pick fork of the feature and that merge conflicts on pre-existing feature-divergence, unrelated to this migration.

## Safety
Additive AD metadata only — a single `UPDATE AD_Field SET SortNo=1` on an existing field. No view/function redefinition, no DDL regression risk.
