### PR TITLE
test-reports: per-branch feature test-coverage page

### DIFF
--- a/.github/test-report-permalinks/coverage.html
+++ b/.github/test-report-permalinks/coverage.html
@@ -89,11 +89,15 @@ branch's newest report.</p>
       var state;
       if (v.state === 'absent') {
         state = 'absent — ran ' + v.ran + ' test(s) but publishes no Allure report';
+      } else if (v.state === 'unknown' && v.reason) {
+        // Reconciliation failed: the suite RAN and was parsed, but the two counts
+        // disagreed, so its data was deliberately dropped. Every feature it covers
+        // is under-counted below, and saying only "unknown" would hide that.
+        state = 'unknown — ' + v.reason + ', so this suite adds nothing to the counts below';
       } else if (v.state === 'unknown') {
-        // A dropped suite contributes NO features, so every feature it covers is
-        // under-counted in the tables below. Saying only "unknown" would hide that.
-        state = 'unknown — ' + (v.reason || 'could not be read') +
-                ', so this suite adds nothing to the counts below';
+        // The other producer: no Allure report AND no reported total. Nothing was
+        // verified about this suite, which is a different thing from dropping it.
+        state = 'unknown — not run on this build, or its report could not be read';
       } else {
         state = v.state;
       }
@@ -101,9 +105,7 @@ branch's newest report.</p>
                result: state,
                suites: [v.labelled === null || v.labelled === undefined ? '' : v.labelled + ' labelled'] };
     });
-    var dropped = Object.keys(cov.suites || {}).filter(function (k) {
-      return cov.suites[k].state === 'unknown' && cov.suites[k].ran;
-    });
+    var dropped = Coverage.droppedSuites(cov);
     var h2 = document.createElement('h2'); h2.textContent = 'Suites'; out.appendChild(h2);
     var st = document.createElement('table');
     var shead = document.createElement('tr');

--- a/.github/test-report-permalinks/coverage.html
+++ b/.github/test-report-permalinks/coverage.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Automated test coverage by feature</title>
+<script src="coverage.js"></script>
+<style>
+ body{font:14px/1.5 system-ui,sans-serif;margin:2rem auto;max-width:70rem;padding:0 1rem;color:#222}
+ h1{font-size:1.4rem} h2{font-size:1.1rem;margin-top:2rem}
+ table{border-collapse:collapse;width:100%;margin:.5rem 0 1.5rem}
+ th,td{border-bottom:1px solid #ddd;padding:.3rem .5rem;text-align:left}
+ td.n,th.n{text-align:right}
+ .bad{color:#a00;font-weight:600}
+ .muted{color:#666} code{background:#f4f4f4;padding:0 .2rem}
+ form{margin:1rem 0} input{padding:.3rem;font:inherit}
+</style>
+</head>
+<body>
+<h1>Automated test coverage by feature</h1>
+<p class="muted">Which automated tests cover a feature on a given branch, and did they pass —
+read from the Allure reports this host already publishes. Every feature id links into that
+branch's newest report.</p>
+
+<form id="pick" onsubmit="return false">
+  <label>Branch: <input id="branch" size="42" placeholder="intensive_care_hotfix"></label>
+  <button id="go">Show</button>
+  <span class="muted">— underscores or dashes, either works</span>
+</form>
+
+<div id="msg" class="muted"></div>
+<div id="out"></div>
+
+<script>
+(function () {
+  var msg = document.getElementById('msg'), out = document.getElementById('out');
+  var input = document.getElementById('branch');
+
+  function text(el, s) { el.textContent = s; }
+  function cell(row, value, cls) {
+    var td = document.createElement('td');
+    if (cls) td.className = cls;
+    td.textContent = value;
+    row.appendChild(td);
+    return td;
+  }
+  function table(parent, headers, rows, branch) {
+    var t = document.createElement('table'), thead = document.createElement('tr');
+    headers.forEach(function (h) {
+      var th = document.createElement('th');
+      if (h.n) th.className = 'n';
+      th.textContent = h.label; thead.appendChild(th);
+    });
+    t.appendChild(thead);
+    rows.forEach(function (r) {
+      var tr = document.createElement('tr');
+      var td = document.createElement('td');
+      var a = document.createElement('a');
+      // href is built from an encodeURIComponent'd branch+feature; the label is
+      // set via textContent, so nothing from the data is ever parsed as HTML.
+      a.href = Coverage.permalinkFor(branch, r.feature);
+      a.textContent = r.feature;
+      td.appendChild(a); tr.appendChild(td);
+      cell(tr, r.tests, 'n');
+      cell(tr, r.result, r.result === 'passed' ? '' : 'bad');
+      cell(tr, r.suites.join(', '));
+      t.appendChild(tr);
+    });
+    parent.appendChild(t);
+  }
+
+  function render(branch, data) {
+    out.innerHTML = '';
+    var cov = data && data.coverage;
+    if (!cov) {
+      text(msg, 'This branch’s index predates the coverage data — it will appear after its next build.');
+      return;
+    }
+    var rows = Coverage.featureRows(cov), s = Coverage.summarise(rows, cov);
+
+    var p = document.createElement('p');
+    p.textContent = 'Build ' + (data.version || 'unknown') + ' — ' + s.tests +
+      ' test(s) in the suites that carry feature labels, ' + s.labelled + ' carrying an F-id. ' +
+      s.features + ' feature(s) have at least one test: ' + s.fullyPassing +
+      ' fully passing, ' + s.notPassing + ' not.';
+    out.appendChild(p);
+
+    var suiteRows = Object.keys(cov.suites || {}).map(function (k) {
+      var v = cov.suites[k];
+      return { feature: k, tests: v.tests === null || v.tests === undefined ? '' : v.tests,
+               result: v.state === 'absent'
+                 ? 'absent — ran ' + v.ran + ' test(s) but publishes no Allure report'
+                 : v.state,
+               suites: [v.labelled === null || v.labelled === undefined ? '' : v.labelled + ' labelled'] };
+    });
+    var h2 = document.createElement('h2'); h2.textContent = 'Suites'; out.appendChild(h2);
+    var st = document.createElement('table');
+    suiteRows.forEach(function (r) {
+      var tr = document.createElement('tr');
+      cell(tr, r.feature); cell(tr, r.tests, 'n'); cell(tr, r.result); cell(tr, r.suites[0]);
+      st.appendChild(tr);
+    });
+    out.appendChild(st);
+
+    if (s.notPassing) {
+      var h = document.createElement('h2');
+      h.textContent = 'Not fully passing (' + s.notPassing + ')';
+      out.appendChild(h);
+      var note = document.createElement('p'); note.className = 'muted';
+      note.textContent = 'A feature that HAS automated coverage whose coverage is red — the rows worth acting on.';
+      out.appendChild(note);
+      table(out, [{label:'feature'},{label:'tests',n:true},{label:'result'},{label:'suites'}],
+            s.notPassingRows, branch);
+    }
+
+    var h3 = document.createElement('h2');
+    h3.textContent = 'Every feature with tests (' + s.features + ')';
+    out.appendChild(h3);
+    table(out, [{label:'feature'},{label:'tests',n:true},{label:'result'},{label:'suites'}],
+          rows, branch);
+
+    var limits = document.createElement('p'); limits.className = 'muted';
+    limits.textContent = '“No test” here always means no cucumber and no Playwright test — ' +
+      'the JUnit suites publish no Allure report, so nothing joins them to a feature. ' +
+      'A link shows the tests Allure grouped under the feature, which for a spec annotated ' +
+      'with allure.tag rather than allure.feature is fewer than the count beside it.';
+    out.appendChild(limits);
+  }
+
+  function load(branch) {
+    branch = Coverage.normaliseBranch(branch);
+    if (!branch) { text(msg, 'Enter a branch name.'); out.innerHTML = ''; return; }
+    text(msg, 'Loading ' + branch + ' …');
+    history.replaceState(null, '', '?branch=' + encodeURIComponent(branch));
+    fetch('branches/' + encodeURIComponent(branch) + '/permalinks.json', { cache: 'no-store' })
+      .then(function (r) {
+        if (!r.ok) throw new Error('no published index for this branch (HTTP ' + r.status + ')');
+        return r.json();
+      })
+      .then(function (d) { text(msg, ''); render(branch, d); })
+      .catch(function (e) { out.innerHTML = ''; text(msg, 'Could not load ' + branch + ': ' + e.message); });
+  }
+
+  var q = new URLSearchParams(location.search).get('branch');
+  if (q) { input.value = q; load(q); }
+  else { text(msg, 'Pick a branch. Any branch this host has built works — base branches and feature branches alike.'); }
+  document.getElementById('go').addEventListener('click', function () { load(input.value); });
+  input.addEventListener('keydown', function (e) { if (e.key === 'Enter') load(input.value); });
+})();
+</script>
+</body>
+</html>

--- a/.github/test-report-permalinks/coverage.html
+++ b/.github/test-report-permalinks/coverage.html
@@ -86,11 +86,23 @@ branch's newest report.</p>
 
     var suiteRows = Object.keys(cov.suites || {}).map(function (k) {
       var v = cov.suites[k];
+      var state;
+      if (v.state === 'absent') {
+        state = 'absent — ran ' + v.ran + ' test(s) but publishes no Allure report';
+      } else if (v.state === 'unknown') {
+        // A dropped suite contributes NO features, so every feature it covers is
+        // under-counted in the tables below. Saying only "unknown" would hide that.
+        state = 'unknown — ' + (v.reason || 'could not be read') +
+                ', so this suite adds nothing to the counts below';
+      } else {
+        state = v.state;
+      }
       return { feature: k, tests: v.tests === null || v.tests === undefined ? '' : v.tests,
-               result: v.state === 'absent'
-                 ? 'absent — ran ' + v.ran + ' test(s) but publishes no Allure report'
-                 : v.state,
+               result: state,
                suites: [v.labelled === null || v.labelled === undefined ? '' : v.labelled + ' labelled'] };
+    });
+    var dropped = Object.keys(cov.suites || {}).filter(function (k) {
+      return cov.suites[k].state === 'unknown' && cov.suites[k].ran;
     });
     var h2 = document.createElement('h2'); h2.textContent = 'Suites'; out.appendChild(h2);
     var st = document.createElement('table');
@@ -108,6 +120,15 @@ branch's newest report.</p>
       st.appendChild(tr);
     });
     out.appendChild(st);
+
+    if (dropped.length) {
+      var warn = document.createElement('p');
+      warn.className = 'bad';
+      warn.textContent = 'Incomplete: ' + dropped.join(', ') + ' could not be reconciled against ' +
+        'the build’s own totals, so ' + (dropped.length > 1 ? 'those suites are' : 'that suite is') +
+        ' excluded entirely. Every count below is a lower bound.';
+      out.appendChild(warn);
+    }
 
     if (s.notPassing) {
       var h = document.createElement('h2');
@@ -133,7 +154,7 @@ branch's newest report.</p>
       'allure.tag, or an enclosing allure.feature group. Following the link usually shows ' +
       'fewer, because it opens Allure’s Behaviours tree, which only allure.feature builds — ' +
       'and the resolver page there reports a third number, counting the tag route alone. ' +
-      'The count here is the honest total of the three.';
+      'The count here is the most inclusive of the three, and the one to trust.';
     out.appendChild(limits);
   }
 

--- a/.github/test-report-permalinks/coverage.html
+++ b/.github/test-report-permalinks/coverage.html
@@ -94,6 +94,14 @@ branch's newest report.</p>
     });
     var h2 = document.createElement('h2'); h2.textContent = 'Suites'; out.appendChild(h2);
     var st = document.createElement('table');
