### PR TITLE
Cucumber: assert on the rendered PDF of an archived document

### DIFF
--- a/backend/de.metas.cucumber/Readme.md
+++ b/backend/de.metas.cucumber/Readme.md
@@ -89,3 +89,94 @@ If subsequent test runs fail unexpectedly or use data from a previous run, the l
 ### Shutting Down
 
 To cleanly shut down the server and exit the runner, type `exit` at the `>>>` prompt and hit `ENTER`.
+
+# Asserting on a rendered document PDF
+
+`AD_Archive_StepDef` lets a scenario assert against the **actual PDF** metasfresh rendered and archived
+for a document — not against the report's SQL, and not against a mock. Use it whenever the thing under
+test is what the customer or the warehouse will physically read.
+
+The steps resolve the record through the normal step-def identifier mechanism, so they work for **any**
+record that archives a PDF — sales order, shipment, invoice, and so on.
+
+## Getting a PDF to assert on
+
+Two sysconfigs must be set in your `Background`, or you will assert against a placeholder:
+
+```gherkin
+# render the real jasper report; the mock report service would archive a placeholder PDF instead
+And set sys config boolean value false for sys config de.metas.report.jasper.IsMockReportService
+# keep the archive in the DB, so the steps can read it back
+And update AD_Client
+  | Identifier | StoreArchiveOnFileSystem |
+  | 1000000    | false                    |
+```
+
+Then complete the document and run its jasper process — the `Value` is the `AD_Process.Value`, so a
+different document just means a different process:
+
+```gherkin
+When the order identified by order is completed
+And The jasper process is run
+  | Value            | Record_ID |
+  | Auftrag (Jasper) | order     |
+```
+
+`Lieferschein (Jasper)`, `Rechnung (Jasper)`, `Bestellung (Jasper)`, `Wareneingang (Jasper)` and the
+rest work the same way.
+
+## The steps
+
+```gherkin
+# the document was archived at all
+Then an AD_Archive exists for the record identified by "order"
+
+# the text reached the PDF (or must not be there)
+Then the PDF archived for the record identified by "order" contains text "Bitte gekuehlt liefern"
+Then the PDF archived for the record identified by "order" does not contain text "Zwischenpalette"
+
+# WHERE the text sits — counted in rendered visual lines
+Then in the PDF archived for the record identified by "order", exactly 0 lines appear between text "ALPHA-NR" and text "BetaItem"
+Then in the PDF archived for the record identified by "order", at least 2 lines appear between text "Diese Position" and text "BetaItem"
+
+# geometry — compare one vertical gap against another
+Then in the PDF archived for the record identified by "order", the vertical distance from text "A" to text "B" equals the distance from text "C" to text "D"
+```
+
+**Prefer the positional steps over `contains text` alone.** "The text is somewhere in the document" is a
+weak assertion: it passes even when the text lands in the wrong block, above the wrong article, or on
+the wrong page. The `lines between` and `vertical distance` steps are what make *placement* testable.
+
+**Pick single distinctive words as needles.** The extraction yields one entry per rendered visual line,
+so a multi-word needle stops matching as soon as the layout wraps between two of its words.
+
+**A blank line emits no glyphs.** If what you are testing is that something occupies vertical *space*
+(an empty line inside a text block, or the absence of a suppressed block), text adjacency cannot see it
+— use the `vertical distance … equals …` step against a reference block of known height.
+
+## The PDF is attached to the Allure report
+
+Every PDF a scenario asserts against is attached to that scenario's Allure report automatically,
+deduplicated per archive, on pass as well as on failure. That gives a reviewer the actual document
+instead of a description of it.
+
+Allure nests the attachment **under the step that read the PDF**, so the test-case page looks empty
+until you expand that step; the entry is named `PDF archived for <identifier> (AD_Archive_ID=…)`.
+
+To get direct links out of a published report instead of clicking through, for a report base
+`https://test-reports.metasfresh.com/branches/<branch>/builds/<build-tag>/allure/cucumber`:
+
+1. `data/suites.json` → walk to the leaf nodes for each scenario's `uid`
+2. `data/test-cases/<uid>.json` → walk `testStage` recursively over `steps`, collecting `attachments`
+   whose `type` is `application/pdf`; each carries a `source`
+3. the file is at `data/attachments/<source>.pdf`
+
+## How it works, in case a step surprises you
+
+Text is extracted with PDFBox (`PDFTextStripper`, `setSortByPosition(true)`), grouped into visual lines
+by page and y-coordinate. "Lines between" counts those rendered lines, not `\n` characters in the source
+data — which is the point: it measures what the reader sees.
+
+PDFBox is pinned to 2.0.27 in this module's `pom.xml` on purpose: `PDDocument.load(byte[])` exists in
+PDFBox 2 but not in 3, and this module skips the enforcer, so an unpinned transitive bump would break
+these steps with nothing else catching it.

--- a/backend/de.metas.cucumber/Readme.md
+++ b/backend/de.metas.cucumber/Readme.md
@@ -154,6 +154,45 @@ so a multi-word needle stops matching as soon as the layout wraps between two of
 (an empty line inside a text block, or the absence of a suppressed block), text adjacency cannot see it
 — use the `vertical distance … equals …` step against a reference block of known height.
 
