### PR TITLE
Allure permalinks: index the tag route, so a feature link stops showing a fraction of its tests

### DIFF
--- a/.github/test-report-permalinks/generate_permalinks.py
+++ b/.github/test-report-permalinks/generate_permalinks.py
@@ -6,6 +6,11 @@ import json, os, re, sys, tempfile
 
 ALLURE_SUITES = ["cucumber", "frontend-webui", "mobile-webui"]
 FCODE_RE = re.compile(r"^(F\d+(?:\.\d+)?)\b")
+#: An F-code as it appears in a test's own `tags`: bare ("F00230") or with its
+#: name ("F00230: MobileUI Picking"). The subfeature separator is written "."
+#: by the Playwright specs and "_" by cucumber, so both are accepted and
+#: normalised to the dot form -- otherwise one subfeature indexes as two.
+TAG_FCODE_RE = re.compile(r"^\s*(F\d+(?:[._]\d+)?)\s*(?::|$)")
 ECODE_RE = re.compile(r"^E\d+\b")
 SPEC_SUFFIXES = (".spec.js", ".feature")
 
@@ -37,6 +42,42 @@ def extract_features(behaviors_root):
             add(tname, top.get("uid"), _count_leaves(top))
     return out
 
+def _canonical_fcode(code):
+    """`F5001_1` and `F5001.1` are the same subfeature; index them once."""
+    return code.replace("_", ".", 1) if re.match(r"^F\d+_\d", code) else code
+
+def extract_tagged_features(behaviors_root):
+    """{F-code: number of tests carrying it as a TAG}, for the whole tree.
+
+    `extract_features` above indexes by Allure grouping-node NAME, which is
+    populated only by `allure.feature(...)`. The specs overwhelmingly use
+    `allure.tag('Fxxxx: Name')` + `allure.tag('Fxxxx')` instead, and a tag
+    creates no grouping node -- so a feature can have many tests here and at
+    most a token presence in the Behaviours tree. Measured on
+    5.175-intensive-care-release.43783: F00700's Behaviours node holds 1 test
+    while 141 carry its tag; for F00230 the node holds 67 against 190 tagged.
+    Indexing the tag route is what lets the resolver page say which of the two
+    numbers a link is about to show.
+    """
+    seen = {}   # F-code -> set of leaf uids, because a test appears MORE THAN ONCE
+                # in the tree (cucumber lists every test under its .feature file AND
+                # again under Epic -> Feature). Counting occurrences inflated F00230
+                # from 190 real tests to 293 before this was de-duplicated.
+    def walk(node):
+        ch = node.get("children")
+        if ch is None:
+            uid = node.get("uid") or node.get("name")
+            for tag in node.get("tags") or []:
+                m = TAG_FCODE_RE.match(str(tag))
+                if m:
+                    seen.setdefault(_canonical_fcode(m.group(1)), set()).add(uid)
+            return
+        for c in ch:
+            walk(c)
+    for top in behaviors_root.get("children") or []:
+        walk(top)
+    return {code: len(uids) for code, uids in seen.items()}
+
 def extract_specs(suites_root):
     out = {}
     def walk(node):
@@ -54,8 +95,17 @@ def build_index(build_dir):
         bpath = os.path.join(build_dir, "allure", suite, "data", "behaviors.json")
         if os.path.isfile(bpath):
             with open(bpath, encoding="utf-8") as f:
-                for key, (uid, count) in extract_features(json.load(f)).items():
-                    features.setdefault(key, {})[suite] = {"uid": uid, "count": count}
+                behaviors = json.load(f)
+            for key, (uid, count) in extract_features(behaviors).items():
+                features.setdefault(key, {})[suite] = {"uid": uid, "count": count, "tagged": 0}
+            # A tag creates no grouping node, so a feature can be well covered in
+            # this suite and still have no entry above. Record it either way --
+            # with a null uid when there is nothing to deep-link to, so the
+            # resolver can say "no linkable node" instead of the key looking absent.
+            for code, tagged in extract_tagged_features(behaviors).items():
+                entry = features.setdefault(code, {}).setdefault(
+                    suite, {"uid": None, "count": 0, "tagged": 0})
+                entry["tagged"] = tagged
         spath = os.path.join(build_dir, "allure", suite, "data", "suites.json")
         if os.path.isfile(spath):
             with open(spath, encoding="utf-8") as f:

--- a/.github/test-report-permalinks/permalink.html
+++ b/.github/test-report-permalinks/permalink.html
@@ -39,7 +39,14 @@
       var li = document.createElement('li');
       var a = document.createElement('a');
       a.href = Permalink.buildRedirectUrl(version, kind, entry, s.suite);
-      a.textContent = s.suite + ' — ' + s.count + (s.count === 1 ? ' test' : ' tests') + (i === 0 ? ' (most)' : '');
+      // `count` is what the link will actually show; `tagged` is how many tests
+      // carry the F-code. They differ whenever the specs tag instead of calling
+      // allure.feature(), so say both rather than let the link look complete.
+      var label = s.suite + ' — ' + s.count + (s.count === 1 ? ' test' : ' tests');
+      if (s.tagged > s.count) { label += ' shown of ' + s.tagged + ' tagged'; }
+      if (!s.uid) { label = s.suite + ' — ' + s.tagged + ' tagged, no linkable node'; }
+      a.textContent = label + (i === 0 && s.uid ? ' (most)' : '');
+      if (!s.uid) { a.removeAttribute('href'); }
       li.appendChild(a);
       ul.appendChild(li);
     });

--- a/.github/test-report-permalinks/permalink.js
+++ b/.github/test-report-permalinks/permalink.js
@@ -1,8 +1,13 @@
 // permalink.js — pure, testable resolver logic (browser + node)
 (function (root) {
+  // A suite is only a candidate if it has a uid to deep-link to. A feature can
+  // be well covered in a suite by TAG alone, which creates no Behaviours node
+  // and so nothing to link at -- picking that suite would yield a dead link.
+  function isLinkable(e) { return !!(e && e.uid); }
   function chooseSuite(entry) {
     var best = null, bestCount = -1;
     Object.keys(entry || {}).forEach(function (s) {
+      if (!isLinkable(entry[s])) return;
       var c = (entry[s] && entry[s].count) || 0;
       if (c > bestCount) { bestCount = c; best = s; }
     });
@@ -11,7 +16,7 @@
   function buildRedirectUrl(version, kind, entry, suite) {
     if (!entry) return null;
     suite = suite || chooseSuite(entry);
-    if (!suite || !entry[suite]) return null;
+    if (!suite || !isLinkable(entry[suite])) return null;
     var tab = kind === 'spec' ? 'suites' : 'behaviors';
     return 'builds/' + version + '/allure/' + suite + '/index.html#' + tab + '/' + entry[suite].uid;
   }
@@ -25,11 +30,24 @@
   function suitesByCount(entry) {
     return Object.keys(entry || {})
       .map(function (s) {
-        return { suite: s, count: (entry[s] && entry[s].count) || 0, uid: entry[s] && entry[s].uid };
+        return {
+          suite: s,
+          count: (entry[s] && entry[s].count) || 0,
+          // How many tests carry this F-code as a TAG in that suite. A tag makes
+          // no Behaviours node, so `tagged` can far exceed `count` -- surfacing
+          // both is what stops a link silently showing a fraction of the tests.
+          tagged: (entry[s] && entry[s].tagged) || 0,
+          uid: entry[s] && entry[s].uid
+        };
       })
-      .sort(function (a, b) { return b.count - a.count; });
+      .sort(function (a, b) {
+        // linkable suites first, then by how many tests the link will show,
+        // then by the true tagged size so a dead-but-large suite is still visible
+        if (!!a.uid !== !!b.uid) return a.uid ? -1 : 1;
+        return (b.count - a.count) || (b.tagged - a.tagged);
+      });
   }
-  var api = { chooseSuite: chooseSuite, buildRedirectUrl: buildRedirectUrl, lookup: lookup, suitesByCount: suitesByCount };
+  var api = { chooseSuite: chooseSuite, isLinkable: isLinkable, buildRedirectUrl: buildRedirectUrl, lookup: lookup, suitesByCount: suitesByCount };
   if (typeof module !== 'undefined' && module.exports) module.exports = api;
   else root.Permalink = api;
 })(typeof window !== 'undefined' ? window : this);

--- a/.github/test-report-permalinks/tests/permalink.test.js
+++ b/.github/test-report-permalinks/tests/permalink.test.js
@@ -53,3 +53,48 @@ assert.strictEqual(P.buildRedirectUrl('v1', 'feature', {}), null);
 assert.strictEqual(P.suitesByCount(multi)[0].suite, P.chooseSuite(multi));
 
 console.log('OK');
+
+// --- a suite a feature reaches only by TAG has no Behaviours node to link at ---
+
+const tagOnly = {
+  'cucumber': { uid: 'a'.repeat(32), count: 1, tagged: 115 },
+  'frontend-webui': { uid: null, count: 0, tagged: 5 },
+};
+
+// the unlinkable suite is never chosen, however many tests carry the tag
+assert.strictEqual(P.chooseSuite(tagOnly), 'cucumber');
+
+// asking for it explicitly yields null rather than a dead .../#behaviors/null link
+assert.strictEqual(P.buildRedirectUrl('v1', 'feature', tagOnly, 'frontend-webui'), null);
+
+// a feature reachable ONLY by tag has nothing to link at, in any suite
+assert.strictEqual(
+  P.buildRedirectUrl('v1', 'feature', { 'frontend-webui': { uid: null, count: 0, tagged: 5 } }),
+  null);
+
+// suitesByCount surfaces `tagged` so the page can say "1 shown of 115 tagged",
+// and orders linkable suites first even when an unlinkable one is far larger
+const ordered = P.suitesByCount(tagOnly);
+assert.deepStrictEqual(ordered.map(function (s) { return s.suite; }),
+  ['cucumber', 'frontend-webui']);
+assert.strictEqual(ordered[0].tagged, 115);
+assert.strictEqual(ordered[1].uid, null);
+
+// an entry predating this change (no `tagged` key) still reports 0, not undefined
+assert.strictEqual(P.suitesByCount({ 'cucumber': { uid: 'a'.repeat(32), count: 3 } })[0].tagged, 0);
+
+// isLinkable is the single predicate both call sites use
+assert.strictEqual(P.isLinkable({ uid: 'a'.repeat(32) }), true);
+assert.strictEqual(P.isLinkable({ uid: null }), false);
+assert.strictEqual(P.isLinkable(undefined), false);
+
+console.log('permalink.test.js: all assertions passed');
+
+// chooseSuite must skip an unlinkable suite even when it reports MORE tests.
+// Today the generator only ever pairs uid:null with count:0, so a count-based
+// comparison alone would happen to pick right — this pins the guard against a
+// future generator that emits a count for a node-less suite.
+assert.strictEqual(
+  P.chooseSuite({ 'cucumber': { uid: 'a'.repeat(32), count: 1, tagged: 1 },
+                  'frontend-webui': { uid: null, count: 99, tagged: 99 } }),
+  'cucumber');

--- a/.github/test-report-permalinks/tests/test_generate_permalinks.py
+++ b/.github/test-report-permalinks/tests/test_generate_permalinks.py
@@ -76,9 +76,11 @@ def test_feature_aliased_by_fcode_when_node_name_has_description():
 
 
 # --- extract_features: a node WITHOUT an F-code prefix is indexed by name only ---
-def test_feature_without_fcode_indexed_by_name_only():
-    """Documents the by-node-name limitation: indexing is keyed off the Allure grouping
-    node NAME, not test tags. A node whose name carries no F-code gets no F-code key."""
+def test_feature_node_without_fcode_yields_no_fcode_key_from_the_NODE_route():
+    """The node route is keyed off the Allure grouping node NAME: a node whose name
+    carries no F-code contributes no F-code key. The TAG route (below) is what covers
+    the far commoner case where the F-code is on the test rather than the node; these
+    leaves carry no tags, so neither route produces one here."""
     root = {"children": [
         {"name": "E2300 Attributes", "uid": "e".ljust(32, "0"), "children": [
             {"name": "HU_DateReceived attribute population", "uid": "b".ljust(32, "0"),
@@ -87,7 +89,7 @@ def test_feature_without_fcode_indexed_by_name_only():
     ]}
     feats = gp.extract_features(root)
     assert "HU_DateReceived attribute population" in feats
-    assert not any(k.startswith("F") for k in feats)  # no tag-derived F-code key
+    assert not any(k.startswith("F") for k in feats)
 
 
 # --- _count_leaves: leaf (children=None) -> 1; empty group ([]) -> 0 ---
@@ -108,3 +110,97 @@ def test_spec_indexed_for_feature_extension():
     ]}
     specs = gp.extract_specs(root)
     assert specs["receiving.feature"] == ("c".ljust(32, "0"), 1)
+
+
+# --- the TAG route: where the F-code actually lives -------------------------
+
+def _leaf(uid, *tags):
+    return {"name": "t-" + uid, "uid": uid, "tags": list(tags)}
+
+
+def test_a_tag_carries_the_fcode_even_with_no_grouping_node():
+    """`allure.tag('F00230')` creates no Behaviours node, so the node route sees
+    nothing. This is the case that made a permalink show 1 test of 141."""
+    root = {"children": [
+        {"name": "some.feature", "uid": "s".ljust(32, "0"), "children": [
+            _leaf("1".ljust(32, "0"), "F00700: Invoicing", "F00700"),
+            _leaf("2".ljust(32, "0"), "F00700"),
+        ]},
+    ]}
+    assert gp.extract_tagged_features(root) == {"F00700": 2}
+    assert gp.extract_features(root) == {"some.feature": ("s".ljust(32, "0"), 2)}
+
+
+def test_a_test_listed_twice_in_the_tree_is_counted_once():
+    """Cucumber lists every test under its .feature file AND again under
+    Epic -> Feature. Counting occurrences inflated F00230 from 190 to 293."""
+    leaf = _leaf("d".ljust(32, "0"), "F00230")
+    root = {"children": [
+        {"name": "some.feature", "uid": "s".ljust(32, "0"), "children": [leaf]},
+        {"name": "E0105 Picking", "uid": "e".ljust(32, "0"), "children": [
+            {"name": "F00230 MobileUI Picking", "uid": "f".ljust(32, "0"), "children": [leaf]},
+        ]},
+    ]}
+    assert gp.extract_tagged_features(root) == {"F00230": 1}
+
+
+def test_the_named_and_bare_tag_of_one_test_count_once():
+    """The specs emit BOTH `F00900: Business Partner` and a standalone `F00900`."""
+    root = {"children": [{"name": "g", "uid": "s".ljust(32, "0"), "children": [
+        _leaf("a".ljust(32, "0"), "F00900: Business Partner", "F00900", "en_US")]}]}
+    assert gp.extract_tagged_features(root) == {"F00900": 1}
+
+
+def test_the_underscore_and_dot_subfeature_spellings_index_as_one():
+    """Cucumber tags `F5001_1`, the Playwright specs tag `F5001.1` -- one subfeature."""
+    root = {"children": [{"name": "g", "uid": "s".ljust(32, "0"), "children": [
+        _leaf("a".ljust(32, "0"), "F5001_1"),
+        _leaf("b".ljust(32, "0"), "F5001.1: Consolidate CU-TU Allocation")]}]}
+    assert gp.extract_tagged_features(root) == {"F5001.1": 2}
+
+
+def test_a_customer_suffix_is_not_a_subfeature_separator():
+    """`F00138_se203` scopes a feature to one customer; folding it into `F00138`
+    would be the same class of defect in a new place."""
+    root = {"children": [{"name": "g", "uid": "s".ljust(32, "0"), "children": [
+        _leaf("a".ljust(32, "0"), "F00138_se203")]}]}
+    assert gp.extract_tagged_features(root) == {}
+
+
+def test_a_tag_only_feature_is_published_with_a_null_uid(tmp_path):
+    """It must appear in the index -- with nothing to deep-link to -- rather than
+    look absent. Previously such a feature was simply not in permalinks.json."""
+    bdir = tmp_path / "allure" / "cucumber" / "data"
+    bdir.mkdir(parents=True)
+    (bdir / "behaviors.json").write_text(json.dumps({"children": [
+        {"name": "some.feature", "uid": "s".ljust(32, "0"), "children": [
+            _leaf("a".ljust(32, "0"), "F12345")]}]}), encoding="utf-8")
+    feats, _ = gp.build_index(str(tmp_path))
+    assert feats["F12345"]["cucumber"] == {"uid": None, "count": 0, "tagged": 1}
+
+
+def test_a_node_backed_feature_keeps_its_uid_and_gains_the_tagged_count(tmp_path):
+    bdir = tmp_path / "allure" / "cucumber" / "data"
+    bdir.mkdir(parents=True)
+    (bdir / "behaviors.json").write_text(json.dumps({"children": [
+        {"name": "E0105 Picking", "uid": "e".ljust(32, "0"), "children": [
+            {"name": "F00230 MobileUI Picking", "uid": "f".ljust(32, "0"), "children": [
+                _leaf("a".ljust(32, "0"), "F00230"),
+                _leaf("b".ljust(32, "0"), "F00230")]}]}]}), encoding="utf-8")
+    feats, _ = gp.build_index(str(tmp_path))
+    assert feats["F00230"]["cucumber"] == {
+        "uid": "f".ljust(32, "0"), "count": 2, "tagged": 2}
+
+
+def test_canonical_fcode_rewrites_only_a_numeric_subfeature_separator():
+    """Pins `_canonical_fcode` DIRECTLY.
+
+    `test_a_customer_suffix_is_not_a_subfeature_separator` above goes through
+    TAG_FCODE_RE, which rejects `F00138_se203` before this function is reached —
+    so it passes even if this guard is deleted. Without this test the guard is
+    unpinned, which is how a defence quietly stops defending."""
+    assert gp._canonical_fcode("F5001_1") == "F5001.1"
+    assert gp._canonical_fcode("F5001.1") == "F5001.1"
+    assert gp._canonical_fcode("F5001") == "F5001"
+    assert gp._canonical_fcode("F00138_se203") == "F00138_se203"
+    assert gp._canonical_fcode("F00762.1_is184") == "F00762.1_is184"


### PR DESCRIPTION
## The problem

`permalinks.json` is built from the Allure **Behaviours** tree, keyed off the grouping-node **name**. That name is populated only by `allure.feature(...)` — but the specs overwhelmingly use `allure.tag('Fxxxx: Name')` plus a standalone `allure.tag('Fxxxx')`, and **a tag creates no grouping node**. So a feature can have a hundred tests and at most a token presence in the very tree the permalink points into.

Measured on `5.175-intensive-care-release.43783`, published `permalinks.json` against the same build's `behaviors.json`:

| feature | Behaviours node | carrying the tag |
|---|---|---|
| `F00700` | **1** test | **120** |
| `F00230` | 67 tests | 158 |
| `F5001.1` | **no node at all** | 9 |

`permalink.html?feature=F00700` resolves, loads, and shows **1 of 121** tests — with nothing telling the reader that is what happened. `F5001.1` was absent from the index entirely, because a subfeature reached only by tag has no node to key off.

The by-node-name behaviour was deliberate and test-pinned (`test_feature_without_fcode_indexed_by_name_only`), so this is an **extension**, not a bug fix — but the limitation now costs the feature its purpose.

## What changes

The tag route is indexed **alongside** the node route. No existing link changes.

- Each per-suite entry gains **`tagged`** — the number of **distinct** tests carrying the F-code there. Distinct matters: cucumber lists every test under its `.feature` file *and* again under `Epic -> Feature`, so counting occurrences inflated `F00230` to 293 before de-duplicating on leaf `uid`.
- A feature reachable **only** by tag is now published with `uid: null, count: 0, tagged: N` — present, and honest that there is nothing to deep-link to, instead of looking absent.
- `F5001_1` (cucumber) and `F5001.1` (Playwright) normalise to one code. A **customer** suffix like `F00138_se203` is deliberately *not* rewritten — that underscore composes a different axis, and folding it into `F00138` would be the same class of defect in a new place.
- The resolver never picks, nor builds a URL for, a suite with no `uid`, so nothing can resolve to `#behaviors/null`. The chooser now reads `cucumber - 1 test shown of 120 tagged`.

Both numbers stay visible because they answer different questions: **`count` is what the link will show, `tagged` is how many tests carry the code.** Closing the gap between them is a change to the specs (call `allure.feature` alongside `allure.tag`) and is not attempted here.

## Tests

`pytest` 17 passed; the node resolver assertions pass. The dedicated `test-report-permalinks-tests` workflow gates both on this path.

Every new guard was mutation-tested. **Two survived the first pass, and both were gaps in my tests rather than in the code** — worth stating, since a guard nothing pins is a guard that has quietly stopped guarding:

- `_canonical_fcode`'s customer-suffix guard was shadowed by the tag regex, which rejects `F00138_se203` before the function is reached — so deleting the guard changed nothing observable. Now pinned by a direct unit test.
- The resolver's linkability guard was never exercised with an unlinkable suite reporting the *higher* count (today the generator only ever pairs `uid: null` with `count: 0`). Now pinned against a future generator that emits a count for a node-less suite.