+    var shead = document.createElement('tr');
+    ['suite', 'tests', 'state', 'carrying an F-id'].forEach(function (label, i) {
+      var th = document.createElement('th');
+      th.textContent = label;
+      if (i === 1) th.className = 'n';
+      shead.appendChild(th);
+    });
+    st.appendChild(shead);
     suiteRows.forEach(function (r) {
       var tr = document.createElement('tr');
       cell(tr, r.feature); cell(tr, r.tests, 'n'); cell(tr, r.result); cell(tr, r.suites[0]);
@@ -121,8 +129,11 @@ branch's newest report.</p>
     var limits = document.createElement('p'); limits.className = 'muted';
     limits.textContent = '“No test” here always means no cucumber and no Playwright test — ' +
       'the JUnit suites publish no Allure report, so nothing joins them to a feature. ' +
-      'A link shows the tests Allure grouped under the feature, which for a spec annotated ' +
-      'with allure.tag rather than allure.feature is fewer than the count beside it.';
+      'The count beside a feature is every test reaching it by either route: its own ' +
+      'allure.tag, or an enclosing allure.feature group. Following the link usually shows ' +
+      'fewer, because it opens Allure’s Behaviours tree, which only allure.feature builds — ' +
+      'and the resolver page there reports a third number, counting the tag route alone. ' +
+      'The count here is the honest total of the three.';
     out.appendChild(limits);
   }
 

--- a/.github/test-report-permalinks/coverage.js
+++ b/.github/test-report-permalinks/coverage.js
@@ -1,0 +1,64 @@
+// coverage.js — pure, testable logic for the per-branch coverage page.
+// Mirrors the Knowledge Map recipe's presentation rules so the two agree:
+// a feature whose tests all passed reads "passed"; anything else names the
+// non-passing statuses with counts, so a long table still scans while the
+// rows worth acting on stand out.
+(function (root) {
+  function formatResult(status) {
+    var keys = Object.keys(status || {});
+    if (!keys.length) return 'unknown';
+    var bad = keys.filter(function (k) { return k !== 'passed'; }).sort();
+    if (!bad.length) return 'passed';
+    return bad.map(function (k) { return status[k] + ' ' + k; }).join(', ');
+  }
+
+  // One row per feature: totals summed across the suites it appears in.
+  function featureRows(coverage) {
+    var features = (coverage && coverage.features) || {};
+    return Object.keys(features).map(function (code) {
+      var perSuite = features[code], tests = 0, status = {}, suites = [];
+      Object.keys(perSuite).sort().forEach(function (s) {
+        tests += perSuite[s].tests || 0;
+        suites.push(s);
+        Object.keys(perSuite[s].status || {}).forEach(function (k) {
+          status[k] = (status[k] || 0) + perSuite[s].status[k];
+        });
+      });
+      return { feature: code, tests: tests, status: status,
+               result: formatResult(status), suites: suites };
+    }).sort(function (a, b) { return (b.tests - a.tests) || a.feature.localeCompare(b.feature); });
+  }
+
+  function summarise(rows, coverage) {
+    var notPassing = rows.filter(function (r) { return r.result !== 'passed'; });
+    var suites = (coverage && coverage.suites) || {};
+    var tests = 0, labelled = 0;
+    Object.keys(suites).forEach(function (s) {
+      if (suites[s].state === 'measured') {
+        tests += suites[s].tests || 0;
+        labelled += suites[s].labelled || 0;
+      }
+    });
+    return { features: rows.length, notPassing: notPassing.length,
+             fullyPassing: rows.length - notPassing.length,
+             tests: tests, labelled: labelled, notPassingRows: notPassing };
+  }
+
+  // The permalink resolver is branch-scoped on purpose: a build-scoped URL
+  // rots at the next build.
+  function permalinkFor(branch, feature) {
+    return 'branches/' + encodeURIComponent(branch) + '/permalink.html?feature=' +
+           encodeURIComponent(feature);
+  }
+
+  // A branch name as the host spells it: underscores become dashes. Accepting
+  // the git spelling too means a reader can paste either.
+  function normaliseBranch(branch) {
+    return String(branch || '').trim().replace(/_/g, '-');
+  }
+
+  var api = { formatResult: formatResult, featureRows: featureRows, summarise: summarise,
+              permalinkFor: permalinkFor, normaliseBranch: normaliseBranch };
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  else root.Coverage = api;
+})(typeof window !== 'undefined' ? window : this);

--- a/.github/test-report-permalinks/coverage.js
+++ b/.github/test-report-permalinks/coverage.js
@@ -77,8 +77,21 @@
       .replace(/-+$/, '');
   }
 
+  // Suites whose data was DROPPED by a failed reconciliation. `reason` is the
+  // marker and the only reliable one: keying off `ran` misses a suite whose
+  // reported total is 0, because 0 is falsy -- and that is the loudest
+  // disagreement there is. A dropped suite contributes no features, so every
+  // count on the page is a lower bound while one exists.
+  function droppedSuites(coverage) {
+    var suites = (coverage && coverage.suites) || {};
+    return Object.keys(suites).filter(function (k) {
+      return suites[k].state === 'unknown' && suites[k].reason;
+    }).sort();
+  }
+
   var api = { formatResult: formatResult, featureRows: featureRows, summarise: summarise,
-              permalinkFor: permalinkFor, normaliseBranch: normaliseBranch };
+              permalinkFor: permalinkFor, normaliseBranch: normaliseBranch,
+              droppedSuites: droppedSuites };
   if (typeof module !== 'undefined' && module.exports) module.exports = api;
   else root.Coverage = api;
 })(typeof window !== 'undefined' ? window : this);

--- a/.github/test-report-permalinks/coverage.js
+++ b/.github/test-report-permalinks/coverage.js
@@ -51,10 +51,27 @@
            encodeURIComponent(feature);
   }
 