+## Checking the layout: nothing printed on top of anything else
+
+```gherkin
+Then the PDF archived for the record identified by "order" has no overlapping text
+Then the PDF archived for the record identified by "order" has no overlapping text within 2 points
+```
+
+A generic layout net. It needs no knowledge of the document, so it can be added to any scenario that
+already prints one. It builds a bounding box per glyph and flags a pair only when the boxes intersect by
+more than the tolerance in **both** dimensions, so glyphs that merely share a column or a baseline are
+not a collision. The tolerance is in PDF user-space **points** (not pixels) and defaults to 2.
+
+It catches an element that stretches or is positioned into its neighbour: a long product name running
+into the quantity column, a block that grew into the row beneath.
+
+**It does not catch clipping**, which is the more common Jasper failure. An element too small for its
+content with `isStretchWithOverflow` off does not overlap anything - it silently truncates. That shows
+up as *missing* text, so assert `contains text` on a word you expect near the end of the content.
+
+Measured on a plain three-position order confirmation: 775 glyphs examined, 0 overlaps at the default
+tolerance.
+
+### Why this works per GLYPH, and not per word
+
+Worth knowing before you "improve" it, because two coarser groupings were tried first and both failed
+against a real document:
+
+- **Per content-stream run** (no `setSortByPosition`): a run in these documents spans several visually
+  separate columns - one came back as `10,00AlphaItem`. Boxes built from that span the whole row and
+  collide with everything on it, so every row reported overlaps a reader cannot see.
+- **Per word** (`setSortByPosition(true)`, which is what makes `writeString` fire once per word): the
+  same sorting that produces words also **fuses colliding glyphs into one word**. With a field
+  deliberately moved on top of the product name, the two texts came back as the single word
+  `ASltpkhaItem` - so there were no longer two boxes to compare, and the real collision was invisible.
+
+Per glyph neither happens: characters inside a word merely abut, because the advance width places the
+next glyph exactly where the previous one ends, so their horizontal overlap is about 0 and stays under
+the tolerance; whereas two texts printed on top of each other overlap by most of a glyph width.
+
 ## The PDF is attached to the Allure report
 
 Every PDF a scenario asserts against is attached to that scenario's Allure report automatically,

--- a/backend/de.metas.cucumber/pom.xml
+++ b/backend/de.metas.cucumber/pom.xml
@@ -136,6 +136,18 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <!--
+                Used by AD_Archive_StepDef to read the text out of an archived document PDF.
+                Pinned deliberately: it otherwise only arrives transitively and unversioned, and
+                PDDocument.load(byte[]) exists in PDFBox 2 but not in 3, so a transitive bump
+                would break those steps. This module skips the enforcer, so nothing else catches it.
+            -->
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.27</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- JUnit 5 and Cucumber JUnit Platform Engine -->
         <dependency>

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/archive/AD_Archive_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/archive/AD_Archive_StepDef.java
@@ -26,23 +26,45 @@ import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.util.IdentifiersResolver;
 import de.metas.util.Services;
 import io.cucumber.java.en.Then;