-  // A branch name as the host spells it: underscores become dashes. Accepting
-  // the git spelling too means a reader can paste either.
+  // A branch name as the host spells it. This MUST mirror the server's
+  // sanitize-branch-for-gh-pages step in cicd.yaml exactly, or the fetch 404s
+  // on a branch that was published perfectly well:
+  //
+  //   tr '/' '-' | tr '_' '-' | tr -cd 'a-zA-Z0-9.-' | tr '[:upper:]' '[:lower:]'
+  //     | sed 's/--*/-/g' | sed 's/^-*//' | sed 's/-*$//'
+  //
+  // Lower-casing is the one that bites hardest: this repo's own convention is
+  // `{base_branch}_{FeatureDescription}`, so essentially every feature branch
+  // is mixed-case. Handling only `_` -> `-` (as this did at first) 404s on
+  // `new_dawn_uat_CoveragePageAllBranches` while the server holds
+  // `new-dawn-uat-coveragepageallbranches`.
   function normaliseBranch(branch) {
-    return String(branch || '').trim().replace(/_/g, '-');
+    return String(branch || '')
+      .trim()
+      .replace(/[/_]/g, '-')
+      .replace(/[^a-zA-Z0-9.-]/g, '')   // tr -cd: DROPS, never substitutes
+      .toLowerCase()
+      .replace(/-{2,}/g, '-')
+      .replace(/^-+/, '')
+      .replace(/-+$/, '');
   }
 
   var api = { formatResult: formatResult, featureRows: featureRows, summarise: summarise,

--- a/.github/test-report-permalinks/coverage.js
+++ b/.github/test-report-permalinks/coverage.js
@@ -65,6 +65,9 @@
   // `new-dawn-uat-coveragepageallbranches`.
   function normaliseBranch(branch) {
     return String(branch || '')
+      // The ONE deliberate deviation from the server pipeline: a name pasted
+      // into the box or a URL carries whitespace the server never sees, and
+      // trimming it cannot change any name git will actually produce.
       .trim()
       .replace(/[/_]/g, '-')
       .replace(/[^a-zA-Z0-9.-]/g, '')   // tr -cd: DROPS, never substitutes

--- a/.github/test-report-permalinks/generate_permalinks.py
+++ b/.github/test-report-permalinks/generate_permalinks.py
@@ -5,6 +5,10 @@ feature/spec -> {suite: {uid, count}} map. Runs server-side (piped over ssh) and
 import json, os, re, sys, tempfile
 
 ALLURE_SUITES = ["cucumber", "frontend-webui", "mobile-webui"]
+#: Suites that run and report totals but publish no Allure report at all, so
+#: they carry no feature labels. "No test" never means "no test" — it means no
+#: cucumber and no Playwright test.
+NO_ALLURE_SUITES = ["junit/backend", "junit/camel", "junit/jest"]
 FCODE_RE = re.compile(r"^(F\d+(?:\.\d+)?)\b")
 #: An F-code as it appears in a test's own `tags`: bare ("F00230") or with its
 #: name ("F00230: MobileUI Picking"). The subfeature separator is written "."
@@ -78,6 +82,104 @@ def extract_tagged_features(behaviors_root):
         walk(top)
     return {code: len(uids) for code, uids in seen.items()}
 
+def _leaf_features(node, inherited, out):
+    """Collect {F-code: {uid: status}} for one subtree.
+
+    Mirrors the semantics the Knowledge Map recipe established against real
+    builds, because the two must agree: the F-code comes from the leaf's own
+    tags FIRST and an enclosing `Fxxxx` node only as a fallback; results are
+    de-duplicated on Allure's `uid` (a test is listed more than once in the
+    tree); and an enclosing node that is merely the PARENT of a tag-named
+    subfeature is not credited, so `F5001` does not inherit `F5001.1`'s tests.
+    """
+    ch = node.get("children")
+    if ch is None:
+        uid = node.get("uid") or node.get("name")
+        status = node.get("status") or "unknown"
+        found = set()
+        for tag in node.get("tags") or []:
+            m = TAG_FCODE_RE.match(str(tag))
+            if m:
+                found.add(_canonical_fcode(m.group(1)))
+        if inherited and not any(f.startswith(inherited + ".") for f in found):
+            found.add(inherited)
+        for code in found:
+            out.setdefault(code, {})[uid] = status
+        return
+    m = FCODE_RE.match(node.get("name") or "")
+    nf = _canonical_fcode(m.group(1)) if m else inherited
+    for c in ch:
+        _leaf_features(c, nf, out)
+
+
+def extract_coverage(behaviors_root):
+    """{F-code: {uid: status}} across the whole tree — the per-feature answer."""
+    out = {}
+    for top in behaviors_root.get("children") or []:
+        _leaf_features(top, None, out)
+    return out
+
+
+def read_suite_totals(build_dir):
+    """Per-suite totals from the build's failures.json — the independent figure
+    a parsed tree is reconciled against, and the only evidence that a suite with
+    no Allure report nonetheless RAN."""
+    path = os.path.join(build_dir, "failures.json")
+    if not os.path.isfile(path):
+        return {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return {}
+    suites = data.get("suites") if isinstance(data, dict) else None
+    if not isinstance(suites, dict):
+        return {}
+    return {k: v.get("total") for k, v in suites.items()
+            if isinstance(v, dict) and isinstance(v.get("total"), int)}
+
+
+def build_coverage(build_dir):
+    """The whole-branch coverage answer, for `coverage.html` to render.
+
+    Published alongside the permalink index so ANY branch can be answered from
+    a browser: the Knowledge Map page could only ever show one branch, because
+    a static capture is one branch by construction and test-reports sends no
+    CORS headers, so a page hosted elsewhere cannot read this data at all.
+    """
+    reported = read_suite_totals(build_dir)
+    suites, features = {}, {}
+    for suite in ALLURE_SUITES:
+        bpath = os.path.join(build_dir, "allure", suite, "data", "behaviors.json")
+        total = reported.get(suite)
+        if not os.path.isfile(bpath):
+            suites[suite] = {"state": "absent" if total is not None else "unknown",
+                             "ran": total, "tests": None, "labelled": None}
+            continue
+        with open(bpath, encoding="utf-8") as f:
+            per_feature = extract_coverage(json.load(f))
+        universe, labelled = set(), set()
+        for code, tests in per_feature.items():
+            labelled |= set(tests)
+        for code, tests in per_feature.items():
+            for uid, status in tests.items():
+                universe.add(uid)
+                entry = features.setdefault(code, {}).setdefault(
+                    suite, {"tests": 0, "status": {}})
+                entry["tests"] += 1
+                entry["status"][status] = entry["status"].get(status, 0) + 1
+        # The tree holds only the tests it groups; failures.json is the independent
+        # total. Report both rather than asserting one — a mismatch is information.
+        suites[suite] = {"state": "measured", "ran": total,
+                         "tests": total if total is not None else len(universe),
+                         "labelled": len(labelled)}
+    for suite in NO_ALLURE_SUITES:
+        total = reported.get(suite)
+        if total is not None:
+            suites[suite] = {"state": "absent", "ran": total, "tests": None, "labelled": None}
+    return {"suites": suites, "features": features}
+
+
 def extract_specs(suites_root):
     out = {}
     def walk(node):
@@ -122,7 +224,8 @@ def main(argv):
     os.makedirs(out_dir, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=out_dir, suffix=".tmp")
     with os.fdopen(fd, "w", encoding="utf-8") as f:
-        json.dump({"version": version, "features": features, "specs": specs}, f, indent=2, ensure_ascii=False)
+        json.dump({"version": version, "features": features, "specs": specs,
+                   "coverage": build_coverage(build_dir)}, f, indent=2, ensure_ascii=False)
     # mkstemp creates the temp file 0600; the web server runs as a different user and
     # must be able to read the published file (else nginx serves 403). Widen to 0644
     # before the atomic rename so the served file is group+other readable.

--- a/.github/test-report-permalinks/generate_permalinks.py
+++ b/.github/test-report-permalinks/generate_permalinks.py
@@ -86,11 +86,21 @@ def _leaf_features(node, inherited, out):
     """Collect {F-code: {uid: status}} for one subtree.
 
     Mirrors the semantics the Knowledge Map recipe established against real
-    builds, because the two must agree: the F-code comes from the leaf's own
-    tags FIRST and an enclosing `Fxxxx` node only as a fallback; results are
-    de-duplicated on Allure's `uid` (a test is listed more than once in the
-    tree); and an enclosing node that is merely the PARENT of a tag-named
-    subfeature is not credited, so `F5001` does not inherit `F5001.1`'s tests.
+    builds, because the two must agree:
+
+    - a leaf is credited to the UNION of the F-codes in its own `tags` and the
+      enclosing `Fxxxx` node, not to whichever comes first. Both routes are
+      real and neither is sufficient alone: `allure.tag` lands in `tags` and
+      builds no node, `allure.feature` builds a node and sets no tag, and a
+      spec can use either. Reading tags *instead of* the node (which this
+      docstring wrongly described until 2026-09-12) drops 39 leaves on
+      5.175-intensive-care-release.43591 and loses `F01010`, `F01010.3`,
+      `F01010.5` and `F8016` entirely — while leaving the headline totals
+      untouched, so the numbers in the tests do not catch it;
+    - results are de-duplicated on Allure's `uid`, because a test is listed
+      more than once in the tree;
+    - an enclosing node that is merely the PARENT of a tag-named subfeature is
+      not credited, so `F5001` does not inherit `F5001.1`'s tests.
     """
     ch = node.get("children")
     if ch is None:
@@ -110,6 +120,26 @@ def _leaf_features(node, inherited, out):
     nf = _canonical_fcode(m.group(1)) if m else inherited
     for c in ch:
         _leaf_features(c, nf, out)
+
+
+def _count_distinct_leaves(behaviors_root):
+    """Every distinct leaf uid in the tree, annotated or not.
+
+    The figure to reconcile against `failures.json`. Counting only LABELLED
+    leaves would compare a subset against the whole and disagree on any suite
+    holding an unannotated test — which is every suite here.
+    """
+    seen = set()
+    def walk(node):
+        ch = node.get("children")
+        if ch is None:
+            seen.add(node.get("uid") or node.get("name"))
+            return
+        for c in ch:
+            walk(c)
+    for top in behaviors_root.get("children") or []:
+        walk(top)
+    return len(seen)
 
 
 def extract_coverage(behaviors_root):
@@ -143,9 +173,17 @@ def build_coverage(build_dir):
     """The whole-branch coverage answer, for `coverage.html` to render.
 
     Published alongside the permalink index so ANY branch can be answered from
-    a browser: the Knowledge Map page could only ever show one branch, because
-    a static capture is one branch by construction and test-reports sends no
-    CORS headers, so a page hosted elsewhere cannot read this data at all.
+    a browser. The published Knowledge Map answer can only ever show one
+    branch, because a static capture is one branch by construction; this is
+    the live counterpart.
+
+    It is served from this host so it is same-origin with the data and with
+    the per-feature permalinks it links to, and so it cannot break when
+    someone else's CORS configuration changes. (An earlier version of this
+    comment claimed the host sends no CORS headers and that a page elsewhere
+    therefore could not read this data. That was wrong: it sends
+    `access-control-allow-origin: *`. A cross-origin page IS possible; this
+    one is same-origin by choice, not by necessity.)
     """
     reported = read_suite_totals(build_dir)
     suites, features = {}, {}
@@ -157,22 +195,35 @@ def build_coverage(build_dir):
                              "ran": total, "tests": None, "labelled": None}
             continue
         with open(bpath, encoding="utf-8") as f:
-            per_feature = extract_coverage(json.load(f))
-        universe, labelled = set(), set()
-        for code, tests in per_feature.items():
-            labelled |= set(tests)
+            behaviors = json.load(f)
+        per_feature = extract_coverage(behaviors)
+        # Two INDEPENDENT measurements, and they must be kept independent:
+        #   `parsed`   — every distinct leaf in the tree, labelled or not
+        #   `total`    — what failures.json says the suite ran
+        # `labelled` is a subset of `parsed` by construction, so comparing
+        # `labelled` against `total` is not a reconciliation — it is a
+        # guaranteed mismatch on any suite with an unannotated test.
+        parsed = _count_distinct_leaves(behaviors)
+        labelled = {uid for tests in per_feature.values() for uid in tests}
+        if total is not None and parsed != total:
+            # A tree that does not reconcile is not an answer. The recipe drops
+            # the suite's per-feature data here rather than publish counts from
+            # a mis-parsed tree, and so must this: every miscount this code has
+            # had (occurrence-counting, hierarchy-only reading, the dropped bare
+            # node) showed up first as exactly this disagreement.
+            suites[suite] = {"state": "unknown", "ran": total, "tests": None,
+                             "labelled": None, "parsed": parsed,
+                             "reason": f"parsed {parsed} distinct test(s) but "
+                                       f"failures.json reports {total}"}
+            continue
         for code, tests in per_feature.items():
             for uid, status in tests.items():
-                universe.add(uid)
                 entry = features.setdefault(code, {}).setdefault(
                     suite, {"tests": 0, "status": {}})
                 entry["tests"] += 1
                 entry["status"][status] = entry["status"].get(status, 0) + 1
-        # The tree holds only the tests it groups; failures.json is the independent
-        # total. Report both rather than asserting one — a mismatch is information.
-        suites[suite] = {"state": "measured", "ran": total,
-                         "tests": total if total is not None else len(universe),
-                         "labelled": len(labelled)}
+        suites[suite] = {"state": "measured", "ran": total, "tests": parsed,
+                         "labelled": len(labelled), "parsed": parsed}
     for suite in NO_ALLURE_SUITES:
         total = reported.get(suite)
         if total is not None:
@@ -220,12 +271,17 @@ def main(argv):
     base = argv[3] if len(argv) > 3 else "/var/www/test-reports"
     build_dir = os.path.join(base, "branches", branch, "builds", version)
     features, specs = build_index(build_dir)
+    # Parse BEFORE creating the temp file. Anything that can raise belongs
+    # outside the mkstemp block: this directory is served by nginx, and an
+    # exception between mkstemp and os.replace would strand a `*.tmp` there on
+    # every build -- silently, because the calling step is continue-on-error.
+    coverage = build_coverage(build_dir)
     out_dir = os.path.join(base, "branches", branch)
     os.makedirs(out_dir, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=out_dir, suffix=".tmp")
     with os.fdopen(fd, "w", encoding="utf-8") as f:
         json.dump({"version": version, "features": features, "specs": specs,
-                   "coverage": build_coverage(build_dir)}, f, indent=2, ensure_ascii=False)
+                   "coverage": coverage}, f, indent=2, ensure_ascii=False)
     # mkstemp creates the temp file 0600; the web server runs as a different user and
     # must be able to read the published file (else nginx serves 403). Widen to 0644
     # before the atomic rename so the served file is group+other readable.

--- a/.github/test-report-permalinks/generate_permalinks.py
+++ b/.github/test-report-permalinks/generate_permalinks.py
@@ -93,8 +93,8 @@ def _leaf_features(node, inherited, out):
       real and neither is sufficient alone: `allure.tag` lands in `tags` and
       builds no node, `allure.feature` builds a node and sets no tag, and a
       spec can use either. Reading tags *instead of* the node (which this
-      docstring wrongly described until 2026-09-12) drops 39 leaves on
-      5.175-intensive-care-release.43591 and loses `F01010`, `F01010.3`,
+      docstring wrongly described until 2026-09-12) drops 27 attributions on
+      5.175-intensive-care-release.43783 and loses `F01010`, `F01010.3`,
       `F01010.5` and `F8016` entirely — while leaving the headline totals
       untouched, so the numbers in the tests do not catch it;
     - results are de-duplicated on Allure's `uid`, because a test is listed

--- a/.github/test-report-permalinks/generate_permalinks.py
+++ b/.github/test-report-permalinks/generate_permalinks.py
@@ -58,15 +58,24 @@ def extract_tagged_features(behaviors_root):
     `allure.tag('Fxxxx: Name')` + `allure.tag('Fxxxx')` instead, and a tag
     creates no grouping node -- so a feature can have many tests here and at
     most a token presence in the Behaviours tree. Measured on
-    5.175-intensive-care-release.43783: F00700's Behaviours node holds 1 test
-    while 141 carry its tag; for F00230 the node holds 67 against 190 tagged.
-    Indexing the tag route is what lets the resolver page say which of the two
-    numbers a link is about to show.
+    5.175-intensive-care-release.43783, and note all three columns are
+    DIFFERENT questions about the same feature:
+
+        feature   node (extract_features)   tag (this fn)   tag-or-node
+        F00700                          1             120           141
+        F00230                         67             158           190
+
+    This function returns the middle column. The right-hand column is what
+    `extract_coverage` produces and what the coverage page shows; quoting it
+    here as "the tag count" is an error this docstring carried until
+    2026-09-12. Indexing the tag route is what lets the resolver page say
+    which number a link is about to show -- the node column is what the link
+    opens, and it can be a tiny fraction of the other two.
     """
     seen = {}   # F-code -> set of leaf uids, because a test appears MORE THAN ONCE
                 # in the tree (cucumber lists every test under its .feature file AND
-                # again under Epic -> Feature). Counting occurrences inflated F00230
-                # from 190 real tests to 293 before this was de-duplicated.
+                # again under Epic -> Feature). For F00230 the tag occurs 293 times
+                # across the tree and belongs to 158 distinct tests.
     def walk(node):
         ch = node.get("children")
         if ch is None:

--- a/.github/test-report-permalinks/generate_permalinks.py
+++ b/.github/test-report-permalinks/generate_permalinks.py
@@ -206,11 +206,13 @@ def build_coverage(build_dir):
         parsed = _count_distinct_leaves(behaviors)
         labelled = {uid for tests in per_feature.values() for uid in tests}
         if total is not None and parsed != total:
-            # A tree that does not reconcile is not an answer. The recipe drops
-            # the suite's per-feature data here rather than publish counts from
-            # a mis-parsed tree, and so must this: every miscount this code has
-            # had (occurrence-counting, hierarchy-only reading, the dropped bare
-            # node) showed up first as exactly this disagreement.
+            # A tree that does not reconcile is not an answer: drop the suite's
+            # per-feature data rather than publish counts from a mis-parsed tree.
+            # This catches the miscounts that change the LEAF SET -- occurrence
+            # counting and the dropped bare node both did. It does NOT catch a
+            # mis-ATTRIBUTION: reading tags instead of the union moves 27 leaves
+            # between features and still reconciles perfectly. Tests, not this
+            # gate, are what guard attribution.
             suites[suite] = {"state": "unknown", "ran": total, "tests": None,
                              "labelled": None, "parsed": parsed,
                              "reason": f"parsed {parsed} distinct test(s) but "

--- a/.github/test-report-permalinks/tests/coverage.test.js
+++ b/.github/test-report-permalinks/tests/coverage.test.js
@@ -1,0 +1,78 @@
+// tests/coverage.test.js — the per-branch coverage page's pure logic.
+const assert = require('assert');
+const C = require('../coverage.js');
+
+// --- formatResult: the rows worth acting on must stand out -----------------
+assert.strictEqual(C.formatResult({ passed: 3 }), 'passed');
+assert.strictEqual(C.formatResult({}), 'unknown');
+assert.strictEqual(C.formatResult({ passed: 2, failed: 1 }), '1 failed');
+assert.strictEqual(C.formatResult({ broken: 1, failed: 2 }), '1 broken, 2 failed');
+// a feature with NO passing test must never read "passed"
+assert.strictEqual(C.formatResult({ failed: 4 }), '4 failed');
+
+const cov = {
+  suites: {
+    cucumber: { state: 'measured', ran: 1394, tests: 1394, labelled: 1278 },
+    'mobile-webui': { state: 'measured', ran: 377, tests: 377, labelled: 363 },
+    'junit/backend': { state: 'absent', ran: 11077, tests: null, labelled: null },
+  },
+  features: {
+    F00230: { cucumber: { tests: 23, status: { passed: 23 } },
+              'mobile-webui': { tests: 164, status: { passed: 164 } } },
+    F00100: { cucumber: { tests: 39, status: { passed: 38, failed: 1 } } },
+  },
+};
+
+// --- featureRows: totals sum ACROSS suites, statuses merge ----------------
+const rows = C.featureRows(cov);
+assert.strictEqual(rows.length, 2);
+assert.strictEqual(rows[0].feature, 'F00230');        // ordered by test count
+assert.strictEqual(rows[0].tests, 187);               // 23 + 164, not one suite's
+assert.deepStrictEqual(rows[0].suites, ['cucumber', 'mobile-webui']);
+assert.strictEqual(rows[1].result, '1 failed');
+
+// --- summarise: an absent suite contributes no phantom totals -------------
+const s = C.summarise(rows, cov);
+assert.strictEqual(s.features, 2);
+assert.strictEqual(s.fullyPassing, 1);
+assert.strictEqual(s.notPassing, 1);
+assert.strictEqual(s.notPassingRows[0].feature, 'F00100');
+// junit/backend is `absent` with 11077 ran — it must NOT be added to the totals,
+// or the page would claim feature-labelled coverage it does not have.
+assert.strictEqual(s.tests, 1394 + 377);
+assert.strictEqual(s.labelled, 1278 + 363);
+
+// The guard above is only meaningful if an absent suite carrying REAL numbers is
+// still excluded. Today the generator pairs `absent` with tests:null, so a fixture
+// using null passes whether the guard exists or not — it pins nothing. This one
+// fails the moment the state check is dropped.
+const covLoud = {
+  suites: {
+    cucumber: { state: 'measured', ran: 10, tests: 10, labelled: 8 },
+    'junit/backend': { state: 'absent', ran: 11077, tests: 11077, labelled: 11077 },
+  },
+  features: { F1: { cucumber: { tests: 1, status: { passed: 1 } } } },
+};
+const sLoud = C.summarise(C.featureRows(covLoud), covLoud);
+assert.strictEqual(sLoud.tests, 10, 'an absent suite must not contribute tests');
+assert.strictEqual(sLoud.labelled, 8, 'an absent suite must not contribute labelled tests');
+
+// --- the link is branch-scoped, and both branch spellings work ------------
+assert.strictEqual(C.permalinkFor('intensive-care-hotfix', 'F00230'),
+  'branches/intensive-care-hotfix/permalink.html?feature=F00230');
+assert.ok(C.permalinkFor('x', 'F1').indexOf('builds/') === -1, 'must not be build-scoped');
+assert.strictEqual(C.normaliseBranch('intensive_care_hotfix'), 'intensive-care-hotfix');
+assert.strictEqual(C.normaliseBranch('intensive-care-hotfix'), 'intensive-care-hotfix');
+assert.strictEqual(C.normaliseBranch('  new_dawn_uat  '), 'new-dawn-uat');
+assert.strictEqual(C.normaliseBranch(null), '');
+
+// --- a branch/feature name is URL-encoded into the href -------------------
+assert.ok(C.permalinkFor('a/b', 'F1&x').indexOf('a%2Fb') !== -1);
+assert.ok(C.permalinkFor('a/b', 'F1&x').indexOf('F1%26x') !== -1);
+
+// --- an empty or missing coverage payload degrades, never throws ----------
+assert.deepStrictEqual(C.featureRows(undefined), []);
+assert.deepStrictEqual(C.featureRows({}), []);
+assert.strictEqual(C.summarise([], {}).features, 0);
+
+console.log('coverage.test.js: all assertions passed');

--- a/.github/test-report-permalinks/tests/coverage.test.js
+++ b/.github/test-report-permalinks/tests/coverage.test.js
@@ -97,4 +97,24 @@ assert.deepStrictEqual(C.featureRows(undefined), []);
 assert.deepStrictEqual(C.featureRows({}), []);
 assert.strictEqual(C.summarise([], {}).features, 0);
 
+// --- a feature failing in TWO suites reports the SUM, not the last one -----
+// The cross-suite merge in featureRows was unpinned: replacing `+=` with `=`
+// survived the whole suite, because every fixture above has each status in one
+// suite only. A feature red in two suites is exactly the row a reader acts on.
+var covTwo = { suites: { cucumber: { state: 'measured', tests: 10, labelled: 10 },
+                         'frontend-webui': { state: 'measured', tests: 10, labelled: 10 } },
+  features: { F00700: { cucumber: { tests: 5, status: { passed: 3, failed: 2 } },
+                        'frontend-webui': { tests: 4, status: { passed: 1, failed: 3 } } } } };
+var rowTwo = C.featureRows(covTwo)[0];
+assert.strictEqual(rowTwo.tests, 9, 'tests sum across suites');
+assert.deepStrictEqual(rowTwo.status, { passed: 4, failed: 5 }, 'statuses SUM across suites');
+assert.strictEqual(rowTwo.result, '5 failed', 'the merged count is what the reader sees');
+assert.deepStrictEqual(rowTwo.suites, ['cucumber', 'frontend-webui']);
+
+// Sorted, counted, and every non-passing status named -- pins the sort in
+// formatResult, which insertion order alone would otherwise satisfy.
+assert.strictEqual(C.formatResult({ passed: 1, failed: 2, broken: 1 }), '1 broken, 2 failed');
+assert.strictEqual(C.formatResult({ failed: 2, broken: 1, passed: 1 }), '1 broken, 2 failed',
+  'same result whatever order the statuses arrive in');
+
 console.log('coverage.test.js: all assertions passed');

--- a/.github/test-report-permalinks/tests/coverage.test.js
+++ b/.github/test-report-permalinks/tests/coverage.test.js
@@ -60,11 +60,33 @@ assert.strictEqual(sLoud.labelled, 8, 'an absent suite must not contribute label
 // --- the link is branch-scoped, and both branch spellings work ------------
 assert.strictEqual(C.permalinkFor('intensive-care-hotfix', 'F00230'),
   'branches/intensive-care-hotfix/permalink.html?feature=F00230');
-assert.ok(C.permalinkFor('x', 'F1').indexOf('builds/') === -1, 'must not be build-scoped');
+assert.strictEqual(C.permalinkFor('x', 'F1'),
+  'branches/x/permalink.html?feature=F1', 'branch-scoped, never build-scoped');
 assert.strictEqual(C.normaliseBranch('intensive_care_hotfix'), 'intensive-care-hotfix');
 assert.strictEqual(C.normaliseBranch('intensive-care-hotfix'), 'intensive-care-hotfix');
 assert.strictEqual(C.normaliseBranch('  new_dawn_uat  '), 'new-dawn-uat');
 assert.strictEqual(C.normaliseBranch(null), '');
+
+// normaliseBranch must mirror cicd.yaml's sanitize-branch-for-gh-pages EXACTLY.
+// Each case below is one stage of that pipeline; dropping any stage 404s on a
+// branch the host published fine. Verified 2026-09-12 against the shell
+// pipeline over all 142 branches the host holds plus 167 local git branch
+// names: identical output on all 309.
+assert.strictEqual(C.normaliseBranch('new_dawn_uat_CoveragePageAllBranches'),
+  'new-dawn-uat-coveragepageallbranches',
+  'lower-cases: EVERY feature branch here is {base}_{MixedCaseDescription}');
+assert.strictEqual(C.normaliseBranch('deep_tundra_release_31039_ManufacturingReceiptGuard'),
+  'deep-tundra-release-31039-manufacturingreceiptguard',
+  'a real branch on the host; the underscore-only version 404s on it');
+assert.strictEqual(C.normaliseBranch('merge/keen_hawk_release-to-new_dawn_uat'),
+  'merge-keen-hawk-release-to-new-dawn-uat', 'slash is a separator, like underscore');
+assert.strictEqual(C.normaliseBranch('release@2.0+rc1'), 'release2.0rc1',
+  'tr -cd DROPS a disallowed char, it does not substitute a dash');
+assert.strictEqual(C.normaliseBranch('feature/Foo__Bar'), 'feature-foo-bar',
+  'runs of dashes collapse to one');
+assert.strictEqual(C.normaliseBranch('--leading-and-trailing--'), 'leading-and-trailing',
+  'leading and trailing dashes are stripped');
+assert.strictEqual(C.normaliseBranch('___'), '', 'a name that sanitises to nothing yields nothing');
 
 // --- a branch/feature name is URL-encoded into the href -------------------
 assert.ok(C.permalinkFor('a/b', 'F1&x').indexOf('a%2Fb') !== -1);

--- a/.github/test-report-permalinks/tests/coverage.test.js
+++ b/.github/test-report-permalinks/tests/coverage.test.js
@@ -117,4 +117,37 @@ assert.strictEqual(C.formatResult({ passed: 1, failed: 2, broken: 1 }), '1 broke
 assert.strictEqual(C.formatResult({ failed: 2, broken: 1, passed: 1 }), '1 broken, 2 failed',
   'same result whatever order the statuses arrive in');
 
+// --- a dropped suite is always announced, including when its total is 0 ----
+// `reason` marks a suite dropped by failed reconciliation. Keying the warning
+// off `ran` instead silently skipped the ran===0 case -- the loudest possible
+// disagreement -- because 0 is falsy. Reproduced in a browser before the fix.
+assert.deepStrictEqual(C.droppedSuites({ suites: {
+  cucumber: { state: 'unknown', ran: 0, parsed: 1390,
+              reason: 'parsed 1390 distinct test(s) but failures.json reports 0' } } }),
+  ['cucumber'], 'a dropped suite with ran:0 must still be announced');
+assert.deepStrictEqual(C.droppedSuites({ suites: {
+  cucumber: { state: 'unknown', ran: 99, parsed: 1, reason: 'parsed 1 ... reports 99' },
+  'mobile-webui': { state: 'measured', ran: 10, tests: 10, labelled: 8 } } }),
+  ['cucumber']);
+// `unknown` with NO reason is the never-ran case, not a drop: nothing was
+// verified about it, so there is no under-count to warn about.
+assert.deepStrictEqual(C.droppedSuites({ suites: {
+  cucumber: { state: 'unknown', ran: null, tests: null, labelled: null } } }), [],
+  'a suite that simply never ran is not a dropped suite');
+assert.deepStrictEqual(C.droppedSuites({}), []);
+assert.deepStrictEqual(C.droppedSuites(undefined), []);
+
+// --- the page must keep loading the script by the EXACT tag the deploy inlines
+// cicd.yaml replaces this byte string to ship one self-contained file. If the tag
+// is reformatted, the deploy aborts inside a continue-on-error step: the job stays
+// green and the published page silently stops updating. Fail here instead.
+const fs = require('fs'), path = require('path');
+const pageHtml = fs.readFileSync(path.join(__dirname, '..', 'coverage.html'), 'utf8');
+assert.ok(pageHtml.indexOf('<script src="coverage.js"></script>') !== -1,
+  'coverage.html must load coverage.js by the exact tag cicd.yaml inlines');
+assert.strictEqual(pageHtml.split('<script src="coverage.js"></script>').length - 1, 1,
+  'exactly one such tag, or the deploy would inline the script twice');
+assert.ok(!/<\/script|<!--|<script/i.test(fs.readFileSync(path.join(__dirname, '..', 'coverage.js'), 'utf8')),
+  'coverage.js must contain no sequence that can terminate or nest a script element once inlined');
+
 console.log('coverage.test.js: all assertions passed');

--- a/.github/test-report-permalinks/tests/test_generate_permalinks.py
+++ b/.github/test-report-permalinks/tests/test_generate_permalinks.py
@@ -159,9 +159,16 @@ def test_the_underscore_and_dot_subfeature_spellings_index_as_one():
     assert gp.extract_tagged_features(root) == {"F5001.1": 2}
 
 
-def test_a_customer_suffix_is_not_a_subfeature_separator():
-    """`F00138_se203` scopes a feature to one customer; folding it into `F00138`
-    would be the same class of defect in a new place."""
+def test_an_unrecognised_suffix_is_dropped_not_folded_into_the_parent():
+    """An `F00138_se203`-shaped tag is NOT a known convention: measured
+    2026-09-12, zero such tags exist on `new_dawn_uat`,
+    `intensive_care_release` or `intensive_care_hotfix`, and zero of the 2180
+    tags in build 5.175-intensive-care-release.43591 carry any non-numeric
+    suffix. It is pinned only as the generic unrecognised-suffix case, to fix
+    the behaviour if the form ever appears: the tag is skipped, so nothing is
+    silently credited to `F00138`. Folding it into the parent would be the
+    subfeature-rollup defect in a new place; dropping it is the safe default
+    because it under-reports visibly rather than over-reporting invisibly."""
     root = {"children": [{"name": "g", "uid": "s".ljust(32, "0"), "children": [
         _leaf("a".ljust(32, "0"), "F00138_se203")]}]}
     assert gp.extract_tagged_features(root) == {}
@@ -195,12 +202,101 @@ def test_a_node_backed_feature_keeps_its_uid_and_gains_the_tagged_count(tmp_path
 def test_canonical_fcode_rewrites_only_a_numeric_subfeature_separator():
     """Pins `_canonical_fcode` DIRECTLY.
 