+import io.qameta.allure.Allure;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.archive.api.IArchiveBL;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.util.lang.impl.TableRecordReference;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.apache.pdfbox.text.TextPosition;
 import org.compiere.model.I_AD_Archive;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 /**
- * Verifies that an {@code AD_Archive} record (the generated document PDF) exists for a given document.
+ * Verifies that an {@code AD_Archive} record (the generated document PDF) exists for a given document, and
+ * inspects the actual rendered PDF content (via Apache PDFBox) of that archive.
  */
 @RequiredArgsConstructor
 public class AD_Archive_StepDef
 {
 	@NonNull private final IdentifiersResolver identifiersResolver;
 
-	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	@NonNull private final IArchiveBL archiveBL = Services.get(IArchiveBL.class);
+
+	/** AD_Archive_IDs already attached to the report in THIS scenario — see {@link #attachToAllureReportOnce}. */
+	@NonNull private final Set<Integer> attachedArchiveIds = new HashSet<>();
 
 	/**
 	 * @cucumber.stepdef
@@ -66,5 +88,397 @@ public class AD_Archive_StepDef
 		assertThat(count)
 				.as("AD_Archive count for record %s", recordRef)
 				.isGreaterThanOrEqualTo(1);
+	}
+
+	/**
+	 * Extracts the text of the most recently archived PDF for the given record (via PDFBox) and asserts it
+	 * contains the given text.
+	 * <p>
+	 * Prefer a single distinctive word over a phrase when the text under test can wrap: a line break falls
+	 * between two words, so a multi-word needle fails as soon as the layout wraps between them.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then the PDF archived for the record identified by "order" contains text "Teillieferungsavis"
+	 * </pre>
+	 */
+	@Then("the PDF archived for the record identified by {string} contains text {string}")
+	public void assert_archived_pdf_contains_text(
+			@NonNull final String recordIdentifier,
+			@NonNull final String expectedText)
+	{
+		final String pdfText = extractPdfVisualLines(recordIdentifier).stream()
+				.map(PdfLine::getText)
+				.collect(Collectors.joining("\n"));
+
+		assertThat(pdfText)
+				.as("Text extracted from the PDF archived for record %s", recordIdentifier)
+				.contains(expectedText);
+	}
+
+	/**
+	 * The negative of {@link #assert_archived_pdf_contains_text(String, String)}: asserts that the text does
+	 * not appear ANYWHERE in the archived PDF. This is the assertion for "the text is gone", which no
+	 * positional step can make — those only ever say what is not between two anchors, while an orphaned
+	 * value could have landed above another line or at the end of the document.
+	 * <p>
+	 * Use a single distinctive word, for the same reason as the positive step: a needle that the layout can
+	 * wrap in the middle would be absent from the extracted text even when the value did print.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then the PDF archived for the record identified by "order" does not contain text "Zwischenpalette"
+	 * </pre>
+	 */
+	@Then("the PDF archived for the record identified by {string} does not contain text {string}")
+	public void assert_archived_pdf_does_not_contain_text(
+			@NonNull final String recordIdentifier,
+			@NonNull final String unexpectedText)
+	{
+		final String pdfText = extractPdfVisualLines(recordIdentifier).stream()
+				.map(PdfLine::getText)
+				.collect(Collectors.joining("\n"));
+
+		assertThat(pdfText)
+				.as("Text extracted from the PDF archived for record %s", recordIdentifier)
+				.doesNotContain(unexpectedText);
+	}
+
+	/**
+	 * Verifies that, in the visual (top-to-bottom, left-to-right) reading order of the archived PDF, exactly
+	 * {@code linesBetween} other text lines separate {@code earlierText} from {@code laterText} — no more,
+	 * no fewer. Pass 0 to pin adjacency: the two texts then sit on consecutive lines, so nothing was printed
+	 * between them.
+	 * <p>
+	 * Both anchors should be text you control, so that a failure names the two rows it happened between.
+	 * A non-zero expected count means the anchors have something unidentified between them, which makes the
+	 * assertion composite — prefer moving the anchors over raising the count.
+	 * <p>
+	 * Limitation: text extraction sees glyphs, not layout. This proves no extra TEXT was printed; it says
+	 * nothing about empty vertical space, which carries no text of its own. To rule that out as well, use
+	 * the vertical-distance step below.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then in the PDF archived for the record identified by "order", exactly 0 lines appear between text "ALPHA-NR" and text "BetaItem"
+	 * </pre>
+	 */
+	@Then("in the PDF archived for the record identified by {string}, exactly {int} lines appear between text {string} and text {string}")
+	public void assert_archived_pdf_exactly_lines_between(
+			@NonNull final String recordIdentifier,
+			final int linesBetween,
+			@NonNull final String earlierText,
+			@NonNull final String laterText)
+	{
+		final List<PdfLine> lines = extractPdfVisualLines(recordIdentifier);
+		assertLinesBetween(lines, earlierText, laterText, linesBetween, linesBetween);
+	}
+
+	/**
+	 * Verifies that at least {@code minLinesBetween} other visual lines separate {@code earlierText} from
+	 * {@code laterText} in the archived PDF — used to prove a long value actually wrapped onto several visual
+	 * lines rather than being clipped onto (or squeezed into) a single one. The exact number of wrapped lines
+	 * depends on font metrics, so it is deliberately not pinned.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then in the PDF archived for the record identified by "order", at least 2 lines appear between text "Diese Position" and text "BetaItem"
+	 * </pre>
+	 */
+	@Then("in the PDF archived for the record identified by {string}, at least {int} lines appear between text {string} and text {string}")
+	public void assert_archived_pdf_at_least_lines_between(
+			@NonNull final String recordIdentifier,
+			final int minLinesBetween,
+			@NonNull final String earlierText,
+			@NonNull final String laterText)
+	{
+		final List<PdfLine> lines = extractPdfVisualLines(recordIdentifier);
+		assertLinesBetween(lines, earlierText, laterText, minLinesBetween, Integer.MAX_VALUE);
+	}
+
+	/**
+	 * Verifies that the two text pairs are the same vertical distance apart on the page.
+	 * <p>
+	 * This is the assertion for "nothing was printed AND nothing took up space". A band that renders a
+	 * blank value emits no glyphs at all, so no text-based assertion can tell it apart from a band that was
+	 * suppressed — but it still consumes its own height, which shows up here as a larger distance.
+	 * <p>
+	 * Pick the reference pair (the second one) so that the band under test CANNOT fall inside it — a leg
+	 * that the same band also inflates makes the comparison pass again once every row grows equally, which
+	 * is exactly what happens when a guard is removed outright rather than mis-evaluated. A pair that stays
+	 * within one row, below the band in question, is such a fixed reference.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then in the PDF archived for the record identified by "order", the vertical distance from text "ALPHA-NR" to text "BetaItem" equals the distance from text "BETA-NR" to text "GammaItem"
+	 * </pre>
+	 */
+	@Then("in the PDF archived for the record identified by {string}, the vertical distance from text {string} to text {string} equals the distance from text {string} to text {string}")
+	public void assert_archived_pdf_vertical_distances_equal(
+			@NonNull final String recordIdentifier,
+			@NonNull final String firstFromText,
+			@NonNull final String firstToText,
+			@NonNull final String secondFromText,
+			@NonNull final String secondToText)
+	{
+		final List<PdfLine> lines = extractPdfVisualLines(recordIdentifier);
+
+		final float firstDistance = verticalDistance(lines, firstFromText, firstToText);
+		final float secondDistance = verticalDistance(lines, secondFromText, secondToText);
+
+		// The smallest difference this has to detect is one suppressed-vs-printed band, which is whole
+		// points tall, so a fraction of a point of float noise in the glyph coordinates is not a difference.
+		assertThat(firstDistance)
+				.as("Vertical distance '%s'->'%s' vs '%s'->'%s' in extracted PDF text %s",
+						firstFromText, firstToText, secondFromText, secondToText, textsOf(lines))
+				.isCloseTo(secondDistance, within(0.5f));
+	}
+
+	private static float verticalDistance(
+			@NonNull final List<PdfLine> lines,
+			@NonNull final String fromText,
+			@NonNull final String toText)
+	{
+		final int fromIdx = indexOfLineContaining(lines, fromText, 0);
+		assertThat(fromIdx)
+				.as("Line containing '%s' in extracted PDF text %s", fromText, textsOf(lines))
+				.isGreaterThanOrEqualTo(0);
+
+		final int toIdx = indexOfLineContaining(lines, toText, fromIdx + 1);
+		assertThat(toIdx)
+				.as("Line containing '%s' after '%s' in extracted PDF text %s", toText, fromText, textsOf(lines))
+				.isGreaterThanOrEqualTo(0);
+
+		// Page coordinates restart on every page, so a distance measured across a page break is a
+		// meaningless number that would silently satisfy or break the comparison.
+		assertThat(lines.get(toIdx).getPageIndex())
+				.as("Page of '%s' vs page of '%s': a vertical distance is only meaningful within one page",
+						toText, fromText)
+				.isEqualTo(lines.get(fromIdx).getPageIndex());
+
+		return lines.get(toIdx).getY() - lines.get(fromIdx).getY();
+	}
+
+	private static void assertLinesBetween(
+			@NonNull final List<PdfLine> lines,
+			@NonNull final String earlierText,
+			@NonNull final String laterText,
+			final int minLinesBetween,
+			final int maxLinesBetween)
+	{
+		final int earlierIdx = indexOfLineContaining(lines, earlierText, 0);
+		assertThat(earlierIdx)
+				.as("Line containing '%s' in extracted PDF text %s", earlierText, textsOf(lines))
+				.isGreaterThanOrEqualTo(0);
+
+		final int laterIdx = indexOfLineContaining(lines, laterText, earlierIdx + 1);
+		assertThat(laterIdx)
+				.as("Line containing '%s' after '%s' in extracted PDF text %s", laterText, earlierText, textsOf(lines))
+				.isGreaterThanOrEqualTo(0);
+
+		final int linesBetween = laterIdx - earlierIdx - 1;
+		assertThat(linesBetween)
+				.as("Lines between '%s' and '%s' in extracted PDF text %s", earlierText, laterText, textsOf(lines))
+				.isBetween(minLinesBetween, maxLinesBetween);
+	}
+
+	private static int indexOfLineContaining(@NonNull final List<PdfLine> lines, @NonNull final String needle, final int fromIndex)
+	{
+		for (int i = fromIndex; i < lines.size(); i++)
+		{
+			if (lines.get(i).getText().contains(needle))
+			{
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private static List<String> textsOf(@NonNull final List<PdfLine> lines)
+	{
+		return lines.stream().map(PdfLine::getText).collect(Collectors.toList());
+	}
+
+	/**
+	 * Extracts the most recently archived PDF for the given record as an ordered list of visual text lines
+	 * (top-to-bottom, left-to-right) — the order a human reads on the page, which is what a reviewer would
+	 * check by eye — each carrying the page it sits on and its vertical position.
+	 * <p>
+	 * {@link PDFTextStripper#setSortByPosition(boolean)} is what makes the order VISUAL rather than the raw
+	 * content-stream order: a Jasper band placed above another one may well be written to the content stream
+	 * after it.
+	 * <p>
+	 * The grouping is PDFBox's own. {@code writeString} fires once per WORD, not once per line (PDFBox 2.x
+	 * {@code PDFTextStripper.writeLine} calls it per {@code WordWithTextPositions}), so {@link PdfLineStripper}
+	 * accumulates words and flushes a line only on {@code writeLineSeparator} — which reproduces exactly what
+	 * {@code getText()} would have returned, while also keeping the coordinates {@code getText()} discards.
+	 */
+	private List<PdfLine> extractPdfVisualLines(@NonNull final String recordIdentifier)
+	{
+		final byte[] pdfBytes = getLatestArchivedPdfBytes(recordIdentifier);
+
+		final List<PdfLine> lines;
+		try (final PDDocument document = PDDocument.load(pdfBytes))
+		{
+			final PdfLineStripper stripper = new PdfLineStripper();
+			stripper.getText(document); // the captured lines, not the return value, are what we use
+			lines = stripper.getLines();
+		}
+		catch (final IOException e)
+		{
+			throw new AdempiereException("Failed to extract text from the PDF archived for record " + recordIdentifier, e);
+		}
+
+		// A rendered document PDF always carries text. If it carries none, the render or the archiving went
+		// wrong; fail here rather than let a text assertion pass against an empty extraction.
+		assertThat(lines)
+				.as("Text lines extracted from the PDF archived for record %s", recordIdentifier)
+				.isNotEmpty();
+
+		return lines;
+	}
+
+	private byte[] getLatestArchivedPdfBytes(@NonNull final String recordIdentifier)
+	{
+		final TableRecordReference recordRef = identifiersResolver.getTableRecordReference(StepDefDataIdentifier.ofString(recordIdentifier));
+
+		// Deliberately not IArchiveDAO.retrieveLastArchives: that orders by Created descending
+		// (ArchiveDAO.java:87). A scenario that prints the same record twice can produce both archives
+		// within one clock tick, and then "last" is whichever row the DB happens to return first.
+		// AD_Archive_ID is monotonic and never ties, so ordering by it picks the newest archive
+		// deterministically -- which is what an assertion about "the PDF just printed" needs.
+		final I_AD_Archive archive = queryBL.createQueryBuilder(I_AD_Archive.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_AD_Archive.COLUMNNAME_AD_Table_ID, recordRef.getAD_Table_ID())
+				.addEqualsFilter(I_AD_Archive.COLUMNNAME_Record_ID, recordRef.getRecord_ID())
+				.orderByDescending(I_AD_Archive.COLUMNNAME_AD_Archive_ID)
+				.create()
+				.first();
+
+		if (archive == null)
+		{
+			throw new AdempiereException("No AD_Archive found for record " + recordRef);
+		}
+
+		// Read via IArchiveBL, not AD_Archive.BinaryData: DBArchiveStorage stores the document ZIPPED in
+		// that column, and with AD_Client.StoreArchiveOnFileSystem='Y' it is not in the column at all.
+		// Only the archive storage knows how to hand back the plain document bytes.
+		final byte[] binaryData = archiveBL.getBinaryData(archive);
+		assertThat(binaryData)
+				.as("Archived PDF data of AD_Archive_ID=%s", archive.getAD_Archive_ID())
+				.isNotNull()
+				.isNotEmpty();
+
+		attachToAllureReportOnce(archive.getAD_Archive_ID(), recordIdentifier, binaryData);
+
+		return binaryData;
+	}
+
+	/**
+	 * Attaches the rendered PDF to the Allure report, so a reviewer can open the actual document a
+	 * scenario asserted against instead of inferring it from extracted text.
+	 * <p>
+	 * Deduplicated per archive: several assertion steps in one scenario read the same document, and each
+	 * would otherwise attach another copy of it. This step-def instance lives for exactly one scenario
+	 * (picocontainer builds a fresh one per scenario), so the set needs no clearing.
+	 */
+	private void attachToAllureReportOnce(
+			final int archiveId,
+			@NonNull final String recordIdentifier,
+			@NonNull final byte[] pdfBytes)
+	{
+		if (!attachedArchiveIds.add(archiveId))
+		{
+			return;
+		}
+
+		Allure.addAttachment(
+				"PDF archived for " + recordIdentifier + " (AD_Archive_ID=" + archiveId + ")",
+				"application/pdf",
+				new ByteArrayInputStream(pdfBytes),
+				".pdf");
+	}
+
+	/** One visual line of the PDF: the page it sits on, its vertical position, and its text. */
+	@Value
+	private static class PdfLine
+	{
+		int pageIndex;
+		float y;
+		@NonNull String text;
+	}
+
+	/**
+	 * Collects one {@link PdfLine} per visual line PDFBox emits, in top-to-bottom reading order, keeping the
+	 * vertical position that {@link PDFTextStripper#getText(PDDocument)} throws away.
+	 */
+	private static final class PdfLineStripper extends PDFTextStripper
+	{
+		private final List<PdfLine> lines = new ArrayList<>();
+		private final StringBuilder currentLine = new StringBuilder();
+		private Float currentY = null;
+		private int currentPageIndex = 0;
+
+		PdfLineStripper() throws IOException
+		{
+			super();
+			setSortByPosition(true);
+			setLineSeparator("\n");
+		}
+
+		@Override
+		protected void writeString(final String text, final List<TextPosition> textPositions)
+		{
+			currentLine.append(text);
+			if (currentY == null && !textPositions.isEmpty())
+			{
+				currentY = textPositions.get(0).getYDirAdj();
+			}
+		}
+
+		@Override
+		protected void writeWordSeparator()
+		{
+			currentLine.append(getWordSeparator());
+		}
+
+		@Override
+		protected void writeLineSeparator()
+		{
+			flushCurrentLine();
+		}
+
+		@Override
+		protected void startPage(final PDPage page)
+		{
+			currentPageIndex = getCurrentPageNo();
+		}
+
+		@Override
+		protected void endPage(final PDPage page)
+		{
+			flushCurrentLine(); // the last line of a page is not followed by a line separator
+		}
+
+		private void flushCurrentLine()
+		{
+			final String text = currentLine.toString().trim();
+			if (!text.isEmpty() && currentY != null)
+			{
+				lines.add(new PdfLine(currentPageIndex, currentY, text));
+			}
+			currentLine.setLength(0);
+			currentY = null;
+		}
+
+		List<PdfLine> getLines()
+		{
+			return lines;
+		}
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/archive/AD_Archive_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/archive/AD_Archive_StepDef.java
@@ -239,6 +239,58 @@ public class AD_Archive_StepDef
 				.isCloseTo(secondDistance, within(0.5f));
 	}
 
+	/**
+	 * Asserts that no two words in the archived PDF are printed on top of each other.
+	 * <p>
+	 * A generic layout net: it needs no knowledge of the document, so it can be added to any scenario that
+	 * already prints one. It catches the failure where an element stretches or is positioned into its
+	 * neighbour — a long product name running into the quantity column, a block that grew into the row
+	 * beneath.
+	 * <p>
+	 * It does NOT catch CLIPPING, which is the more common Jasper failure: an element too small for its
+	 * content with {@code isStretchWithOverflow} off does not overlap anything, it silently truncates. That
+	 * shows up as MISSING text, so assert on a word you expect near the end of the content instead.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then the PDF archived for the record identified by "order" has no overlapping text
+	 * </pre>
+	 */
+	@Then("the PDF archived for the record identified by {string} has no overlapping text")
+	public void assert_archived_pdf_has_no_overlapping_text(@NonNull final String recordIdentifier)
+	{
+		assert_archived_pdf_has_no_overlapping_text_within(recordIdentifier, DEFAULT_OVERLAP_TOLERANCE_POINTS);
+	}
+
+	/**
+	 * Same as {@link #assert_archived_pdf_has_no_overlapping_text(String)} with an explicit tolerance.
+	 * <p>
+	 * The unit is PDF user-space POINTS, not pixels. Two boxes count as overlapping only when they intersect
+	 * by more than the tolerance in BOTH dimensions, so words merely sharing a column or a baseline are not
+	 * flagged; only a true two-dimensional collision is.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then the PDF archived for the record identified by "order" has no overlapping text within 2 points
+	 * </pre>
+	 */
+	@Then("the PDF archived for the record identified by {string} has no overlapping text within {int} points")
+	public void assert_archived_pdf_has_no_overlapping_text_within(
+			@NonNull final String recordIdentifier,
+			final int tolerancePoints)
+	{
+		final List<PdfWord> words = extractPdfWords(recordIdentifier);
+		final List<String> overlaps = detectOverlaps(words, tolerancePoints);
+
+		assertThat(overlaps)
+				.as("Overlapping text in the PDF archived for record %s (tolerance %s points, %s words examined)",
+						recordIdentifier, tolerancePoints, words.size())
+				.isEmpty();
+	}
+
+
 	private static float verticalDistance(
 			@NonNull final List<PdfLine> lines,
 			@NonNull final String fromText,
@@ -481,4 +533,146 @@ public class AD_Archive_StepDef
 			return lines;
 		}
 	}
+
+	/** Tolerance in PDF user-space points, matching the frontend PdfLayoutValidator default. */
+	private static final int DEFAULT_OVERLAP_TOLERANCE_POINTS = 2;
+
+	/**
+	 * Every pair of words whose bounding boxes intersect by more than {@code tolerancePoints} in BOTH
+	 * dimensions, described for the failure message.
+	 * <p>
+	 * Requiring both dimensions is what keeps this quiet on a normal document: words in the same column share
+	 * an x-range and words on the same line share a y-range, and neither alone is a collision. Pairwise is
+	 * O(n^2), which is fine at document scale.
+	 */
+	private static List<String> detectOverlaps(@NonNull final List<PdfWord> words, final int tolerancePoints)
+	{
+		final List<String> overlaps = new ArrayList<>();
+
+		for (int i = 0; i < words.size(); i++)
+		{
+			final PdfWord one = words.get(i);
+			for (int j = i + 1; j < words.size(); j++)
+			{
+				final PdfWord other = words.get(j);
+				if (one.getPageIndex() != other.getPageIndex())
+				{
+					continue;
+				}
+
+				final float overlapX = Math.min(one.getRight(), other.getRight()) - Math.max(one.getLeft(), other.getLeft());
+				final float overlapY = Math.min(one.getBottom(), other.getBottom()) - Math.max(one.getTop(), other.getTop());
+
+				if (overlapX > tolerancePoints && overlapY > tolerancePoints)
+				{
+					overlaps.add(String.format(
+							"page %s: '%s' and '%s' overlap by %.1f x %.1f points",
+							one.getPageIndex(), one.getText(), other.getText(), overlapX, overlapY));
+				}
+			}
+		}
+
+		return overlaps;
+	}
+
+	/**
+	 * Extracts the archived PDF as one bounding box per WORD.
+	 * <p>
+	 * Word granularity comes free: PDFBox 2.x calls {@code writeString} once per word (see
+	 * {@link #extractPdfVisualLines(String)}). It is also the right unit here — per glyph would flag normal
+	 * kerning, per line would be too coarse to see a collision within a row.
+	 */
+	private List<PdfWord> extractPdfWords(@NonNull final String recordIdentifier)
+	{
+		final byte[] pdfBytes = getLatestArchivedPdfBytes(recordIdentifier);
+
+		final List<PdfWord> words;
+		try (final PDDocument document = PDDocument.load(pdfBytes))
+		{
+			final PdfWordStripper stripper = new PdfWordStripper();
+			stripper.getText(document);
+			words = stripper.getWords();
+		}
+		catch (final IOException e)
+		{
+			throw new AdempiereException("Failed to extract words from the PDF archived for record " + recordIdentifier, e);
+		}
+
+		assertThat(words)
+				.as("Words extracted from the PDF archived for record %s", recordIdentifier)
+				.isNotEmpty();
+
+		return words;
+	}
+
+	/** One word of the PDF with the box it occupies, in PDF user-space points, y growing downwards. */
+	@Value
+	private static class PdfWord
+	{
+		int pageIndex;
+		float left;
+		float right;
+		float top;
+		float bottom;
+		@NonNull String text;
+	}
+
+	/**
+	 * Collects one {@link PdfWord} per GLYPH, with its bounding box.
+	 * <p>
+	 * Glyph level, not word level, and the reason is measured rather than theoretical. Two higher-level
+	 * groupings were tried first and both fail:
+	 * <ul>
+	 * <li><b>Unsorted runs</b> — PDFBox hands back raw content-stream runs, and a run in these documents spans
+	 * several visually separate columns: one came back as {@code "10,00AlphaItem"}. Boxes built from those
+	 * span the whole row and collide with everything on it, so every row reports overlaps a reader cannot see.
+	 * <li><b>Sorted words</b> ({@code setSortByPosition(true)}, which makes {@code writeString} fire per word)
+	 * — the sorting that produces words also FUSES colliding glyphs into one word. With a field deliberately
+	 * moved on top of the product name, the two texts came back as the single word {@code "ASltpkhaItem"}, so
+	 * there were no longer two boxes to compare and the collision was invisible.
+	 * </ul>
+	 * Per glyph, neither happens: characters within a word merely abut (the advance width puts the next glyph
+	 * exactly where the previous ends, so their horizontal overlap is ~0 and stays under the tolerance), while
+	 * two texts printed on top of each other overlap by most of a glyph width and are flagged.
+	 */
+	private static final class PdfWordStripper extends PDFTextStripper
+	{
+		private final List<PdfWord> words = new ArrayList<>();
+
+		PdfWordStripper() throws IOException
+		{
+			super();
+		}
+
+		List<PdfWord> getWords()
+		{
+			return words;
+		}
+
+		@Override
+		protected void writeString(final String text, final List<TextPosition> textPositions)
+		{
+			for (final TextPosition position : textPositions)
+			{
+				final String glyph = position.getUnicode();
+				if (glyph == null || glyph.trim().isEmpty())
+				{
+					continue; // whitespace lays down no ink and cannot collide with anything
+				}
+
+				final float x = position.getXDirAdj();
+				final float y = position.getYDirAdj();
+				final float height = position.getHeightDir();
+
+				words.add(new PdfWord(
+						getCurrentPageNo(),
+						x,
+						x + position.getWidthDirAdj(),
+						y - height,
+						y,
+						glyph));
+			}
+		}
+	}
+
 }

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/report/archivedPdfAssertions.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/report/archivedPdfAssertions.feature
@@ -1,0 +1,100 @@
+@from:cucumber
+@allure.label.feature:F71030_Cucumber_Integration_Testing
+@ghActions:run_on_executor2
+Feature: Asserting on the rendered PDF of an archived document
+## F71030: Cucumber Integration Testing
+  The steps in AD_Archive_StepDef read the PDF metasfresh actually rendered and archived for a record.
+  This feature is their self-test: it prints an ordinary sales order and exercises every one of them,
+  so the steps cannot silently rot, and so a reader has one worked example of each.
+  It asserts nothing about any particular feature's content - only about the steps themselves.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    # render the real jasper report; the mock report service would archive a placeholder PDF instead
+    And set sys config boolean value false for sys config de.metas.report.jasper.IsMockReportService
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+    And set sys config boolean value false for sys config de.metas.payment.esr.Enabled
+    And set sys config boolean value false for sys config de.metas.fresh.ordercheckup.FailIfOrderWarehouseHasNoPlant
+    And metasfresh has date and time 2025-04-01T13:30:13+01:00[Europe/Berlin]
+    # another feature in this suite flips this flag; pin it so this scenario cannot depend on suite order.
+    # It must stay 'false': the steps read the archive back out of the database.
+    And update AD_Client
+      | Identifier | StoreArchiveOnFileSystem |
+      | 1000000    | false                    |
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID |
+      | wh             |
+    # Value differs from Name on purpose: the article row shows the Name, the line below it the Value,
+    # which gives the positional steps two distinct anchors per position. Keep the Names short - the
+    # product name stretches with overflow, and a wrapping Name would change the line counts below.
+    And metasfresh contains M_Products:
+      | Identifier | Value    | Name      |
+      | productA   | ALPHA-NR | AlphaItem |
+      | productB   | BETA-NR  | BetaItem  |
+      | productC   | GAMMA-NR | GammaItem |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl         | ps                 | CH           | CHF           | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv        | pl             |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | ppA        | plv                    | productA     | 10.0     | PCE      |
+      | ppB        | plv                    | productB     | 10.0     | PCE      |
+      | ppC        | plv                    | productC     | 10.0     | PCE      |
+    # dev-note: pin the payment term, so the order does not depend on the branch's default
+    And metasfresh contains C_PaymentTerm
+      | Identifier          |
+      | customerPaymentTerm |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID | C_PaymentTerm_ID    |
+      | customer   | N        | Y          | ps                 | customerPaymentTerm |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | C_BPartner_ID | C_Country_ID | IsShipToDefault | IsBillToDefault |
+      | customerLocation | customer      | CH           | Y               | Y               |
+    And metasfresh contains C_Tax
+      | Identifier | C_TaxCategory_ID.InternalName | Name      | ValidFrom  | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
+      | de_ch_tax  | Normal                        | de_ch_tax | 2021-04-02 | 2.5  | DE                       | CH                        |
+      | ch_ch_tax  | Normal                        | ch_ch_tax | 2021-04-02 | 2.5  | CH                       | CH                        |
+
+  @Id:S71030_10
+  Scenario: Every archived-PDF assertion step, exercised on an order confirmation
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | M_PricingSystem_ID |
+      | order      | true    | customer      | 2025-04-01  | wh             | ps                 |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | line10     | order      | productA     | 1          |
+      | line20     | order      | productB     | 1          |
+      | line30     | order      | productC     | 1          |
+    When the order identified by order is completed
+    And The jasper process is run
+      | Value            | Record_ID |
+      | Auftrag (Jasper) | order     |
+
+    # the document was archived at all
+    Then an AD_Archive exists for the record identified by "order"
+
+    # presence and absence of text
+    And the PDF archived for the record identified by "order" contains text "AlphaItem"
+    And the PDF archived for the record identified by "order" does not contain text "Sortimentsware"
+
+    # WHERE the text sits. Each position prints its article row and then its product number on the next
+    # line, so position 20's article row follows position 10's product number with nothing in between.
+    And in the PDF archived for the record identified by "order", exactly 0 lines appear between text "ALPHA-NR" and text "BetaItem"
+
+    # ... and from position 10's name to position 30's name there are at least the three lines of
+    # positions 10 and 20 that sit between them
+    And in the PDF archived for the record identified by "order", at least 2 lines appear between text "AlphaItem" and text "GammaItem"
+
+    # geometry: one position occupies the same vertical space as the next, since all three are alike
+    And in the PDF archived for the record identified by "order", the vertical distance from text "AlphaItem" to text "BetaItem" equals the distance from text "BetaItem" to text "GammaItem"
+
+    # nothing is printed on top of anything else, anywhere in the document
+    And the PDF archived for the record identified by "order" has no overlapping text


### PR DESCRIPTION
Feature: **F71030 — Cucumber Integration Testing**

## What

Seven cucumber steps that assert against the **actual PDF** metasfresh rendered and archived for a
document, a scenario that exercises all of them, and the documentation.

```gherkin
Then an AD_Archive exists for the record identified by "order"
Then the PDF archived for the record identified by "order" contains text "Bitte gekuehlt liefern"
Then the PDF archived for the record identified by "order" does not contain text "Zwischenpalette"
Then in the PDF archived for the record identified by "order", exactly 0 lines appear between text "ALPHA-NR" and text "BetaItem"
Then in the PDF archived for the record identified by "order", at least 2 lines appear between text "Diese Position" and text "BetaItem"
Then in the PDF archived for the record identified by "order", the vertical distance from text "A" to text "B" equals the distance from text "C" to text "D"
Then the PDF archived for the record identified by "order" has no overlapping text
```

They resolve the record through the usual step-def identifier mechanism, so they work for **any** record
that archives a PDF — sales order, shipment, invoice, receipt.

## Why

Until now a scenario could assert what a report's SQL returned, but not what the document actually looks
like. For anything whose requirement is about the printed result — a text block that must appear
**above** its own article row, a heading that introduces a group, a block that must take no vertical
space when empty — the SQL is not the thing under test.

`contains text` alone is a weak assertion: it passes when the text lands in the wrong block, above the
wrong article, or on a different page. Counting **rendered visual lines** between two anchors, comparing
one vertical gap against another, and checking that nothing is printed on top of anything else, is what
makes *layout* testable.

## The overlap check works per glyph, and that is load-bearing

Two coarser groupings were implemented first and both were falsified against a real order confirmation:

- **Per content-stream run** (no `setSortByPosition`): a run in these documents spans several visually
  separate columns — one came back as `10,00AlphaItem`. Boxes built from those span the whole row and
  collide with everything on it, so every row reported collisions a reader cannot see.
- **Per word** (`setSortByPosition(true)`, which is what makes `writeString` fire once per word): the
  same sorting that produces words also **fuses colliding glyphs into one token**. With a report element
  deliberately moved on top of the product name, the two texts arrived as the single word
  `ASltpkhaItem` — nothing left to compare, and the real collision was invisible.

Per glyph neither happens: characters inside a word abut (the advance width puts the next glyph exactly
where the previous ends, so horizontal overlap is ~0 and stays under the tolerance), while two texts
printed on top of each other overlap by most of a glyph width.

The tolerance is in PDF user-space **points**. The frontend `PdfLayoutValidator` documents its
equivalent as "pixels", which is wrong; this one says points.

## Verification

Both directions, against a local stack:

- **Clean document** — a three-position order confirmation: 775 glyphs examined, **0 overlaps** at the
  default tolerance, all seven steps green.
- **Collided document** — one report element moved on top of another: the **overlap step itself** fails
  (`✘ … has no overlapping text`).

The second is the one that matters. Without it this would be a detector that looks right and reports
nothing, which is how the two earlier implementations passed while being blind.

## The PDFs land in the Allure report

Every asserted PDF is attached to its scenario, deduplicated per archive, on pass as well as failure —
so a reviewer opens the document instead of reading a description of it. `Readme.md` explains where
Allure nests them (under the step that read the PDF, which is not obvious) and how to pull direct links
out of a published report.

## Notes for the reviewer

- **PDFBox is pinned to 2.0.27, deliberately.** `PDDocument.load(byte[])` exists in PDFBox 2 but not in
  3; this module skips the enforcer, so an unpinned transitive bump would break these steps with nothing
  else catching it. The reason is recorded next to the dependency.
- The new scenario is tagged for one CI executor and asserts nothing about any particular feature's
  content — only about the steps themselves.
- `Readme.md` gained a section covering the steps, the two sysconfigs a scenario needs so a *real* report
  is rendered rather than the mock placeholder, why the overlap check is per glyph, and the two pitfalls
  that cost the most time: a multi-word needle stops matching once the layout wraps between its words,
  and a blank line emits no glyphs so only the vertical-distance step can see it.

## Test plan

- [ ] CI compiles the module and runs the new scenario (a local compile of this branch was not possible
      in the authoring workspace: its `.m2-local` is populated for a different branch and lacks
      `de.metas.einvoice.base:10.0.0`; the scenario itself was run green against a local stack from a
      worktree that has those artifacts).