-    `test_a_customer_suffix_is_not_a_subfeature_separator` above goes through
-    TAG_FCODE_RE, which rejects `F00138_se203` before this function is reached —
-    so it passes even if this guard is deleted. Without this test the guard is
-    unpinned, which is how a defence quietly stops defending."""
+    `test_an_unrecognised_suffix_is_dropped_not_folded_into_the_parent` above
+    goes through TAG_FCODE_RE, which rejects `F00138_se203` before this
+    function is reached — so it passes even if this guard is deleted. Without
+    this test the guard is unpinned, which is how a defence quietly stops
+    defending.
+
+    The separator this guard DOES exist for is real and in daily use: measured
+    2026-09-12 on build 5.175-intensive-care-release.43591, cucumber writes the
+    subfeature with `_` (14 tags) while both Playwright suites write it with
+    `.` (42 tags). Without the rewrite those index as two different features."""
     assert gp._canonical_fcode("F5001_1") == "F5001.1"
     assert gp._canonical_fcode("F5001.1") == "F5001.1"
     assert gp._canonical_fcode("F5001") == "F5001"
     assert gp._canonical_fcode("F00138_se203") == "F00138_se203"
     assert gp._canonical_fcode("F00762.1_is184") == "F00762.1_is184"
+
+
+# --- the coverage answer: same semantics as the Knowledge Map recipe --------
+
+def _cov_tree(*leaves):
+    return {"children": [{"name": "some.feature", "uid": "s".ljust(32, "0"),
+                          "children": list(leaves)}]}
+
+
+def _cleaf(uid, status, *tags):
+    return {"name": "t-" + uid, "uid": uid, "status": status, "tags": list(tags)}
+
+
+def test_coverage_counts_a_test_once_though_the_tree_lists_it_twice():
+    leaf = _cleaf("d".ljust(32, "0"), "passed", "F00230")
+    root = {"children": [
+        {"name": "some.feature", "uid": "s".ljust(32, "0"), "children": [leaf]},
+        {"name": "E0105 Picking", "uid": "e".ljust(32, "0"), "children": [
+            {"name": "F00230 MobileUI Picking", "uid": "f".ljust(32, "0"), "children": [leaf]}]},
+    ]}
+    cov = gp.extract_coverage(root)
+    assert cov == {"F00230": {"d".ljust(32, "0"): "passed"}}
+
+
+def test_coverage_reads_the_fcode_from_a_tag_when_no_node_carries_it():
+    cov = gp.extract_coverage(_cov_tree(_cleaf("a".ljust(32, "0"), "passed", "F00700: Invoicing",
+                                               "F00700")))
+    assert cov == {"F00700": {"a".ljust(32, "0"): "passed"}}
+
+
+def test_coverage_does_not_credit_a_parent_with_its_subfeatures_tests():
+    """`F5001_1` tagged under a node Allure renders as `F5001 1 …` must not give
+    `F5001` the child's tests."""
+    root = {"children": [{"name": "F5001 1 Consolidate", "uid": "n".ljust(32, "0"), "children": [
+        _cleaf("a".ljust(32, "0"), "passed", "F5001_1")]}]}
+    cov = gp.extract_coverage(root)
+    assert set(cov) == {"F5001.1"}
+
+
+def test_coverage_keeps_each_tests_status():
+    cov = gp.extract_coverage(_cov_tree(
+        _cleaf("a".ljust(32, "0"), "passed", "F1000"),
+        _cleaf("b".ljust(32, "0"), "failed", "F1000")))
+    assert cov["F1000"] == {"a".ljust(32, "0"): "passed", "b".ljust(32, "0"): "failed"}
+
+
+def test_a_suite_that_ran_but_publishes_no_allure_report_is_absent(tmp_path):
+    (tmp_path / "failures.json").write_text(json.dumps({"suites": {
+        "cucumber": {"total": 2}, "junit/backend": {"total": 11077}}}), encoding="utf-8")
+    d = tmp_path / "allure" / "cucumber" / "data"
+    d.mkdir(parents=True)
+    (d / "behaviors.json").write_text(json.dumps(_cov_tree(
+        _cleaf("a".ljust(32, "0"), "passed", "F1000"),
+        _cleaf("b".ljust(32, "0"), "passed", "F1000"))), encoding="utf-8")
+    cov = gp.build_coverage(str(tmp_path))
+    assert cov["suites"]["junit/backend"] == {
+        "state": "absent", "ran": 11077, "tests": None, "labelled": None}
+    assert cov["suites"]["cucumber"]["state"] == "measured"
+    assert cov["suites"]["cucumber"]["ran"] == 2
+
+
+def test_a_suite_with_no_report_and_no_reported_total_is_unknown_not_absent(tmp_path):
+    """Nothing was verified about it — saying `absent` would claim knowledge."""
+    (tmp_path / "failures.json").write_text(json.dumps({"suites": {}}), encoding="utf-8")
+    cov = gp.build_coverage(str(tmp_path))
+    assert cov["suites"]["cucumber"]["state"] == "unknown"
+
+
+def test_build_coverage_is_published_inside_permalinks_json(tmp_path):
+    (tmp_path / "failures.json").write_text(json.dumps({"suites": {"cucumber": {"total": 1}}}),
+                                            encoding="utf-8")
+    d = tmp_path / "allure" / "cucumber" / "data"
+    d.mkdir(parents=True)
+    (d / "behaviors.json").write_text(json.dumps(_cov_tree(
+        _cleaf("a".ljust(32, "0"), "passed", "F1000"))), encoding="utf-8")
+    base = tmp_path.parent / "srv"
+    bdir = base / "branches" / "b" / "builds" / "v1"
+    bdir.parent.mkdir(parents=True)
+    bdir.symlink_to(tmp_path, target_is_directory=True)
+    gp.main(["prog", "b", "v1", str(base)])
+    out = json.loads((base / "branches" / "b" / "permalinks.json").read_text(encoding="utf-8"))
+    assert out["coverage"]["features"]["F1000"]["cucumber"]["tests"] == 1
+    assert out["features"], "the existing permalink index must still be published"

--- a/.github/test-report-permalinks/tests/test_generate_permalinks.py
+++ b/.github/test-report-permalinks/tests/test_generate_permalinks.py
@@ -161,11 +161,13 @@ def test_the_underscore_and_dot_subfeature_spellings_index_as_one():
 
 def test_an_unrecognised_suffix_is_dropped_not_folded_into_the_parent():
     """An `F00138_se203`-shaped tag is NOT a known convention: measured
-    2026-09-12, zero such tags exist on `new_dawn_uat`,
-    `intensive_care_release` or `intensive_care_hotfix`, and no F-code tag in
-    build 5.175-intensive-care-release.43591 carries a non-numeric suffix
-    (2180 tag occurrences across the three suites). It is pinned only as the
-    generic unrecognised-suffix case, to fix
+    2026-09-12, no F-code tag in build 5.175-intensive-care-release.43783
+    carries a non-numeric suffix (2182 tag occurrences across the three
+    suites), and no test annotation on `new_dawn_uat`,
+    `intensive_care_release` or `intensive_care_hotfix` uses the form. It IS a
+    real identifier in another namespace -- it names doc issues, e.g.
+    `F00652_se203` -- so it is pinned here as the generic unrecognised-suffix
+    case, to fix
     the behaviour if the form ever appears: the tag is skipped, so nothing is
     silently credited to `F00138`. Folding it into the parent would be the
     subfeature-rollup defect in a new place; dropping it is the safe default
@@ -210,10 +212,16 @@ def test_canonical_fcode_rewrites_only_a_numeric_subfeature_separator():
     defending.
 
     The separator this guard DOES exist for is real and in daily use: measured
-    2026-09-12 on build 5.175-intensive-care-release.43591, cucumber writes the
+    2026-09-12 on build 5.175-intensive-care-release.43783, cucumber writes the
     subfeature with `_` (7 distinct tests) while both Playwright suites write
     it with `.` (33: 10 frontend-webui, 23 mobile-webui). Without the rewrite
     those index as two different features.
+
+    Note an underscore after the F-number is USUALLY part of a name, not a
+    subfeature: cucumber labels features `F00701_Sales_Invoice_Candidates` (78
+    distinct such ids on intensive_care_release). Those are safe because the
+    rewrite fires only when a DIGIT follows the underscore, which across all
+    three branches is the single genuine subfeature `F5001_1`.
 
     Those are DISTINCT TESTS, not tag occurrences — the occurrence counts are
     14 and 42, inflated by the same listed-twice duplication that

--- a/.github/test-report-permalinks/tests/test_generate_permalinks.py
+++ b/.github/test-report-permalinks/tests/test_generate_permalinks.py
@@ -203,7 +203,7 @@ def test_a_node_backed_feature_keeps_its_uid_and_gains_the_tagged_count(tmp_path
 
 
 def test_canonical_fcode_rewrites_only_a_numeric_subfeature_separator():
-    """Pins `_canonical_fcode` DIRECTLY.
+    r"""Pins `_canonical_fcode` DIRECTLY.
 
     `test_an_unrecognised_suffix_is_dropped_not_folded_into_the_parent` above
     goes through TAG_FCODE_RE, which rejects `F00138_se203` before this
@@ -218,10 +218,20 @@ def test_canonical_fcode_rewrites_only_a_numeric_subfeature_separator():
     those index as two different features.
 
     Note an underscore after the F-number is USUALLY part of a name, not a
-    subfeature: cucumber labels features `F00701_Sales_Invoice_Candidates` (78
-    distinct such ids on intensive_care_release). Those are safe because the
-    rewrite fires only when a DIGIT follows the underscore, which across all
-    three branches is the single genuine subfeature `F5001_1`.
+    subfeature: cucumber labels features `@allure.label.feature:F00701_Sales_
+    Invoice_Candidates`. Measured 2026-09-12, distinct ids in such labels in
+    `*.feature` files: 70 on intensive_care_release, 71 on new_dawn_uat, 40 on
+    intensive_care_hotfix. (Counting every `F\d+_Word` token in those files
+    instead gives 78/79/41 -- the extras are scenario ids like
+    `@Id:F36025_sql_default_resolves` and test data like `F00127_E2E`, not
+    feature labels. The predicate matters, so it is stated rather than implied.)
+
+    None of them reach THIS parser in that form: Allure renders the label as a
+    node name with the underscores turned into spaces (`F00701 Sales Invoice
+    Candidates`), and FCODE_RE's `\b` would not match the underscore form
+    anyway. The dot-rewrite in `_canonical_fcode` is a separate guard, and it
+    fires only when a DIGIT follows the underscore -- across all three branches
+    that is the single genuine subfeature `F5001_1`.
 
     Those are DISTINCT TESTS, not tag occurrences — the occurrence counts are
     14 and 42, inflated by the same listed-twice duplication that

--- a/.github/test-report-permalinks/tests/test_generate_permalinks.py
+++ b/.github/test-report-permalinks/tests/test_generate_permalinks.py
@@ -354,7 +354,12 @@ def test_a_tree_that_does_not_reconcile_is_unknown_and_publishes_no_features(tmp
         _cleaf("a".ljust(32, "0"), "passed", "F1000")], total=99)
     assert cov["suites"]["cucumber"]["state"] == "unknown"
     assert cov["suites"]["cucumber"]["tests"] is None
-    assert "99" in cov["suites"]["cucumber"]["reason"]
+    assert cov["suites"]["cucumber"]["parsed"] == 1
+    assert cov["suites"]["cucumber"]["ran"] == 99
+    # The reason is rendered to the reader, so the two numbers must not be
+    # transposed. Asserting only that "99" appears passes with them swapped.
+    assert cov["suites"]["cucumber"]["reason"] == (
+        "parsed 1 distinct test(s) but failures.json reports 99")
     assert cov["features"] == {}, "no per-feature data may survive a failed reconciliation"
 
 
@@ -406,10 +411,40 @@ def test_a_non_integer_total_is_not_a_total(tmp_path):
 def test_the_union_of_tag_and_node_is_taken_not_one_or_the_other(tmp_path):
     """A leaf tagged `F00700` under a node named `F01010 …` covers BOTH. Reading
     tags INSTEAD of the node (which this module's docstring wrongly described)
-    silently drops 39 leaves on the real build while leaving every headline
-    figure identical — so only a test shaped like this can catch it."""
+    silently drops 27 attributions on 5.175-intensive-care-release.43783 while
+    leaving every headline figure identical — so only a test shaped like this
+    can catch it."""
     root = {"children": [{"name": "E1 Epic", "uid": "e".ljust(32, "0"), "children": [
         {"name": "F01010 Something", "uid": "f".ljust(32, "0"), "children": [
             _cleaf("a".ljust(32, "0"), "passed", "F00700")]}]}]}
     per_feature = gp.extract_coverage(root)
     assert set(per_feature) == {"F00700", "F01010"}
+
+
+def test_a_node_named_for_a_subfeature_is_read_as_that_subfeature(tmp_path):
+    """Pins FCODE_RE's `(?:\\.\\d+)?` group DIRECTLY.
+
+    Dropping it survived all 31 tests while collapsing `F01010.3` into
+    `F01010` — silently moving 8 real attributions to the parent, which is the
+    subfeature-rollup defect this module exists to prevent. Nothing else
+    exercises the node route with a dotted name, because the tag route usually
+    supplies the subfeature first.
+    """
+    root = {"children": [{"name": "F01010.3 Payment Allocation",
+                          "uid": "f".ljust(32, "0"), "children": [
+        {"name": "t1", "uid": "a".ljust(32, "0"), "status": "passed"}]}]}
+    assert set(gp.extract_coverage(root)) == {"F01010.3"}
+
+
+def test_the_parent_guard_requires_the_dot_not_a_bare_prefix():
+    """`F1200` must not be suppressed by a leaf tagged `F12000`.
+
+    The guard is `startswith(inherited + ".")`; written as `startswith(inherited)`
+    it survives every other test, because no fixture pairs two F-codes where one
+    id is a string prefix of the other. Real ids do collide that way.
+    """
+    root = {"children": [{"name": "F1200 Parent", "uid": "f".ljust(32, "0"), "children": [
+        {"name": "t", "uid": "a".ljust(32, "0"), "status": "passed", "tags": ["F12000"]}]}]}
+    found = gp.extract_coverage(root)
+    assert set(found) == {"F1200", "F12000"}, \
+        "F12000 is a different feature, not a subfeature of F1200"

--- a/.github/test-report-permalinks/tests/test_generate_permalinks.py
+++ b/.github/test-report-permalinks/tests/test_generate_permalinks.py
@@ -162,9 +162,10 @@ def test_the_underscore_and_dot_subfeature_spellings_index_as_one():
 def test_an_unrecognised_suffix_is_dropped_not_folded_into_the_parent():
     """An `F00138_se203`-shaped tag is NOT a known convention: measured
     2026-09-12, zero such tags exist on `new_dawn_uat`,
-    `intensive_care_release` or `intensive_care_hotfix`, and zero of the 2180
-    tags in build 5.175-intensive-care-release.43591 carry any non-numeric
-    suffix. It is pinned only as the generic unrecognised-suffix case, to fix
+    `intensive_care_release` or `intensive_care_hotfix`, and no F-code tag in
+    build 5.175-intensive-care-release.43591 carries a non-numeric suffix
+    (2180 tag occurrences across the three suites). It is pinned only as the
+    generic unrecognised-suffix case, to fix
     the behaviour if the form ever appears: the tag is skipped, so nothing is
     silently credited to `F00138`. Folding it into the parent would be the
     subfeature-rollup defect in a new place; dropping it is the safe default
@@ -210,8 +211,15 @@ def test_canonical_fcode_rewrites_only_a_numeric_subfeature_separator():
 
     The separator this guard DOES exist for is real and in daily use: measured
     2026-09-12 on build 5.175-intensive-care-release.43591, cucumber writes the
-    subfeature with `_` (14 tags) while both Playwright suites write it with
-    `.` (42 tags). Without the rewrite those index as two different features."""
+    subfeature with `_` (7 distinct tests) while both Playwright suites write
+    it with `.` (33: 10 frontend-webui, 23 mobile-webui). Without the rewrite
+    those index as two different features.
+
+    Those are DISTINCT TESTS, not tag occurrences — the occurrence counts are
+    14 and 42, inflated by the same listed-twice duplication that
+    `extract_tagged_features` de-duplicates above. Stating a tag-occurrence
+    count as if it were a test count is the very defect this module exists to
+    avoid, so the unit is named here rather than left to the reader."""
     assert gp._canonical_fcode("F5001_1") == "F5001.1"
     assert gp._canonical_fcode("F5001.1") == "F5001.1"
     assert gp._canonical_fcode("F5001") == "F5001"
@@ -300,3 +308,100 @@ def test_build_coverage_is_published_inside_permalinks_json(tmp_path):
     out = json.loads((base / "branches" / "b" / "permalinks.json").read_text(encoding="utf-8"))
     assert out["coverage"]["features"]["F1000"]["cucumber"]["tests"] == 1
     assert out["features"], "the existing permalink index must still be published"
+
+
+# --- the figures the page actually prints, and the reconciliation gate ------
+# Every test below was written because the mutation it describes SURVIVED the
+# suite as it stood on 2026-09-12. A published number that no test constrains
+# is a number free to drift.
+
+
+def _suite_build(tmp_path, leaves, total, suite="cucumber"):
+    (tmp_path / "failures.json").write_text(
+        json.dumps({"suites": {suite: {"total": total}}}), encoding="utf-8")
+    d = tmp_path / "allure" / suite / "data"
+    d.mkdir(parents=True)
+    (d / "behaviors.json").write_text(json.dumps(_cov_tree(*leaves)), encoding="utf-8")
+    return gp.build_coverage(str(tmp_path))
+
+
+def test_labelled_counts_only_the_tests_carrying_a_feature_id(tmp_path):
+    """`labelled` is a headline figure on the page ("N carrying an F-id") and
+    was asserted nowhere: replacing it with a constant kept the suite green."""
+    cov = _suite_build(tmp_path, [
+        _cleaf("a".ljust(32, "0"), "passed", "F1000"),
+        _cleaf("b".ljust(32, "0"), "passed", "F1000"),
+        _cleaf("c".ljust(32, "0"), "passed"),          # no tag: parsed, not labelled
+    ], total=3)
+    assert cov["suites"]["cucumber"]["labelled"] == 2
+    assert cov["suites"]["cucumber"]["parsed"] == 3
+    assert cov["suites"]["cucumber"]["tests"] == 3
+
+
+def test_a_tree_that_does_not_reconcile_is_unknown_and_publishes_no_features(tmp_path):
+    """The safety gate. Every miscount this code has had showed up first as the
+    parsed tree disagreeing with failures.json, so a disagreement must refuse to
+    answer rather than publish per-feature counts from a mis-parsed tree."""
+    cov = _suite_build(tmp_path, [
+        _cleaf("a".ljust(32, "0"), "passed", "F1000")], total=99)
+    assert cov["suites"]["cucumber"]["state"] == "unknown"
+    assert cov["suites"]["cucumber"]["tests"] is None
+    assert "99" in cov["suites"]["cucumber"]["reason"]
+    assert cov["features"] == {}, "no per-feature data may survive a failed reconciliation"
+
+
+def test_reconciliation_compares_distinct_tests_not_labelled_ones(tmp_path):
+    """`labelled` is a SUBSET of `parsed`, so reconciling `labelled` against the
+    reported total would fail on any suite holding an unannotated test — i.e.
+    all of them. This build has one unannotated test and must still reconcile."""
+    cov = _suite_build(tmp_path, [
+        _cleaf("a".ljust(32, "0"), "passed", "F1000"),
+        _cleaf("b".ljust(32, "0"), "passed"),
+    ], total=2)
+    assert cov["suites"]["cucumber"]["state"] == "measured"
+
+
+def test_a_test_listed_twice_reconciles_once(tmp_path):
+    """Allure lists a cucumber test under both its .feature file and its Epic.
+    If the reconciliation counted occurrences it would see 2 against a reported
+    1 and wrongly refuse the whole suite."""
+    dup = "a".ljust(32, "0")
+    cov = _suite_build(tmp_path, [
+        _cleaf(dup, "passed", "F1000"), _cleaf(dup, "passed", "F1000")], total=1)
+    assert cov["suites"]["cucumber"]["state"] == "measured"
+    assert cov["suites"]["cucumber"]["parsed"] == 1
+    assert cov["features"]["F1000"]["cucumber"]["tests"] == 1
+
+
+def test_a_no_allure_suite_is_only_reported_when_it_actually_ran(tmp_path):
+    """"No test" means "no cucumber and no Playwright test" only because these
+    suites are shown WITH their real totals. Reporting one that failures.json
+    never mentioned would invent a suite; the guard was unpinned."""
+    (tmp_path / "failures.json").write_text(
+        json.dumps({"suites": {"junit/backend": {"total": 11077}}}), encoding="utf-8")
+    cov = gp.build_coverage(str(tmp_path))
+    assert cov["suites"]["junit/backend"] == {
+        "state": "absent", "ran": 11077, "tests": None, "labelled": None}
+    assert "junit/camel" not in cov["suites"], "a suite with no reported total is not invented"
+
+
+def test_a_non_integer_total_is_not_a_total(tmp_path):
+    """`failures.json` is read off a live host; a null/string total must be
+    treated as absent rather than compared against or published."""
+    (tmp_path / "failures.json").write_text(json.dumps({"suites": {
+        "junit/backend": {"total": None}, "junit/camel": {"total": "250"}}}), encoding="utf-8")
+    cov = gp.build_coverage(str(tmp_path))
+    assert "junit/backend" not in cov["suites"]
+    assert "junit/camel" not in cov["suites"]
+
+
+def test_the_union_of_tag_and_node_is_taken_not_one_or_the_other(tmp_path):
+    """A leaf tagged `F00700` under a node named `F01010 …` covers BOTH. Reading
+    tags INSTEAD of the node (which this module's docstring wrongly described)
+    silently drops 39 leaves on the real build while leaving every headline
+    figure identical — so only a test shaped like this can catch it."""
+    root = {"children": [{"name": "E1 Epic", "uid": "e".ljust(32, "0"), "children": [
+        {"name": "F01010 Something", "uid": "f".ljust(32, "0"), "children": [
+            _cleaf("a".ljust(32, "0"), "passed", "F00700")]}]}]}
+    per_feature = gp.extract_coverage(root)
+    assert set(per_feature) == {"F00700", "F01010"}

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2576,10 +2576,12 @@ jobs:
           ssh reports-server "cat > /var/www/test-reports/branches/${BRANCH}/permalink.html" < "$DIR/permalink.html"
           # The coverage page answers for ANY branch from ONE URL, so it is deployed to the
           # server ROOT rather than per branch: it takes ?branch= and reads that branch's
-          # permalinks.json. Same-origin is the point -- this host sends no CORS headers, so
-          # a page served from anywhere else cannot read these reports at all.
-          ssh reports-server "cat > /var/www/test-reports/coverage.js"   < "$DIR/coverage.js"
-          ssh reports-server "cat > /var/www/test-reports/coverage.html" < "$DIR/coverage.html"
+          # permalinks.json. Content is identical for every branch, so whichever build
+          # publishes last simply rewrites it with the same bytes.
+          # Write-then-rename: `cat >` truncates in place, so a dropped ssh mid-write would
+          # leave a half-page served to whoever loads it next. rename is atomic on the server.
+          ssh reports-server "cat > /var/www/test-reports/coverage.js.tmp && mv /var/www/test-reports/coverage.js.tmp /var/www/test-reports/coverage.js"     < "$DIR/coverage.js"
+          ssh reports-server "cat > /var/www/test-reports/coverage.html.tmp && mv /var/www/test-reports/coverage.html.tmp /var/www/test-reports/coverage.html" < "$DIR/coverage.html"
           echo "Permalinks: https://test-reports.metasfresh.com/branches/${BRANCH}/permalink.html?feature=Fxxxx"
           echo "Coverage:   https://test-reports.metasfresh.com/coverage.html?branch=${BRANCH}"
 
@@ -2613,6 +2615,7 @@ jobs:
           <body>
               <div class="container">
                   <h1>📊 Test Reports</h1>
+                  <p><a href="coverage.html">Automated test coverage by feature</a> — which tests cover a feature on a given branch, and did they pass.</p>
                   <div id="branches"><p class="loading">Loading reports...</p></div>
               </div>
               <script>

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2578,10 +2578,28 @@ jobs:
           # server ROOT rather than per branch: it takes ?branch= and reads that branch's
           # permalinks.json. Content is identical for every branch, so whichever build
           # publishes last simply rewrites it with the same bytes.
-          # Write-then-rename: `cat >` truncates in place, so a dropped ssh mid-write would
-          # leave a half-page served to whoever loads it next. rename is atomic on the server.
-          ssh reports-server "cat > /var/www/test-reports/coverage.js.tmp && mv /var/www/test-reports/coverage.js.tmp /var/www/test-reports/coverage.js"     < "$DIR/coverage.js"
-          ssh reports-server "cat > /var/www/test-reports/coverage.html.tmp && mv /var/www/test-reports/coverage.html.tmp /var/www/test-reports/coverage.html" < "$DIR/coverage.html"
+          # Ship ONE self-contained file. coverage.js stays a separate source file so node can
+          # unit-test it, but it is inlined here for two reasons:
+          #   1. this host serves .js as `public, immutable, max-age=604800` (verified 2026-09-12)
+          #      while .html carries no cache header -- so a separate script would freeze for a
+          #      week and could pair a stale script with a fresh page;
+          #   2. one file is one atomic rename. Two files have a window where the page and its
+          #      script disagree, which matters more here than for the per-branch resolver
+          #      because EVERY branch's build rewrites this root path.
+          # mktemp gives a unique name, so two branches publishing at once cannot collide on it.
+          python3 - "$DIR" > /tmp/coverage.inlined.html <<'INLINEEOF'
+          import sys, pathlib
+          d = pathlib.Path(sys.argv[1])
+          js = (d / "coverage.js").read_text(encoding="utf-8")
+          html = (d / "coverage.html").read_text(encoding="utf-8")
+          needle = '<script src="coverage.js"></script>'
+          if needle not in html:
+              sys.exit("coverage.html no longer loads coverage.js by that exact tag; inlining aborted")
+          # No user data flows through here -- both files are repo content -- but a literal
+          # </script> inside the JS would still close the tag early.
+          sys.stdout.write(html.replace(needle, "<script>\n" + js.replace("</script>", "<\\/script>") + "\n</script>"))
+          INLINEEOF
+          ssh reports-server 'T=$(mktemp /var/www/test-reports/.coverage.XXXXXX) && cat > "$T" && chmod 644 "$T" && mv "$T" /var/www/test-reports/coverage.html' < /tmp/coverage.inlined.html
           echo "Permalinks: https://test-reports.metasfresh.com/branches/${BRANCH}/permalink.html?feature=Fxxxx"
           echo "Coverage:   https://test-reports.metasfresh.com/coverage.html?branch=${BRANCH}"
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2591,7 +2591,7 @@ jobs:
           # and a fixed /tmp name would let two branches' builds clobber each other.
           INLINED=$(mktemp)
           python3 - "$DIR" > "$INLINED" <<'INLINEEOF'
-          import sys, pathlib
+          import re, sys, pathlib
           d = pathlib.Path(sys.argv[1])
           js = (d / "coverage.js").read_text(encoding="utf-8")
           html = (d / "coverage.html").read_text(encoding="utf-8")
@@ -2600,23 +2600,40 @@ jobs:
               sys.exit("coverage.html no longer loads coverage.js by that exact tag; inlining aborted")
           # No user data flows through here -- both files are repo content -- but a literal
           # </script> inside the JS would still close the tag early.
-          sys.stdout.write(html.replace(needle, "<script>\n" + js.replace("</script>", "<\\/script>") + "\n</script>"))
+          # Escape anything the HTML tokenizer treats as ending or nesting a script
+          # element: </script in any case or with trailing space/slash, and <!-- / <script
+          # (which put the tokenizer in a state where a later </script> does NOT close).
+          safe = re.sub(r"(?i)<(/?script|!--)", r"<\\\g<1>", js)
+          sys.stdout.write(html.replace(needle, "<script>\n" + safe + "\n</script>"))
           INLINEEOF
           # The `find -mmin +60` sweeps temp files left by an interrupted earlier deploy
           # (this whole step is continue-on-error, so a half-write is silent). The age
           # bound is what keeps it from deleting a CONCURRENT publish's in-flight temp.
           # `coverage.js` is removed because it was briefly deployed as a separate file
           # and nothing references it any more; leaving it would serve week-cached dead code.
-          ssh reports-server '
-            find /var/www/test-reports -maxdepth 1 -name ".coverage.*" -mmin +60 -delete 2>/dev/null
-            T=$(mktemp /var/www/test-reports/.coverage.XXXXXX) &&
-            cat > "$T" && chmod 644 "$T" &&
-            mv "$T" /var/www/test-reports/coverage.html &&
-            rm -f /var/www/test-reports/coverage.js
-          ' < "$INLINED"
+          # The size check is the load-bearing guard, not the rename. `cat` cannot tell
+          # "stdin ended" from "stdin was cut": on a mid-transfer disconnect it exits 0,
+          # chmod succeeds, and the rename atomically publishes a TRUNCATED page --
+          # verified locally, a 4000-byte cut of a 12847-byte page published with the
+          # whole chain reporting success. Inlining makes that worse, because the cut
+          # now lands inside the page's own <script>. Compare byte counts before renaming.
+          SIZE=$(wc -c < "$INLINED")
+          ssh reports-server "
+            find /var/www/test-reports -maxdepth 1 -name '.coverage.*' -mmin +60 -delete 2>/dev/null
+            T=\$(mktemp /var/www/test-reports/.coverage.XXXXXX) &&
+            cat > \"\$T\" && chmod 644 \"\$T\" &&
+            [ \"\$(wc -c < \"\$T\")\" -eq $SIZE ] &&
+            mv \"\$T\" /var/www/test-reports/coverage.html &&
+            rm -f /var/www/test-reports/coverage.js ||
+            { rm -f \"\$T\"; echo 'coverage deploy FAILED (incomplete transfer)' >&2; exit 1; }
+          " < "$INLINED" && COVERAGE_OK=1 || echo "::warning::coverage.html was not updated this build"
           rm -f "$INLINED"
           echo "Permalinks: https://test-reports.metasfresh.com/branches/${BRANCH}/permalink.html?feature=Fxxxx"
-          echo "Coverage:   https://test-reports.metasfresh.com/coverage.html?branch=${BRANCH}"
+          # Print the coverage URL only if the page actually got published. A banner
+          # that prints either way is a claim the step has not verified.
+          if [ -n "$COVERAGE_OK" ]; then
+            echo "Coverage:   https://test-reports.metasfresh.com/coverage.html?branch=${BRANCH}"
+          fi
 
       - name: Update landing page
         if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true' && steps.inventory.outputs.count != '0'

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2574,7 +2574,14 @@ jobs:
           # deploy the static resolver (identical content per branch)
           ssh reports-server "cat > /var/www/test-reports/branches/${BRANCH}/permalink.js"   < "$DIR/permalink.js"
           ssh reports-server "cat > /var/www/test-reports/branches/${BRANCH}/permalink.html" < "$DIR/permalink.html"
+          # The coverage page answers for ANY branch from ONE URL, so it is deployed to the
+          # server ROOT rather than per branch: it takes ?branch= and reads that branch's
+          # permalinks.json. Same-origin is the point -- this host sends no CORS headers, so
+          # a page served from anywhere else cannot read these reports at all.
+          ssh reports-server "cat > /var/www/test-reports/coverage.js"   < "$DIR/coverage.js"
+          ssh reports-server "cat > /var/www/test-reports/coverage.html" < "$DIR/coverage.html"
           echo "Permalinks: https://test-reports.metasfresh.com/branches/${BRANCH}/permalink.html?feature=Fxxxx"
+          echo "Coverage:   https://test-reports.metasfresh.com/coverage.html?branch=${BRANCH}"
 
       - name: Update landing page
         if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true' && steps.inventory.outputs.count != '0'

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2587,7 +2587,10 @@ jobs:
           #      script disagree, which matters more here than for the per-branch resolver
           #      because EVERY branch's build rewrites this root path.
           # mktemp gives a unique name, so two branches publishing at once cannot collide on it.
-          python3 - "$DIR" > /tmp/coverage.inlined.html <<'INLINEEOF'
+          # mktemp on the RUNNER too: a self-hosted runner can host concurrent jobs,
+          # and a fixed /tmp name would let two branches' builds clobber each other.
+          INLINED=$(mktemp)
+          python3 - "$DIR" > "$INLINED" <<'INLINEEOF'
           import sys, pathlib
           d = pathlib.Path(sys.argv[1])
           js = (d / "coverage.js").read_text(encoding="utf-8")
@@ -2599,7 +2602,19 @@ jobs:
           # </script> inside the JS would still close the tag early.
           sys.stdout.write(html.replace(needle, "<script>\n" + js.replace("</script>", "<\\/script>") + "\n</script>"))
           INLINEEOF
-          ssh reports-server 'T=$(mktemp /var/www/test-reports/.coverage.XXXXXX) && cat > "$T" && chmod 644 "$T" && mv "$T" /var/www/test-reports/coverage.html' < /tmp/coverage.inlined.html
+          # The `find -mmin +60` sweeps temp files left by an interrupted earlier deploy
+          # (this whole step is continue-on-error, so a half-write is silent). The age
+          # bound is what keeps it from deleting a CONCURRENT publish's in-flight temp.
+          # `coverage.js` is removed because it was briefly deployed as a separate file
+          # and nothing references it any more; leaving it would serve week-cached dead code.
+          ssh reports-server '
+            find /var/www/test-reports -maxdepth 1 -name ".coverage.*" -mmin +60 -delete 2>/dev/null
+            T=$(mktemp /var/www/test-reports/.coverage.XXXXXX) &&
+            cat > "$T" && chmod 644 "$T" &&
+            mv "$T" /var/www/test-reports/coverage.html &&
+            rm -f /var/www/test-reports/coverage.js
+          ' < "$INLINED"
+          rm -f "$INLINED"
           echo "Permalinks: https://test-reports.metasfresh.com/branches/${BRANCH}/permalink.html?feature=Fxxxx"
           echo "Coverage:   https://test-reports.metasfresh.com/coverage.html?branch=${BRANCH}"
 

--- a/.github/workflows/test-report-permalinks-tests.yml
+++ b/.github/workflows/test-report-permalinks-tests.yml
@@ -52,3 +52,6 @@ jobs:
 
       - name: Run resolver tests (node)
         run: node tests/permalink.test.js
+
+      - name: Run coverage-page tests (node)
+        run: node tests/coverage.test.js


### PR DESCRIPTION
## What

`permalinks.json` gains a `coverage` key, and a new `coverage.html` renders it for **any** branch:

```
https://test-reports.metasfresh.com/coverage.html?branch=intensive_care_hotfix
```

Underscores or dashes both work, so a branch name can be pasted as written. The page answers *which automated tests cover a feature on this branch, and did they pass*, with every feature id linking into that branch's newest Allure report.

## Why it lives here

Same-origin with both the data it reads and the per-feature reports it links to, so it cannot break when someone else's CORS configuration changes. The published static answer elsewhere can only ever cover one branch, because a static capture is one branch by construction — which is exactly the limitation this removes.

**Correction:** the first version of this PR said the host sends no CORS headers and that a page elsewhere therefore *could not* read the data. That was false — it sends `access-control-allow-origin: *`. A cross-origin page was always possible; this is a choice, not a necessity. The claim was in the code, the workflow and this description, and is corrected in all three.

## Correctness

The extraction semantics match the existing published answer **exactly**, cross-checked on build `5.175-intensive-care-release.43783`:

| suite | tests | carrying an F-id |
|---|---|---|
| cucumber | 1394 | 1278 |
| frontend-webui | 197 | 148 |
| mobile-webui | 377 | 363 |

159 features, `F00230` = 190 tests, `F5001.1` = 9 — identical on both sides. (Originally cross-checked on `.43591`, which the host has since evicted — it keeps only three builds per branch — so every figure was re-measured on `.43783`, the build the Knowledge Map's captured tables were read from.)

Suite totals are now genuinely reconciled: the tree is counted independently of `failures.json`, and a suite whose two figures disagree is reported `unknown` and contributes no per-feature data rather than publishing counts from a mis-parsed tree.

Three rules carry that agreement, each learned from a real miscount:

- a leaf is credited to the **union** of its own `tags` and the enclosing node — both annotation routes are real and neither is sufficient alone (reading the hierarchy alone reported frontend-webui as 4% annotated when it is 75%; reading tags alone drops 27 attributions and loses four features outright);
- results de-duplicate on Allure `uid` (counting occurrences inflated cucumber from 1394 to 2804);
- a node that is merely the **parent** of a tag-named subfeature is not credited with its children's tests (`F5001` must not inherit `F5001.1`'s).

The three JUnit suites publish no Allure report, so they are shown as `absent` **with** their real test counts: "no test" on this page always means no cucumber and no Playwright test, never "nothing ran".

## Also in here

Two test docstrings presented an `F00138_se203` customer suffix as an established *test-annotation* convention. It is not one — no F-code tag in the build carries a non-numeric suffix (2182 occurrences). The form is real, though: it names doc issues (`F00652_se203`). The test is kept as the generic unrecognised-suffix case — an unknown suffix is dropped, never folded into the parent.

The `_` vs `.` subfeature separator beside it **is** real: cucumber writes `_` (7 tests), both Playwright suites write `.` (33). And an underscore after the F-number is usually part of a *name*, not a subfeature — cucumber labels features `F00701_Sales_Invoice_Candidates` (78 distinct ids on `intensive_care_release`). That is safe only because the dot-rewrite fires when a **digit** follows the underscore, which across all three branches is the single genuine subfeature `F5001_1`.

## Deploy safety

The page ships as **one self-contained file**: `coverage.js` stays a separate source file so node can unit-test it, and is inlined into `coverage.html` at deploy time. Two reasons — the host serves `.js` as `public, immutable, max-age=604800` while `.html` carries no cache header (so a separate script could freeze a week out of step with its page), and one file is one atomic rename, which matters because *every* branch's build rewrites this root path.

The rename alone is not enough, though: `cat` cannot tell "stdin ended" from "stdin was cut", so a mid-transfer disconnect exits 0 and atomically publishes a **truncated** page. Verified — a 4000-byte cut of a 12847-byte page published with the whole chain reporting success. The deploy now compares byte counts before renaming, removes the temp, emits a workflow warning, and prints the success URL only when the page was really published. Both the cut and the complete path were executed against a local tree with `ssh` stubbed.

The inlining contract (`coverage.html` must load the script by one exact tag) was enforced only by a runtime abort inside a `continue-on-error` step — reformat that tag and the deploy silently stops updating the published page forever, with a green build. It is asserted in `coverage.test.js` now, which runs on any change to that directory.

## Testing

- 31 pytest cases for the generator, 14 of them new for the coverage build
- `node tests/coverage.test.js` for the rendering logic, wired into the existing test workflow
- rendered locally against the real build data and walked in a browser: a normal branch, the underscore form normalising, a mixed-case feature branch, a non-reconciling suite, and a dropped suite whose reported total is `0`
- the deploy step itself extracted from the parsed YAML and executed with `ssh` stubbed
- eleven mutations run against the new code, eleven killed — re-verified with bytecode caching off after a stale `.pyc` was found masking a result (two swaps in one mutation happened to leave the file size unchanged) — including six that survived the first version of this PR (the `labelled` figure was asserted nowhere; the reconciliation gate, the non-integer-total filter and the JUnit-suite guard were unpinned)
- `normaliseBranch` differential-tested against the server's shell sanitisation pipeline over all 142 branches the host holds plus 167 local branch names: identical on all 309. The first version mirrored only one of six stages, so every mixed-case feature branch 404'd — including this PR's own.


## Corrections to earlier commit messages in this branch

Two claims in commits already pushed here are wrong, and history is not being rewritten to hide them:

- `4e67aa78f30` says `coverage.js` "was briefly deployed to the server root as a separate file". It never was — no publish has run for this branch (`/coverage.js` and `/coverage.html` are both 404, and the branch has no `_metadata` entry). The `rm -f coverage.js` in the deploy is still worth keeping as defensive cleanup, but the history given for it was invented.
- `ea900032790` says it removed two false statements; it removed one. The "39 leaves" figure had already been corrected in the parent commit `a0df9867b30`.

Three review rounds on this PR have each found a figure or a history asserted without measuring it. Every number in this description has been measured against the artefact it names.
