### PR TITLE
Merge: modus_operandi_release -> new_dawn_uat

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/material/dispo/AtpDivergenceReport_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/material/dispo/AtpDivergenceReport_StepDef.java
@@ -1,0 +1,146 @@
+package de.metas.cucumber.stepdefs.material.dispo;
+
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.M_Product_StepDefData;
+import de.metas.cucumber.stepdefs.productCategory.M_Product_Category_StepDefData;
+import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
+import de.metas.material.dispo.reconcile.process.MD_Candidate_ATP_Divergence_Report;
+import de.metas.process.AdProcessId;
+import de.metas.process.IADProcessDAO;
+import de.metas.process.ProcessExecutionResult;
+import de.metas.process.ProcessInfo;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Step definitions around the read-only {@code AD_Process} {@link MD_Candidate_ATP_Divergence_Report}:
+ * running it with an optional warehouse/product/product-category filter and asserting its resolved log
+ * text - the process writes nothing, so the log is the only outcome there is to assert on. Structured
+ * after the sibling {@code AtpReconciliationBackup_StepDef}'s own process-invocation steps.
+ */
+@RequiredArgsConstructor
+public class AtpDivergenceReport_StepDef
+{
+	@NonNull private final IADProcessDAO processDAO = Services.get(IADProcessDAO.class);
+
+	@NonNull private final M_Product_StepDefData productTable;
+	@NonNull private final M_Warehouse_StepDefData warehouseTable;
+	@NonNull private final M_Product_Category_StepDefData productCategoryTable;
+
+	/** Maps a scenario-local alias (e.g. {@code report_a}) to the resolved log text of the run it came from. */
+	private final Map<String, String> processLogByAlias = new HashMap<>();
+
+	/**
+	 * Invokes {@link MD_Candidate_ATP_Divergence_Report}. Every filter column is optional, matching the
+	 * process's own parameters; an omitted filter is not restricted on. The resolved log text (every
+	 * {@code {}} placeholder already substituted) is stored under {@code runIdAlias} for
+	 * {@link #assertProcessLogContains}/{@link #assertProcessLogDoesNotContain} to check afterwards.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_Product_ID</b> — (optional, identifier-ref) restricts the run to this product<br>
+	 *   <b>M_Warehouse_ID</b> — (optional, identifier-ref) restricts the run to this warehouse<br>
+	 *   <b>M_Product_Category_ID</b> — (optional, identifier-ref) restricts the run to this product category<br>
+	 * @cucumber.depends StepDefData: M_Product_StepDefData, M_Warehouse_StepDefData, M_Product_Category_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * When the MD_Candidate_ATP_Divergence_Report process is run with parameters, storing the run id as "report_a":
+	 *   | M_Product_Category_ID |
+	 *   | cat_report_a          |
+	 * </pre>
+	 */
+	@When("^the MD_Candidate_ATP_Divergence_Report process is run with parameters, storing the run id as \"([^\"]*)\":$")
+	public void runDivergenceReportProcess(
+			@NonNull final String runIdAlias,
+			@NonNull final DataTable dataTable)
+	{
+		final DataTableRow row = DataTableRows.of(dataTable).getFirstRow();
+
+		final AdProcessId processId = processDAO.retrieveProcessIdByClass(MD_Candidate_ATP_Divergence_Report.class);
+		final ProcessInfo.ProcessInfoBuilder processInfoBuilder = ProcessInfo.builder()
+				.setAD_Process_ID(processId.getRepoId());
+
+		row.getAsOptionalIdentifier("M_Warehouse_ID")
+				.ifPresent(identifier -> processInfoBuilder.addParameter("M_Warehouse_ID", warehouseTable.getId(identifier).getRepoId()));
+		row.getAsOptionalIdentifier("M_Product_ID")
+				.ifPresent(identifier -> processInfoBuilder.addParameter("M_Product_ID", productTable.getId(identifier).getRepoId()));
+		row.getAsOptionalIdentifier("M_Product_Category_ID")
+				.ifPresent(identifier -> processInfoBuilder.addParameter("M_Product_Category_ID", productCategoryTable.getId(identifier).getRepoId()));
+
+		final ProcessExecutionResult result = processInfoBuilder
+				.buildAndPrepareExecution()
+				.executeSync()
+				.getResult();
+
+		assertThat(result).as("MD_Candidate_ATP_Divergence_Report process result").isNotNull();
+		assertThat(result.isError()).as("MD_Candidate_ATP_Divergence_Report process failed: %s", result).isFalse();
+
+		processLogByAlias.put(runIdAlias, result.getLogInfo());
+	}
+
+	/**
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then the divergence report process log for the run id "report_a" contains "1 diverged"
+	 * </pre>
+	 */
+	@Then("^the divergence report process log for the run id \"([^\"]*)\" contains \"([^\"]*)\"$")
+	public void assertProcessLogContains(
+			@NonNull final String runIdAlias,
+			@NonNull final String expectedSubstring)
+	{
+		final String logText = processLogByAlias.get(runIdAlias);
+		assertThat(logText).as("no process log was stored for alias '%s' - the triggering step must run first", runIdAlias).isNotNull();
+		assertThat(logText).as("process log for run '%s'", runIdAlias).contains(expectedSubstring);
+	}
+
+	/**
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then the divergence report process log for the run id "report_a" does not contain "storedAtp=80, difference=0"
+	 * </pre>
+	 */
+	@Then("^the divergence report process log for the run id \"([^\"]*)\" does not contain \"([^\"]*)\"$")
+	public void assertProcessLogDoesNotContain(
+			@NonNull final String runIdAlias,
+			@NonNull final String unexpectedSubstring)
+	{
+		final String logText = processLogByAlias.get(runIdAlias);
+		assertThat(logText).as("no process log was stored for alias '%s' - the triggering step must run first", runIdAlias).isNotNull();
+		assertThat(logText).as("process log for run '%s'", runIdAlias).doesNotContain(unexpectedSubstring);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/material/dispo/AtpReconciliationBackup_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/material/dispo/AtpReconciliationBackup_StepDef.java
@@ -1,0 +1,297 @@
+package de.metas.cucumber.stepdefs.material.dispo;
+
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.common.util.time.SystemTime;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.M_Product_StepDefData;
+import de.metas.cucumber.stepdefs.StepDefConstants;
+import de.metas.cucumber.stepdefs.StepDefUtil;
+import de.metas.cucumber.stepdefs.productCategory.M_Product_Category_StepDefData;
+import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.dispo.model.I_MD_ATP_Reconciliation_Backup;
+import de.metas.material.dispo.reconcile.AtpReconciliationCommand;
+import de.metas.material.dispo.reconcile.AtpReconciliationRunLog;
+import de.metas.material.dispo.reconcile.process.MD_Candidate_Reconcile_ATP;
+import de.metas.material.event.commons.AttributesKey;
+import de.metas.process.AdProcessId;
+import de.metas.process.IADProcessDAO;
+import de.metas.process.ProcessExecutionResult;
+import de.metas.process.ProcessInfo;
+import de.metas.product.ProductCategoryId;
+import de.metas.product.ProductId;
+import de.metas.logging.LogManager;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.SpringContextHolder;
+import org.slf4j.Logger;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Step definitions around ATP reconciliation: invoking {@link AtpReconciliationCommand#reconcileAndLog} directly,
+ * invoking the operator-facing {@code AD_Process} {@link MD_Candidate_Reconcile_ATP}, and asserting the durable
+ * backup a run persists is recoverable from {@code MD_ATP_Reconciliation_Backup} - never from the in-process
+ * {@link AtpReconciliationRunLog} return value, which does not outlive the JVM that produced it.
+ * <p>
+ * <b>Scope note:</b> {@link #runReconciliation} validates the command layer only, not the real operator entry
+ * point - a real (non-dry) run through {@link MD_Candidate_Reconcile_ATP} is enqueued and never returns its
+ * {@code ReconciliationRunUUID} to the caller, so there is nothing for this scenario's run-id-keyed assertions to
+ * read back. An operator cannot reproduce this exact scenario from the WebUI today.
+ */
+@RequiredArgsConstructor
+public class AtpReconciliationBackup_StepDef
+{
+	private static final Logger logger = LogManager.getLogger(AtpReconciliationBackup_StepDef.class);
+
+	@NonNull private final IADProcessDAO processDAO = Services.get(IADProcessDAO.class);
+
+	@NonNull private final M_Product_StepDefData productTable;
+	@NonNull private final M_Warehouse_StepDefData warehouseTable;
+	@NonNull private final M_Product_Category_StepDefData productCategoryTable;
+
+	/** Maps a scenario-local alias (e.g. {@code run_a}) to the {@code ReconciliationRunUUID} it produced. */
+	private final Map<String, String> runUuidByAlias = new HashMap<>();
+
+	/** Maps a scenario-local alias to the full log text of the {@link MD_Candidate_Reconcile_ATP} run it came from. */
+	private final Map<String, String> processLogByAlias = new HashMap<>();
+
+	/**
+	 * Invokes {@link AtpReconciliationCommand#reconcileAndLog} directly for the given product/warehouse key (there
+	 * is no {@code AD_Process} for it yet - see the class Javadoc), establishing a real, non-dry-run correction and
+	 * storing its {@code ReconciliationRunUUID} under {@code runIdAlias} so a later step can look up the durable
+	 * backup it persisted (see {@link #assertBackupRow}).
+	 */
+	@When("the ATP reconciliation is run for M_Product_ID {string} and M_Warehouse_ID {string}, storing the run id as {string}")
+	public void runReconciliation(
+			@NonNull final String productIdentifier,
+			@NonNull final String warehouseIdentifier,
+			@NonNull final String runIdAlias)
+	{
+		final ProductId productId = productTable.getId(productIdentifier);
+		final WarehouseId warehouseId = warehouseTable.getId(warehouseIdentifier);
+
+		final StockDataRecordIdentifier key = StockDataRecordIdentifier.builder()
+				.clientId(StepDefConstants.CLIENT_ID)
+				.orgId(StepDefConstants.ORG_ID)
+				.warehouseId(warehouseId)
+				.productId(productId)
+				.storageAttributesKey(AttributesKey.NONE)
+				.build();
+
+		final AtpReconciliationCommand atpReconciliationCommand = SpringContextHolder.instance.getBean(AtpReconciliationCommand.class);
+		final AtpReconciliationRunLog runLog = atpReconciliationCommand.reconcileAndLog(key, SystemTime.asInstant(), false);
+
+		assertThat(runLog.getRunUuid())
+				.as("expected an actual correction (a persisted run id) for M_Product_ID=%s M_Warehouse_ID=%s - "
+						+ "check the scenario really set up a divergence for this key", productIdentifier, warehouseIdentifier)
+				.isNotNull();
+
+		runUuidByAlias.put(runIdAlias, runLog.getRunUuid());
+	}
+
+	/**
+	 * Reads {@code MD_ATP_Reconciliation_Backup} fresh from the database by the persisted run id - proving the
+	 * pre-change value and the after value both survive independently of the {@link AtpReconciliationRunLog}
+	 * object the triggering step already discarded.
+	 */
+	@Then("the persisted ATP reconciliation backup for the run id {string} contains a row with QtyBefore {string} and QtyAfter {string}")
+	public void assertBackupRow(
+			@NonNull final String runIdAlias,
+			@NonNull final String qtyBeforeText,
+			@NonNull final String qtyAfterText)
+	{
+		final String runUuid = runUuidByAlias.get(runIdAlias);
+		assertThat(runUuid).as("no run id was stored for alias '%s' - the triggering step must run first", runIdAlias).isNotNull();
+
+		final List<I_MD_ATP_Reconciliation_Backup> backedUpRows = Services.get(IQueryBL.class)
+				.createQueryBuilder(I_MD_ATP_Reconciliation_Backup.class)
+				.addEqualsFilter(I_MD_ATP_Reconciliation_Backup.COLUMNNAME_ReconciliationRunUUID, runUuid)
+				.create()
+				.list();
+
+		final boolean matchFound = backedUpRows.stream()
+				.anyMatch(row -> matchesQuantities(row, qtyBeforeText, qtyAfterText));
+
+		assertThat(matchFound)
+				.as("no persisted MD_ATP_Reconciliation_Backup row for run '%s' with QtyBefore=%s QtyAfter=%s among %s",
+						runUuid, qtyBeforeText, qtyAfterText, backedUpRows)
+				.isTrue();
+	}
+
+	/**
+	 * The asynchronous sibling of {@link #assertBackupRow}: reads {@code MD_ATP_Reconciliation_Backup} fresh from
+	 * the database by <b>product</b> rather than by run id, retrying until the row shows up.
+	 * <p>
+	 * Needed because a real {@link MD_Candidate_Reconcile_ATP} run no longer reconciles inline - it enqueues a
+	 * {@code C_Queue_WorkPackage} that the app server drains, so the caller never sees the run's
+	 * {@code ReconciliationRunUUID}, and the row appears some time after the process step returned. This step is
+	 * therefore how a scenario proves what an <i>operator-launched</i> real run actually changed: which candidate,
+	 * from which quantity to which. (The synchronous, run-id-keyed assertion above stays the stronger check
+	 * wherever the reconciliation is invoked directly.)
+	 * <p>
+	 * <b>Use it at most once per product per scenario.</b> Because it matches on the product alone, a second
+	 * real run of the same product would be asserted against the union of both runs' rows: it would pass on the
+	 * FIRST run's leftover row if the quantities happened to coincide, and could match that row while the second
+	 * run's has not landed yet. Two consecutive real runs of one product need the run-id-keyed assertion, i.e. a
+	 * way to carry the enqueued run's {@code ReconciliationRunUUID} back to the scenario.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then after not more than 60s, the persisted ATP reconciliation backup for M_Product_ID "p_reg4" contains a row with QtyBefore "null" and QtyAfter "60"
+	 * </pre>
+	 */
+	@Then("^after not more than (.*)s, the persisted ATP reconciliation backup for M_Product_ID \"([^\"]*)\" contains a row with QtyBefore \"([^\"]*)\" and QtyAfter \"([^\"]*)\"$")
+	public void assertBackupRowByProduct(
+			final int timeoutSec,
+			@NonNull final String productIdentifier,
+			@NonNull final String qtyBeforeText,
+			@NonNull final String qtyAfterText) throws InterruptedException
+	{
+		final ProductId productId = productTable.getId(productIdentifier);
+
+		StepDefUtil.tryAndWait(
+				timeoutSec,
+				500,
+				() -> retrieveBackupRowsByProduct(productId).stream()
+						.anyMatch(row -> matchesQuantities(row, qtyBeforeText, qtyAfterText)),
+				() -> logger.warn("*** no matching MD_ATP_Reconciliation_Backup row yet for M_Product_ID={}; rows so far: {}",
+						productId, retrieveBackupRowsByProduct(productId)));
+	}
+
+	private static List<I_MD_ATP_Reconciliation_Backup> retrieveBackupRowsByProduct(@NonNull final ProductId productId)
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_MD_ATP_Reconciliation_Backup.class)
+				.addEqualsFilter(I_MD_ATP_Reconciliation_Backup.COLUMNNAME_M_Product_ID, productId)
+				.create()
+				.list();
+	}
+
+	/**
+	 * @param qtyBeforeText the literal {@code null} matches a row this run created (no earlier value to back up)
+	 */
+	private static boolean matchesQuantities(
+			@NonNull final I_MD_ATP_Reconciliation_Backup row,
+			@NonNull final String qtyBeforeText,
+			@NonNull final String qtyAfterText)
+	{
+		final boolean qtyAfterMatches = row.getQtyAfter().compareTo(new BigDecimal(qtyAfterText)) == 0;
+		final boolean qtyBeforeMatches = "null".equalsIgnoreCase(qtyBeforeText)
+				? InterfaceWrapperHelper.isNull(row, I_MD_ATP_Reconciliation_Backup.COLUMNNAME_QtyBefore)
+				: row.getQtyBefore().compareTo(new BigDecimal(qtyBeforeText)) == 0;
+
+		return qtyAfterMatches && qtyBeforeMatches;
+	}
+
+	/**
+	 * Invokes the operator-facing {@code AD_Process} {@link MD_Candidate_Reconcile_ATP} - the real entry point an
+	 * operator uses, as opposed to {@link #runReconciliation} above, which calls the underlying command
+	 * directly. Every filter column is optional, matching the process's own parameters; an omitted filter is not
+	 * restricted on. The process's resolved log text (every value it changed or, on a dry run, would have changed)
+	 * is stored under {@code runIdAlias} for {@link #assertProcessLogContains} to check afterwards.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_Product_ID</b> — (optional, identifier-ref) restricts the run to this product<br>
+	 *   <b>M_Warehouse_ID</b> — (optional, identifier-ref) restricts the run to this warehouse<br>
+	 *   <b>M_Product_Category_ID</b> — (optional, identifier-ref) restricts the run to this product category<br>
+	 *   <b>IsDryRun</b> — (optional, defaults false) when true, nothing is written; the log reports what would change<br>
+	 *   <b>LivenessCutoffDate</b> — (optional, ISO local date) a candidate dated strictly before this date is
+	 *   treated as closed regardless of its source document's own status<br>
+	 * @cucumber.depends StepDefData: M_Product_StepDefData, M_Warehouse_StepDefData, M_Product_Category_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * When the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as "dry_run":
+	 *   | M_Product_ID | IsDryRun |
+	 *   | p_dry_a      | true     |
+	 * </pre>
+	 */
+	@When("^the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as \"([^\"]*)\":$")
+	public void runReconciliationProcess(
+			@NonNull final String runIdAlias,
+			@NonNull final DataTable dataTable)
+	{
+		final DataTableRow row = DataTableRows.of(dataTable).getFirstRow();
+
+		final AdProcessId processId = processDAO.retrieveProcessIdByClass(MD_Candidate_Reconcile_ATP.class);
+		final ProcessInfo.ProcessInfoBuilder processInfoBuilder = ProcessInfo.builder()
+				.setAD_Process_ID(processId.getRepoId());
+
+		row.getAsOptionalIdentifier("M_Warehouse_ID")
+				.ifPresent(identifier -> processInfoBuilder.addParameter("M_Warehouse_ID", warehouseTable.getId(identifier).getRepoId()));
+		row.getAsOptionalIdentifier("M_Product_ID")
+				.ifPresent(identifier -> processInfoBuilder.addParameter("M_Product_ID", productTable.getId(identifier).getRepoId()));
+		row.getAsOptionalIdentifier("M_Product_Category_ID")
+				.ifPresent(identifier -> processInfoBuilder.addParameter("M_Product_Category_ID", productCategoryTable.getId(identifier).getRepoId()));
+		processInfoBuilder.addParameter("IsDryRun", row.getAsOptionalBoolean("IsDryRun").orElseFalse());
+		row.getAsOptionalLocalDateTimestamp("LivenessCutoffDate")
+				.ifPresent(cutoff -> processInfoBuilder.addParameter("LivenessCutoffDate", cutoff));
+
+		final ProcessExecutionResult result = processInfoBuilder
+				.buildAndPrepareExecution()
+				.executeSync()
+				.getResult();
+
+		assertThat(result).as("MD_Candidate_Reconcile_ATP process result").isNotNull();
+		assertThat(result.isError()).as("MD_Candidate_Reconcile_ATP process failed: %s", result).isFalse();
+
+		processLogByAlias.put(runIdAlias, result.getLogInfo());
+	}
+
+	/**
+	 * Asserts that the resolved log text of a {@link #runReconciliationProcess} run - every {@code {}} placeholder
+	 * already substituted with its real value - contains the given substring. Used to prove a dry run reports the
+	 * value it would have changed to, without writing anything.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then the ATP reconciliation process log for the run id "dry_run" contains "would change to 100"
+	 * </pre>
+	 */
+	@Then("^the ATP reconciliation process log for the run id \"([^\"]*)\" contains \"([^\"]*)\"$")
+	public void assertProcessLogContains(
+			@NonNull final String runIdAlias,
+			@NonNull final String expectedSubstring)
+	{
+		final String logText = processLogByAlias.get(runIdAlias);
+		assertThat(logText).as("no process log was stored for alias '%s' - the triggering step must run first", runIdAlias).isNotNull();
+		assertThat(logText).as("process log for run '%s'", runIdAlias).contains(expectedSubstring);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/material/dispo/MD_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/material/dispo/MD_Candidate_StepDef.java
@@ -44,8 +44,10 @@ import de.metas.cucumber.stepdefs.pporder.PP_OrderLine_Candidate_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.PP_Order_BOMLine_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.PP_Order_Candidate_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.PP_Order_StepDefData;
+import de.metas.cucumber.stepdefs.rabbitMQ.RabbitMQ_StepDef;
 import de.metas.i18n.Language;
 import de.metas.logging.LogManager;
+import de.metas.material.cockpit.model.I_MD_Stock;
 import de.metas.material.dispo.commons.SimulatedCandidateService;
 import de.metas.material.dispo.commons.candidate.Candidate;
 import de.metas.material.dispo.commons.candidate.CandidateBusinessCase;
@@ -64,7 +66,10 @@ import de.metas.material.event.MaterialEventObserver;
 import de.metas.material.event.PostMaterialEventService;
 import de.metas.material.event.commons.AttributesKey;
 import de.metas.material.event.commons.EventDescriptor;
+import de.metas.material.event.commons.ProductDescriptor;
 import de.metas.material.event.simulation.DeactivateAllSimulatedCandidatesEvent;
+import de.metas.material.event.stock.ResetStockPInstanceId;
+import de.metas.material.event.stock.StockChangedEvent;
 import de.metas.material.event.stockestimate.AbstractStockEstimateEvent;
 import de.metas.material.event.stockestimate.StockEstimateCreatedEvent;
 import de.metas.material.event.stockestimate.StockEstimateDeletedEvent;
@@ -109,6 +114,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import static de.metas.cucumber.stepdefs.material.dispo.CandidatesToTabularStringConverter.toTabularStringFromCandidateRows;
@@ -122,6 +128,12 @@ import static de.metas.material.dispo.model.I_MD_Candidate.COLUMNNAME_Qty;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
+/**
+ * Step definitions for {@code MD_Candidate} — the material-disposition candidates that carry the
+ * projected ATP. Covers creating and asserting candidates and their detail rows, posting material
+ * events that make the dispo engine build a candidate chain, and reading the resulting running ATP
+ * off the {@code STOCK} candidates.
+ */
 @RequiredArgsConstructor
 public class MD_Candidate_StepDef
 {
@@ -149,6 +161,8 @@ public class MD_Candidate_StepDef
 	@NonNull private final PP_OrderLine_Candidate_StepDefData ppOrderLineCandidateTable;
 	@NonNull private final PP_Order_StepDefData ppOrderTable;
 	@NonNull private final PP_Order_BOMLine_StepDefData ppOrderBOMLineTable;
+
+	@NonNull private final RabbitMQ_StepDef rabbitMQStepDef;
 
 	@When("metasfresh initially has this MD_Candidate data")
 	public void metasfresh_has_this_md_candidate_data1(@NonNull final MD_Candidate_StepDefTable table) throws Throwable
@@ -426,10 +440,53 @@ public class MD_Candidate_StepDef
 				.execute();
 	}
 
+	/**
+	 * Waits (up to {@code timeoutSec} seconds) for each expected {@code MD_Candidate} row to appear, then
+	 * asserts it against the given DataTable row.
+	 * <p>
+	 * Drains the {@code de.metas.material} RabbitMQ queue before validating, rather than leaving that as a
+	 * standalone feature-file step (see {@code de.metas.cucumber/CLAUDE.md} rule 7). This consumer's
+	 * {@link #tryAndWaitForCandidate} already matches a <em>complete</em> candidate row (type, business case,
+	 * product, date, qty, ATP) that no later event revises, so draining first only adds a settled read on top
+	 * of that poll - it never masks a real failure.
+	 * <p>
+	 * DataTable columns (one row per expected candidate):
+	 * <ul>
+	 * <li>{@code Identifier} - registers the matched candidate under this name for later steps</li>
+	 * <li>{@code MD_Candidate_Type} - required; a {@link CandidateType} (e.g. {@code DEMAND}, {@code SUPPLY},
+	 * {@code INVENTORY_UP})</li>
+	 * <li>{@code OPT.MD_Candidate_BusinessCase} - a {@link CandidateBusinessCase} (e.g. {@code SHIPMENT},
+	 * {@code PURCHASE}, {@code PRODUCTION}); omit for a plain {@code STOCK}/inventory candidate with no
+	 * business case</li>
+	 * <li>{@code M_Product_ID} - required; a product identifier</li>
+	 * <li>{@code DateProjected} - required (or {@code OPT.DateProjected_LocalTimeZone} as a local-timezone
+	 * alternative)</li>
+	 * <li>{@code Qty} - required; the candidate's own quantity (sign is normalized internally for
+	 * decreasing-stock candidate types, e.g. {@code DEMAND})</li>
+	 * <li>{@code OPT.ATP} (or the older {@code OPT.Qty_AvailableToPromise}) - the running ATP on the
+	 * candidate's STOCK parent/child; defaults to {@code 0} if neither is given</li>
+	 * <li>{@code OPT.M_Warehouse_ID}, {@code OPT.M_AttributeSetInstance_ID}, {@code OPT.simulated} - optional
+	 * refinements</li>
+	 * <li>{@code OPT.DD_Order_Candidate_ID} / {@code DD_Order_ID} / {@code DD_OrderLine_ID}, and the
+	 * {@code Forward_PP_*} / {@code PP_Order_Candidate_ID} family - optional distribution/production linkage
+	 * columns</li>
+	 * </ul>
+	 * <p>
+	 * Gherkin:
+	 * <pre>
+	 * {@code
+	 * Then after not more than 60s, MD_Candidates are found
+	 *   | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+	 *   | d_1        | DEMAND            | SHIPMENT                  | p_1          | 2024-09-21T21:00:00Z | -30 | 70  | WH_1           |
+	 * }
+	 * </pre>
+	 */
 	@And("^after not more than (.*)s, MD_Candidates are found$")
 	public void validate_md_candidates(final int timeoutSec, @NonNull final MD_Candidate_StepDefTable table) throws Throwable
 	{
 		final Stopwatch stopwatch = Stopwatch.createStarted();
+
+		rabbitMQStepDef.waitEmptyMaterialQueue();
 
 		final HashMap<CandidateId, StepDefDataIdentifier> candidateIdsAlreadyMatched = new HashMap<>();
 		table.forEach((row) -> {
@@ -779,4 +836,165 @@ public class MD_Candidate_StepDef
 		assertThat(result.isError()).isFalse();
 	}
 
+	/**
+	 * Deletes the {@code MD_Candidate_Demand_Detail} row(s) of the given candidate, leaving its
+	 * {@code M_ShipmentSchedule} referenced by no active candidate at all - simulating the drift the
+	 * divergence report's uncovered-document check exists to find (e.g. a candidate purged by a cleanup job
+	 * while its source document survives).
+	 * <p>
+	 * Gherkin: {@code the MD_Candidate_Demand_Detail of <candidateIdentifier> is deleted}
+	 */
+	@And("^the MD_Candidate_Demand_Detail of (.*) is deleted$")
+	public void delete_md_candidate_demand_detail(@NonNull final String candidateIdentifier)
+	{
+		final CandidateId candidateId = materialDispoDataItemStepDefData.get(candidateIdentifier).getCandidateId();
+
+		final List<I_MD_Candidate_Demand_Detail> detailRecords = queryBL.createQueryBuilder(I_MD_Candidate_Demand_Detail.class)
+				.addEqualsFilter(I_MD_Candidate_Demand_Detail.COLUMNNAME_MD_Candidate_ID, candidateId.getRepoId())
+				.create()
+				.list();
+		assertThat(detailRecords).as("MD_Candidate_Demand_Detail of %s", candidateIdentifier).isNotEmpty();
+
+		detailRecords.forEach(InterfaceWrapperHelper::delete);
+	}
+
+	/**
+	 * Sets the ATP baseline from MD_Stock: for the given product, posts one reset-stock
+	 * {@link StockChangedEvent} per MD_Stock row,
+	 * carrying that row's current QtyOnHand. Mirrors what
+	 * StockDataUpdateRequestHandler.fireStockChangedEvent builds, but WITHOUT the old==new guard.
+	 * <p>
+	 * Note: <code>qtyOnHandOld</code> is the quantity the refresh found <em>stored</em> before it wrote the one the
+	 * event now carries. It defaults to the very <code>MD_Stock.QtyOnHand</code> the event's <code>qtyOnHand</code>
+	 * is taken from, because this step never changes <code>MD_Stock</code>: a scenario that says nothing therefore
+	 * posts a refresh that found the stored quantity exactly where it was, and the event's physical movement
+	 * (<code>qtyOnHand - qtyOnHandOld</code>) is genuinely zero. Use the optional <code>QtyOnHandOld</code> column
+	 * to model a refresh that found the stored quantity off by that much - which is the only shape the reset-stock
+	 * process actually emits, since it recomputes <code>MD_Stock</code> from the HUs and skips every key whose
+	 * quantity did not move.
+	 * <p>
+	 * That difference is load-bearing, not cosmetic. Two consumers read it:
+	 * <ul>
+	 * <li><code>StockChangedEventHandler.computeQtyDifference</code>: for a chain that carries an unfulfilled
+	 * <code>DEMAND</code>/<code>SUPPLY</code> at or before the event date, the created candidate's <b>type and
+	 * quantity</b> are that difference - <code>INVENTORY_UP</code>/<code>INVENTORY_DOWN</code> of its absolute
+	 * value, or no candidate at all when it is zero;
+	 * <li>the <code>MovementQty</code> persisted on the resulting <code>MD_Candidate_Transaction_Detail</code> row;
+	 * no scenario asserts that column, but do not rely on it.
+	 * </ul>
+	 * <p>
+	 * Drains the {@code de.metas.material} RabbitMQ queue before posting the event (see
+	 * {@code de.metas.cucumber/CLAUDE.md} rule 7): a still-pending event from an earlier step (e.g. an
+	 * open-demand order completion) must have finished materializing its {@code MD_Candidate} before this
+	 * step's own {@link StockChangedEvent} enters the chain, or the reconciliation the event triggers
+	 * builds forward from an incomplete chain.
+	 * <p>
+	 * Gherkin:
+	 * <pre>
+	 * When metasfresh receives a StockChangedEvent for the current MD_Stock
+	 *   | M_Product_ID | OPT.ChangeDate       | OPT.QtyOnHandOld |
+	 *   | p_od_1       | 2024-09-23T06:00:00Z | 150              |
+	 * </pre>
+	 */
+	@And("^metasfresh receives a StockChangedEvent for the current MD_Stock$")
+	public void metasfresh_receives_stock_changed_event(@NonNull final DataTable dataTable) throws InterruptedException
+	{
+		rabbitMQStepDef.waitEmptyMaterialQueue();
+
+		DataTableRows.of(dataTable).forEach(this::postStockChangedEventsForCurrentStock);
+	}
+
+	/**
+	 * Posts one reset-stock {@link StockChangedEvent} per {@code MD_Stock} row of the row's product.
+	 * See {@link #metasfresh_receives_stock_changed_event(DataTable)} for the {@code qtyOnHandOld} caveat.
+	 */
+	private void postStockChangedEventsForCurrentStock(@NonNull final DataTableRow row)
+	{
+		final StepDefDataIdentifier productIdentifier = row.getAsIdentifier(I_M_Product.COLUMNNAME_M_Product_ID);
+		final int productId = productTable.get(productIdentifier).getM_Product_ID();
+
+		final Instant changeDate = row.getAsOptionalInstant("ChangeDate").orElse(null);
+		final BigDecimal qtyOnHandOldOverride = row.getAsOptionalBigDecimal("QtyOnHandOld").orElse(null);
+
+		final List<I_MD_Stock> stockRecords = queryBL.createQueryBuilderOutOfTrx(I_MD_Stock.class)
+				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, productId)
+				.create()
+				.list(I_MD_Stock.class);
+		assertThat(stockRecords).as("MD_Stock rows for product %s", productIdentifier).isNotEmpty();
+
+		for (final I_MD_Stock stockRecord : stockRecords)
+		{
+			final AttributesKey attributesKey = AttributesKeys.pruneEmptyParts(AttributesKey.ofString(stockRecord.getAttributesKey()));
+			final AttributeSetInstanceId asiId = AttributesKeys.createAttributeSetInstanceFromAttributesKey(attributesKey);
+
+			final StockChangedEvent event = StockChangedEvent.builder()
+					.eventDescriptor(EventDescriptor.ofClientAndOrg(stockRecord.getAD_Client_ID(), stockRecord.getAD_Org_ID()))
+					.productDescriptor(ProductDescriptor.forProductAndAttributes(productId, attributesKey, asiId.getRepoId()))
+					.warehouseId(WarehouseId.ofRepoId(stockRecord.getM_Warehouse_ID()))
+					.qtyOnHand(stockRecord.getQtyOnHand())
+					// A ZERO default measured ATP 1200 instead of 170 on the open-demand-before-the-baseline scenario.
+					.qtyOnHandOld(CoalesceUtil.coalesce(qtyOnHandOldOverride, stockRecord.getQtyOnHand()))
+					.changeDate(changeDate)
+					.stockChangeDetails(StockChangedEvent.StockChangeDetails.builder()
+							.resetStockPInstanceId(ResetStockPInstanceId.ofRepoId(nextResetStockPInstanceRepoId()))
+							.stockId(stockRecord.getMD_Stock_ID())
+							.build())
+					.build();
+
+			postMaterialEventService.enqueueEventNow(event);
+		}
+	}
+
+	/**
+	 * Overwrites the running ATP of one candidate's STOCK record, to set up a chain that has drifted
+	 * away from the physical stock.
+	 * <p>
+	 * Gherkin: {@code the ATP of the STOCK candidate of <candidateIdentifier> is manually set to <newAtp>}
+	 */
+	@And("^the ATP of the STOCK candidate of (.*) is manually set to (.*)$")
+	public void set_stock_candidate_atp(@NonNull final String candidateIdentifier, @NonNull final String newAtpStr)
+	{
+		final BigDecimal newAtp = new BigDecimal(newAtpStr.trim());
+
+		final CandidateId candidateId = materialDispoDataItemStepDefData.get(candidateIdentifier).getCandidateId();
+		final I_MD_Candidate candidateRecord = InterfaceWrapperHelper.load(candidateId.getRepoId(), I_MD_Candidate.class);
+		assertThat(candidateRecord).isNotNull();
+
+		I_MD_Candidate stockRecord = null;
+
+		final int parentId = candidateRecord.getMD_Candidate_Parent_ID();
+		if (parentId > 0)
+		{
+			final I_MD_Candidate parentRecord = InterfaceWrapperHelper.load(parentId, I_MD_Candidate.class);
+			if (parentRecord != null && CandidateType.STOCK.getCode().equals(parentRecord.getMD_Candidate_Type()))
+			{
+				stockRecord = parentRecord;
+			}
+		}
+		if (stockRecord == null)
+		{
+			stockRecord = queryBL.createQueryBuilderOutOfTrx(I_MD_Candidate.class)
+					.addEqualsFilter(I_MD_Candidate.COLUMNNAME_MD_Candidate_Parent_ID, candidateId.getRepoId())
+					.addEqualsFilter(I_MD_Candidate.COLUMNNAME_MD_Candidate_Type, CandidateType.STOCK.getCode())
+					.create()
+					.firstOnly(I_MD_Candidate.class);
+		}
+		assertThat(stockRecord).as("STOCK candidate of %s", candidateIdentifier).isNotNull();
+
+		stockRecord.setQty(newAtp);
+		InterfaceWrapperHelper.save(stockRecord);
+	}
+
+	/**
+	 * A UNIQUE synthetic reset-stock pinstance id per posted event. It must be unique: the engine looks
+	 * its own MD_Candidate_Transaction_Detail up by AD_PInstance_ResetStock_ID, so a constant makes that
+	 * lookup throw QueryMoreThanOneRecordsFound on the second event and the STOCK chain is never built.
+	 */
+	private static final AtomicInteger RESET_STOCK_PINSTANCE_SEQ =
+			new AtomicInteger((int)(System.currentTimeMillis() / 1000L));
+
+	private static int nextResetStockPInstanceRepoId()
+	{
+		return RESET_STOCK_PINSTANCE_SEQ.incrementAndGet();
+	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
@@ -113,6 +113,11 @@ import static de.metas.cucumber.stepdefs.StepDefConstants.TABLECOLUMN_IDENTIFIER
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Step definitions for {@code PP_Order} — manufacturing orders. Covers creating orders and their
+ * BOM lines, driving their document actions (complete, close, reactivate, void), and asserting the
+ * resulting order state.
+ */
 public class PP_Order_StepDef
 {
 	private static final AdMessageKey MISSING_PRODUCT_PLU_CONFIG = AdMessageKey.of("de.metas.externalsystem.leichmehl.ExportPPOrderToLeichMehlService.MissingPLUConfigForProduct");
@@ -383,7 +388,14 @@ public class PP_Order_StepDef
 		}
 	}
 
-	@And("^the manufacturing order identified by (.*) is (reactivated|completed)$")
+	/**
+	 * Runs a document action on the manufacturing order behind the given identifier and waits for the
+	 * resulting doc status: {@code reactivated} to {@code IsInProgress}, {@code completed} to
+	 * {@code IsCompleted}, {@code closed} to {@code IsClosed}.
+	 * <p>
+	 * Gherkin: {@code the manufacturing order identified by <identifier> is <reactivated|completed|closed>}
+	 */
+	@And("^the manufacturing order identified by (.*) is (reactivated|completed|closed)$")
 	public void order_action(
 			@NonNull final String orderIdentifier,
 			@NonNull final String action)
@@ -399,6 +411,12 @@ public class PP_Order_StepDef
 			case completed:
 				orderRecord.setDocAction(IDocument.ACTION_Complete);
 				documentBL.processEx(orderRecord, IDocument.ACTION_Complete, IDocument.STATUS_Completed);
+				break;
+			case closed:
+				// Closes a manufacturing order WITHOUT issuing its components — the BOM demand stays
+				// un-issued, which leaves the ATP decremented for stock that was never consumed.
+				orderRecord.setDocAction(IDocument.ACTION_Close);
+				documentBL.processEx(orderRecord, IDocument.ACTION_Close, IDocument.STATUS_Closed);
 				break;
 			default:
 				throw new AdempiereException("Unhandled PP_Order action")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
@@ -102,6 +102,17 @@ public class RabbitMQ_StepDef
 		waitEmptyMaterialQueue();
 	}
 
+	/**
+	 * Drains the {@code de.metas.material} RabbitMQ queue, i.e. blocks until it is empty or throws after 5 minutes.
+	 * This is the internal collaborator API for a step def that internalizes its own drain (see
+	 * {@code de.metas.cucumber/CLAUDE.md} rule 7) — use this method, not the Gherkin-bound
+	 * {@link #wait_empty_material_queue()}.
+	 */
+	public void waitEmptyMaterialQueue() throws InterruptedException
+	{
+		waitEmptyMaterialQueueInternal();
+	}
+
 	@Given("rabbitMQ queue is created")
 	public void create_queue(@NonNull final DataTable dataTable)
 	{
@@ -335,7 +346,7 @@ public class RabbitMQ_StepDef
 									  .build());
 	}
 
-	private void waitEmptyMaterialQueue() throws InterruptedException
+	private void waitEmptyMaterialQueueInternal() throws InterruptedException
 	{
 		final long nowMillis = System.currentTimeMillis();
 		final long deadLineMillis = nowMillis + (300 * 1000L);    // dev-note: await maximum 5 minutes

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_baseline_after_cleanup.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_baseline_after_cleanup.feature
@@ -1,0 +1,124 @@
+@from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F19000_Material_Dispo
+@ghActions:run_on_executor6
+Feature: ATP baseline from physical stock after an MD_Candidate cleanup
+## After historic candidates are zeroed, the ATP chain restarts at 0 while the physical stock is still
+## correct. Question under test: can a physical inventory put the current stock back into the ATP
+## without touching the physical stock?
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-09-20T08:00:00+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+    And load M_Product_Category:
+      | Identifier             | Name     | Value    |
+      | standard_category_base | Standard | Standard |
+    And metasfresh contains M_Warehouse:
+      | Identifier |
+      | WH_BASE    |
+
+  @Id:ATPBASE_001
+  @from:cucumber
+  Scenario: An inventory whose count equals the book stock does NOT restore a zeroed ATP
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID  | C_UOM_ID.X12DE355 |
+      | p_base_1   | standard_category_base | PCE               |
+
+    # --- step 1: physical stock of 100 exists, ATP is 100 -------------------------------
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_1_a    | WH_BASE        | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_1_a        | invl_1_a   | p_base_1     | 0       | 100      | WH_BASE        | PCE          |
+    And the inventory identified by inv_1_a is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_1_a   | INVENTORY_UP      | p_base_1     | 2024-09-20T06:00:00Z | 100 | 100 | WH_BASE        |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_base_1                | 100       |
+
+    # --- step 2: the customer's cleanup - zero the historic candidate --------------------
+    When the MD_Candidate_Remove_From_ATP process is run
+      | MD_Candidate_ID |
+      | cand_1_a        |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_1_a   | INVENTORY_UP      | p_base_1     | 2024-09-20T06:00:00Z | 0   | 0   | WH_BASE        |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_base_1                | 100       |
+
+    # --- step 3: the proposed fix - count the (correct) physical stock -------------------
+    When metasfresh has date and time 2024-09-21T08:00:00+01:00[Europe/Berlin]
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_1_b    | WH_BASE        | 2024-09-21   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_1_b        | invl_1_b   | p_base_1     | 100     | 100      | WH_BASE        | PCE          |
+    And the inventory identified by inv_1_b is completed
+
+    # --- result: ATP is still 0 -----------------------------------------------------------
+    # The engine mirrors EVERY inventory M_Transaction 1:1 into an INVENTORY_UP/DOWN candidate, and a
+    # zero-movement line (QtyCount == QtyBook) still books one such transaction with MovementQty 0. So a
+    # second, zero-quantity INVENTORY_DOWN candidate appears. It leaves ATP at 0 — which is exactly this
+    # scenario's point: counting the correct physical stock does NOT restore a zeroed ATP.
+    Then after not more than 60s, the MD_Candidate table has only the following records
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_1_a   | INVENTORY_UP      |                           | p_base_1     | 2024-09-20T06:00:00Z | 0   | 0   | WH_BASE        |
+      | cand_1_b   | INVENTORY_DOWN    |                           | p_base_1     | 2024-09-21T06:00:00Z | 0   | 0   | WH_BASE        |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_base_1                | 100       |
+
+  @Id:ATPBASE_002
+  @from:cucumber
+  Scenario: Forcing the ATP up with a book-value-0 inventory double-counts the physical stock
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID  | C_UOM_ID.X12DE355 |
+      | p_base_2   | standard_category_base | PCE               |
+
+    # --- step 1: physical stock of 100 exists, ATP is 100 -------------------------------
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_2_a    | WH_BASE        | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_2_a        | invl_2_a   | p_base_2     | 0       | 100      | WH_BASE        | PCE          |
+    And the inventory identified by inv_2_a is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_2_a   | INVENTORY_UP      | p_base_2     | 2024-09-20T06:00:00Z | 100 | 100 | WH_BASE        |
+
+    # --- step 2: zero it, as the cleanup would --------------------------------------------
+    When the MD_Candidate_Remove_From_ATP process is run
+      | MD_Candidate_ID |
+      | cand_2_a        |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_2_a   | INVENTORY_UP      | p_base_2     | 2024-09-20T06:00:00Z | 0   | 0   | WH_BASE        |
+
+    # --- step 3: pretend the book value is 0 so the inventory produces a +100 movement ----
+    When metasfresh has date and time 2024-09-21T08:00:00+01:00[Europe/Berlin]
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_2_b    | WH_BASE        | 2024-09-21   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_2_b        | invl_2_b   | p_base_2     | 0       | 100      | WH_BASE        | PCE          |
+    And the inventory identified by inv_2_b is completed
+
+    # --- result: ATP is back to 100, but the physical stock is now 200 (double-counted) ---
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_2_b   | INVENTORY_UP      | p_base_2     | 2024-09-21T06:00:00Z | 100 | 100 | WH_BASE        |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_base_2                | 200       |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_baseline_with_open_demand.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_baseline_with_open_demand.feature
@@ -1,0 +1,304 @@
+@from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F19000_Material_Dispo
+@ghActions:run_on_executor6
+Feature: ATP baseline from MD_Stock when an open sales order precedes it
+## Does a reset-stock StockChangedEvent still honour an open, unshipped demand? Business-correct answer
+## in both scenarios: ATP = stock 200 - open demand 30 = 170.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-09-20T08:00:00+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+    And load M_Product_Category:
+      | Identifier | Name     | Value    |
+      | std_cat_od | Standard | Standard |
+    And metasfresh contains M_Warehouse:
+      | Identifier |
+      | WH_OD      |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_od      |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl_so_od   | ps_od              | DE           | EUR           | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_so_od  | pl_so_od       |
+    And metasfresh contains C_BPartners:
+      | Identifier  | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | customer_od | N        | Y          | ps_od              |
+
+  @Id:ATPBASE_003
+  @from:cucumber
+  Scenario: Open demand dated BEFORE the baseline
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID | C_UOM_ID.X12DE355 |
+      | p_od_1     | std_cat_od            | PCE               |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID |
+      | pp_od_1    | plv_so_od              | p_od_1       | 10.0     | PCE               | Normal           |
+
+    # 1) inventory of 100
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_od_1a  | WH_OD          | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_od_1a      | invl_od_1a | p_od_1       | 0       | 100      | WH_OD          | PCE          |
+    And the inventory identified by inv_od_1a is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | c_od_1a    | INVENTORY_UP      | p_od_1       | 2024-09-20T06:00:00Z | 100 | 100 | WH_OD          |
+
+    # 2) sales order for 30, NO shipment
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | PreparationDate      | M_Warehouse_ID |
+      | so_od_1    | true    | customer_od   | 2024-09-20  | 2024-09-21T21:00:00Z | WH_OD          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_od_1   | so_od_1    | p_od_1       | 30         |
+    And the order identified by so_od_1 is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | d_od_1     | DEMAND            | SHIPMENT                  | p_od_1       | 2024-09-21T21:00:00Z | -30 | 70  | WH_OD          |
+
+    # 3) inventory of 200, then corrupt its ATP to 1000
+    And metasfresh has date and time 2024-09-22T08:00:00+01:00[Europe/Berlin]
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_od_1b  | WH_OD          | 2024-09-22   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_od_1b      | invl_od_1b | p_od_1       | 100     | 200      | WH_OD          | PCE          |
+    And the inventory identified by inv_od_1b is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | c_od_1b    | INVENTORY_UP      | p_od_1       | 2024-09-22T06:00:00Z | 100 | 170 | WH_OD          |
+    And the ATP of the STOCK candidate of c_od_1b is manually set to 1000
+
+    # 4) the reconciliation point is the mechanism this scenario is actually about: a reset-stock event
+    # re-baselines onto bare physical stock and would land here at 200, silently absorbing the still-open
+    # demand - the reconciliation is the mechanism that must not do that.
+    When metasfresh has date and time 2024-09-23T08:00:00+01:00[Europe/Berlin]
+    And the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as "reconcile_od_1":
+      | M_Product_ID | IsDryRun |
+      | p_od_1       | false    |
+
+    # business-correct expectation: stock 200 minus the still-open demand 30 = 170
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty  | ATP | M_Warehouse_ID |
+      | base_od_1  | INVENTORY_DOWN    | ATP_RECONCILE             | p_od_1       | 2024-09-23T06:00:00Z | -830 | 170 | WH_OD          |
+
+  @Id:ATPBASE_004
+  @from:cucumber
+  Scenario: Open demand dated AFTER the baseline
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID | C_UOM_ID.X12DE355 |
+      | p_od_2     | std_cat_od            | PCE               |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID |
+      | pp_od_2    | plv_so_od              | p_od_2       | 10.0     | PCE               | Normal           |
+
+    # 1) inventory of 100
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_od_2a  | WH_OD          | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_od_2a      | invl_od_2a | p_od_2       | 0       | 100      | WH_OD          | PCE          |
+    And the inventory identified by inv_od_2a is completed
+
+    # 2) inventory of 200, then corrupt its ATP to 1000
+    And metasfresh has date and time 2024-09-22T08:00:00+01:00[Europe/Berlin]
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_od_2b  | WH_OD          | 2024-09-22   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_od_2b      | invl_od_2b | p_od_2       | 100     | 200      | WH_OD          | PCE          |
+    And the inventory identified by inv_od_2b is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | c_od_2b    | INVENTORY_UP      | p_od_2       | 2024-09-22T06:00:00Z | 100 | 200 | WH_OD          |
+    And the ATP of the STOCK candidate of c_od_2b is manually set to 1000
+
+    # 3) sales order for 30 dated AFTER the baseline date, NO shipment
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | PreparationDate      | M_Warehouse_ID |
+      | so_od_2    | true    | customer_od   | 2024-09-22  | 2024-09-25T21:00:00Z | WH_OD          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_od_2   | so_od_2    | p_od_2       | 30         |
+    And the order identified by so_od_2 is completed
+
+    # 4) post the reset-stock event; MD_Stock is still 200
+    When metasfresh receives a StockChangedEvent for the current MD_Stock
+      | M_Product_ID | OPT.ChangeDate       |
+      | p_od_2       | 2024-09-23T06:00:00Z |
+
+    # business-correct expectation: the later demand still applies -> 200 - 30 = 170
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | d_od_2     | DEMAND            | SHIPMENT                  | p_od_2       | 2024-09-25T21:00:00Z | -30 | 170 | WH_OD          |
+
+  @Id:ATPBASE_005
+  @from:cucumber
+  Scenario: Shipping an open order does not change the ATP — expected decrease becomes certain decrease
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID | C_UOM_ID.X12DE355 |
+      | p_od_3     | std_cat_od            | PCE               |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID |
+      | pp_od_3    | plv_so_od              | p_od_3       | 10.0     | PCE               | Normal           |
+
+    # stock of 100
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_od_3   | WH_OD          | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_od_3       | invl_od_3  | p_od_3       | 0       | 100      | WH_OD          | PCE          |
+    And the inventory identified by inv_od_3 is completed
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_od_3                  | 100       |
+
+    # open sales order for 30 -> ATP 70, stock still 100
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | PreparationDate      | M_Warehouse_ID |
+      | so_od_3    | true    | customer_od   | 2024-09-20  | 2024-09-21T21:00:00Z | WH_OD          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_od_3   | so_od_3    | p_od_3       | 30         |
+    And the order identified by so_od_3 is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | d_od_3     | DEMAND            | SHIPMENT                  | p_od_3       | 2024-09-21T21:00:00Z | -30 | 70  | WH_OD          |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_od_3                  | 100       |
+
+    # ship it in full
+    When after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ss_od_3    | sol_od_3       | N             |
+    And shipment is generated for the following shipment schedule
+      | M_InOut_ID.Identifier | M_ShipmentSchedule_ID.Identifier | quantityTypeToUse | isCompleteShipment |
+      | ship_od_3             | ss_od_3                          | D                 | Y                  |
+
+    # the invariant: stock dropped to 70, ATP is UNCHANGED at 70. The full shipment fulfils the open
+    # demand (its own remaining qty goes to 0) and books the actual movement as a separate certain
+    # decrease - the "expected decrease becomes certain decrease" this scenario is titled for - so ATP
+    # never moves a second time for the same physical consumption.
+    Then after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_od_3                  | 70        |
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type   | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | d_od_3     | DEMAND              | SHIPMENT                  | p_od_3       | 2024-09-21T21:00:00Z | 0   | 70  | WH_OD          |
+      | ud_od_3    | UNEXPECTED_DECREASE | SHIPMENT                  | p_od_3       | 2024-09-20T22:00:00Z | -30 | 70  | WH_OD          |
+
+  @Id:ATPBASE_007
+  @from:cucumber
+  Scenario: A reset-stock refresh applies its own physical movement and leaves the open demand alone
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID | C_UOM_ID.X12DE355 |
+      | p_od_4     | std_cat_od            | PCE               |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID |
+      | pp_od_4    | plv_so_od              | p_od_4       | 10.0     | PCE               | Normal           |
+
+    # stock of 200
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_od_4   | WH_OD          | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_od_4       | invl_od_4  | p_od_4       | 0       | 200      | WH_OD          | PCE          |
+    And the inventory identified by inv_od_4 is completed
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_od_4                  | 200       |
+
+    # open sales order for 30 -> the projection is 170, deliberately NOT the bare physical 200
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | PreparationDate      | M_Warehouse_ID |
+      | so_od_4    | true    | customer_od   | 2024-09-20  | 2024-09-21T21:00:00Z | WH_OD          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_od_4   | so_od_4    | p_od_4       | 30         |
+    And the order identified by so_od_4 is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | d_od_4     | DEMAND            | SHIPMENT                  | p_od_4       | 2024-09-21T21:00:00Z | -30 | 170 | WH_OD          |
+
+    # a reset-stock refresh whose recount from the HUs disagreed with the stored quantity: it found 150 stored,
+    # wrote the recomputed 200 - the quantity MD_Stock now holds - and reports that +50 movement. This is the only
+    # event shape the reset-stock process emits: it skips every key whose recomputed quantity did not move.
+    When metasfresh receives a StockChangedEvent for the current MD_Stock
+      | M_Product_ID | OPT.ChangeDate       | OPT.QtyOnHandOld |
+      | p_od_4       | 2024-09-23T06:00:00Z | 150              |
+
+    # only the refresh's own +50 may reach the chain: the projection moves 170 -> 220 and keeps the open demand.
+    # Re-baselining onto the bare physical 200 would land the projection there and absorb the demand.
+    Then after not more than 60s, the MD_Candidate table has only the following records
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | c_od_4     | INVENTORY_UP      |                           | p_od_4       | 2024-09-20T06:00:00Z | 200 | 200 | WH_OD          |
+      | d_od_4     | DEMAND            | SHIPMENT                  | p_od_4       | 2024-09-21T21:00:00Z | -30 | 170 | WH_OD          |
+      | base_od_4  | INVENTORY_UP      |                           | p_od_4       | 2024-09-23T06:00:00Z | 50  | 220 | WH_OD          |
+
+  @Id:ATPBASE_008
+  @from:cucumber
+  Scenario: A reset-stock refresh with no recorded movement leaves an open demand dated before it untouched
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID | C_UOM_ID.X12DE355 |
+      | p_od_5     | std_cat_od            | PCE               |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID |
+      | pp_od_5    | plv_so_od              | p_od_5       | 10.0     | PCE               | Normal           |
+
+    # stock of 200
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_od_5   | WH_OD          | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_od_5       | invl_od_5  | p_od_5       | 0       | 200      | WH_OD          | PCE          |
+    And the inventory identified by inv_od_5 is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | c_od_5     | INVENTORY_UP      | p_od_5       | 2024-09-20T06:00:00Z | 200 | 200 | WH_OD          |
+
+    # open sales order for 30, dated BEFORE the refresh below, NO shipment
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | PreparationDate      | M_Warehouse_ID |
+      | so_od_5    | true    | customer_od   | 2024-09-20  | 2024-09-21T21:00:00Z | WH_OD          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_od_5   | so_od_5    | p_od_5       | 30         |
+    And the order identified by so_od_5 is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | d_od_5     | DEMAND            | SHIPMENT                  | p_od_5       | 2024-09-21T21:00:00Z | -30 | 170 | WH_OD          |
+
+    # a reset-stock refresh whose recount from the HUs agreed with the stored quantity, dated AFTER the open
+    # demand above: no QtyOnHandOld override, so the step defaults it to the stock's own current QtyOnHand -
+    # a genuinely zero physical movement, with a live open position still in the chain at the event date.
+    When metasfresh receives a StockChangedEvent for the current MD_Stock
+      | M_Product_ID | OPT.ChangeDate       |
+      | p_od_5       | 2024-09-23T06:00:00Z |
+
+    # the refresh must add no candidate at all: the chain still carries the open demand, and its projection
+    # stays exactly what it was before the refresh.
+    Then after not more than 60s, the MD_Candidate table has only the following records
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | c_od_5     | INVENTORY_UP      |                           | p_od_5       | 2024-09-20T06:00:00Z | 200 | 200 | WH_OD          |
+      | d_od_5     | DEMAND            | SHIPMENT                  | p_od_5       | 2024-09-21T21:00:00Z | -30 | 170 | WH_OD          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_divergence_report.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_divergence_report.feature
@@ -1,0 +1,182 @@
+@from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F19000_Material_Dispo
+@ghActions:run_on_executor6
+Feature: ATP divergence report - read-only preview of stored vs. expected ATP
+## The MD_Candidate_ATP_Divergence_Report process reports, per reconciliation key, the divergence between
+## the stored and the expected Available-to-Promise (ATP), and separately every open source document that
+## no candidate references at all. It writes nothing.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-09-20T08:00:00+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+    And load M_Product_Category:
+      | Identifier             | Name     | Value    |
+      | standard_category_base | Standard | Standard |
+    And metasfresh contains M_Warehouse:
+      | Identifier |
+      | WH_BASE    |
+
+  @Id:ATPDIV_001
+  @from:cucumber
+  Scenario: The report flags exactly the drifted key, the healthy key stays absent
+
+    Given metasfresh contains M_Product_Categories:
+      | Identifier   | Name          | Value         |
+      | cat_atpdiv_a | AtpDivReportA | AtpDivReportA |
+    And metasfresh contains M_Products:
+      | Identifier  | M_Product_Category_ID | C_UOM_ID.X12DE355 |
+      | p_healthy_a | cat_atpdiv_a          | PCE               |
+      | p_drifted_a | cat_atpdiv_a          | PCE               |
+
+    # healthy chain: physical stock 80, stored ATP still 80 - no divergence
+    And metasfresh contains M_Inventories:
+      | Identifier    | M_Warehouse_ID | MovementDate |
+      | inv_healthy_a | WH_BASE        | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier     | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_healthy_a  | invl_healthy_a | p_healthy_a  | 0       | 80       | WH_BASE        | PCE          |
+    And the inventory identified by inv_healthy_a is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier     | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_healthy_a | INVENTORY_UP      | p_healthy_a  | 2024-09-20T06:00:00Z | 80  | 80  | WH_BASE        |
+
+    # drifted chain: physical stock 100, but the customer's own cleanup zeroed the stored STOCK candidate
+    And metasfresh contains M_Inventories:
+      | Identifier    | M_Warehouse_ID | MovementDate |
+      | inv_drifted_a | WH_BASE        | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier     | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_drifted_a  | invl_drifted_a | p_drifted_a  | 0       | 100      | WH_BASE        | PCE          |
+    And the inventory identified by inv_drifted_a is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier     | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_drifted_a | INVENTORY_UP      | p_drifted_a  | 2024-09-20T06:00:00Z | 100 | 100 | WH_BASE        |
+    When the MD_Candidate_Remove_From_ATP process is run
+      | MD_Candidate_ID |
+      | cand_drifted_a  |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier     | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_drifted_a | INVENTORY_UP      | p_drifted_a  | 2024-09-20T06:00:00Z | 0   | 0   | WH_BASE        |
+
+    # scoped per product, not the shared category: "metasfresh contains M_Product_Categories" reuses an
+    # existing row by Value, so a category-wide count accumulates this scenario's products across runs on a
+    # reused database and drifts upward, while a per-product count stays exact regardless of database history.
+    When metasfresh has date and time 2024-09-21T08:00:00+01:00[Europe/Berlin]
+    And the MD_Candidate_ATP_Divergence_Report process is run with parameters, storing the run id as "report_healthy_a":
+      | M_Product_ID |
+      | p_healthy_a  |
+    And the MD_Candidate_ATP_Divergence_Report process is run with parameters, storing the run id as "report_drifted_a":
+      | M_Product_ID |
+      | p_drifted_a  |
+
+    Then the divergence report process log for the run id "report_healthy_a" contains "Checked 1 key(s); 0 diverged"
+    And the divergence report process log for the run id "report_drifted_a" contains "Checked 1 key(s); 1 diverged"
+    And the divergence report process log for the run id "report_drifted_a" contains "expectedAtp=100, storedAtp=0, difference=100"
+    # the healthy key's own expected/stored values, had it been logged despite no divergence
+    And the divergence report process log for the run id "report_healthy_a" does not contain "storedAtp=80, difference=0"
+
+  @Id:ATPDIV_002
+  @from:cucumber
+  Scenario: Reconciling a drifted key then re-running the report shows no divergence
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID  | C_UOM_ID.X12DE355 |
+      | p_recon_a  | standard_category_base | PCE               |
+    And metasfresh contains M_Inventories:
+      | Identifier  | M_Warehouse_ID | MovementDate |
+      | inv_recon_a | WH_BASE        | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier   | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_recon_a    | invl_recon_a | p_recon_a    | 0       | 200      | WH_BASE        | PCE          |
+    And the inventory identified by inv_recon_a is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier   | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_recon_a | INVENTORY_UP      | p_recon_a    | 2024-09-20T06:00:00Z | 200 | 200 | WH_BASE        |
+    When the MD_Candidate_Remove_From_ATP process is run
+      | MD_Candidate_ID |
+      | cand_recon_a    |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier   | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_recon_a | INVENTORY_UP      | p_recon_a    | 2024-09-20T06:00:00Z | 0   | 0   | WH_BASE        |
+
+    When metasfresh has date and time 2024-09-22T08:00:00+01:00[Europe/Berlin]
+    And the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as "reconcile_a":
+      | M_Product_ID | IsDryRun |
+      | p_recon_a    | false    |
+    # a real run only ENQUEUES: the process returns as soon as the work package exists and the app server
+    # reconciles afterwards, so the report below would otherwise re-read the chain before the correction has
+    # landed and still see the divergence. Wait for the correction candidate itself - the run's end-state -
+    # rather than for a duration.
+    And after not more than 60s, MD_Candidates are found
+      | Identifier  | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | fix_recon_a | INVENTORY_UP      | ATP_RECONCILE             | p_recon_a    | 2024-09-22T06:00:00Z | 200 | 200 | WH_BASE        |
+
+    And the MD_Candidate_ATP_Divergence_Report process is run with parameters, storing the run id as "report_b":
+      | M_Product_ID |
+      | p_recon_a    |
+    Then the divergence report process log for the run id "report_b" contains "Checked 1 key(s); 0 diverged"
+
+  @Id:ATPDIV_003
+  @from:cucumber
+  Scenario: An open shipment schedule with no candidate at all is reported as uncovered, a covered one stays excluded
+
+    Given metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_uncov   |
+    And metasfresh contains M_PriceLists
+      | Identifier  | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl_so_uncov | ps_uncov           | DE           | EUR           | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier   | M_PriceList_ID |
+      | plv_so_uncov | pl_so_uncov    |
+    And metasfresh contains C_BPartners:
+      | Identifier     | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | customer_uncov | N        | Y          | ps_uncov           |
+    And metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID  | C_UOM_ID.X12DE355 |
+      | p_uncov_a  | standard_category_base | PCE               |
+      | p_cov_a    | standard_category_base | PCE               |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID |
+      | pp_uncov_a | plv_so_uncov           | p_uncov_a    | 10.0     | PCE               | Normal           |
+      | pp_cov_a   | plv_so_uncov           | p_cov_a      | 10.0     | PCE               | Normal           |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID  | DateOrdered | PreparationDate      | M_Warehouse_ID |
+      | so_uncov_a | true    | customer_uncov | 2024-09-20  | 2024-09-21T21:00:00Z | WH_BASE        |
+      | so_cov_a   | true    | customer_uncov | 2024-09-20  | 2024-09-21T21:00:00Z | WH_BASE        |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_uncov_a | so_uncov_a | p_uncov_a    | 30         |
+      | sol_cov_a   | so_cov_a   | p_cov_a      | 50         |
+    And the order identified by so_uncov_a is completed
+    And the order identified by so_cov_a is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | d_uncov_a  | DEMAND            | SHIPMENT                  | p_uncov_a    | 2024-09-21T21:00:00Z | -30 | -30 | WH_BASE        |
+      | d_cov_a    | DEMAND            | SHIPMENT                  | p_cov_a      | 2024-09-21T21:00:00Z | -50 | -50 | WH_BASE        |
+
+    # the candidate that used to cover the p_uncov_a schedule is gone - e.g. purged by a cleanup job - while
+    # the schedule itself is still open: the one gap a recompute cannot close. The p_cov_a schedule keeps its
+    # MD_Candidate_Demand_Detail link intact - it is genuinely covered and must stay excluded from the report.
+    When the MD_Candidate_Demand_Detail of d_uncov_a is deleted
+    And the MD_Candidate_ATP_Divergence_Report process is run with parameters, storing the run id as "report_c":
+      | M_Product_ID |
+      | p_uncov_a    |
+    Then the divergence report process log for the run id "report_c" contains "1 open source document(s) with no candidate at all"
+    And the divergence report process log for the run id "report_c" contains "Uncovered open M_ShipmentSchedule"
+
+    # The negative control, and the reason this scenario can fail at all: p_cov_a's schedule is open exactly
+    # like p_uncov_a's, and differs only in still having its MD_Candidate_Demand_Detail link. Reporting it
+    # would mean the report answers "which open documents exist" instead of "which are uncovered". Scoped to
+    # p_cov_a alone rather than to a shared product category, because the category step reuses an existing row
+    # by Value - so a category-wide count accumulates this scenario's products across runs on a reused
+    # database and drifts upward, while a per-product count stays exact.
+    And the MD_Candidate_ATP_Divergence_Report process is run with parameters, storing the run id as "report_c_covered":
+      | M_Product_ID |
+      | p_cov_a      |
+    Then the divergence report process log for the run id "report_c_covered" contains "0 open source document(s) with no candidate at all"

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_double_decrement.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_double_decrement.feature
@@ -1,0 +1,110 @@
+@from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F19000_Material_Dispo
+@ghActions:run_on_executor6
+Feature: ATP double decrement — a never-issued BOM demand plus the inventory that corrects for it
+## The same physical consumption is subtracted from the ATP twice: component X has ATP and stock 100;
+## a production order books a BOM demand of 20 but the components are never issued while the order is
+## closed anyway; a later inventory counts reality (book 100 / count 80). Stock ends correct at 80, but
+## the ATP ends at 60 instead of 80 — the never-issued demand and the correcting inventory each
+## decrement it.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-09-20T08:00:00+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+    And load M_Product_Category:
+      | Identifier | Name     | Value    |
+      | std_cat_dd | Standard | Standard |
+    And metasfresh contains M_Warehouse:
+      | Identifier |
+      | WH_DD      |
+    And load S_Resource:
+      | S_Resource_ID.Identifier | S_Resource_ID |
+      | plant_dd                 | 540006        |
+
+  @Id:ATPBASE_006
+  @from:cucumber
+  Scenario: A closed manufacturing order whose components were never issued keeps decrementing the ATP
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID | C_UOM_ID.X12DE355 |
+      | fin_dd     | std_cat_dd            | PCE               |
+      | comp_dd    | std_cat_dd            | PCE               |
+    And metasfresh contains PP_Product_BOM
+      | Identifier | M_Product_ID.Identifier | ValidFrom  | PP_Product_BOMVersions_ID.Identifier |
+      | bom_dd     | fin_dd                  | 2024-09-01 | bomv_dd                              |
+    And metasfresh contains PP_Product_BOMLines
+      | Identifier | PP_Product_BOM_ID.Identifier | M_Product_ID.Identifier | ValidFrom  | QtyBatch |
+      | boml_dd    | bom_dd                       | comp_dd                 | 2024-09-01 | 20       |
+    And the PP_Product_BOM identified by bom_dd is completed
+    And verify BOM for M_Product:
+      | M_Product_ID.Identifier |
+      | fin_dd                  |
+    And metasfresh contains PP_Product_Plannings
+      | Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan |
+      | ppln_dd    | fin_dd                  | bomv_dd                                  | false        |
+
+    # --- component stock of 100, ATP 100 -------------------------------------------------
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_dd_1   | WH_DD          | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_dd_1       | invl_dd_1  | comp_dd      | 0       | 100      | WH_DD          | PCE          |
+    And the inventory identified by inv_dd_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID | M_HU_ID |
+      | invl_dd_1          | hu_dd_1 |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | comp_dd                 | 100       |
+
+    # --- a production order books a BOM demand of 20 for the component -------------------
+    When metasfresh has date and time 2024-09-21T08:00:00+01:00[Europe/Berlin]
+    And create PP_Order:
+      | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | OPT.M_Warehouse_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument |
+      | ppo_dd                 | MOP         | fin_dd                  | 1          | plant_dd                 | WH_DD                         | 2024-09-21T07:00:00.00Z | 2024-09-21T07:00:00.00Z | 2024-09-21T07:00:00.00Z | Y                |
+    # the component's ATP must now be 100 - 20 = 80 while its stock is untouched at 100
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected           | Qty | ATP | M_Warehouse_ID |
+      | dem_dd     | DEMAND            | PRODUCTION                | comp_dd      | 2024-09-21T07:00:00.00Z | -20 | 80  | WH_DD          |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | comp_dd                 | 100       |
+
+    # --- the order is CLOSED without ever issuing the components ------------------------
+    When the manufacturing order identified by ppo_dd is closed
+
+    # --- the inventory then counts reality: the components were consumed after all -------
+    And metasfresh has date and time 2024-09-22T08:00:00+01:00[Europe/Berlin]
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_dd_2   | WH_DD          | 2024-09-22   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 | M_HU_ID.Identifier |
+      | inv_dd_2       | invl_dd_2  | comp_dd      | 100     | 80       | WH_DD          | PCE          | hu_dd_1            |
+    And the inventory identified by inv_dd_2 is completed
+
+    # --- stock is correct at 80, but the never-issued BOM demand still decrements a second time: today's
+    # behaviour lands ATP at 60, not the physically correct 80 -----------------------------
+    Then after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | comp_dd                 | 80        |
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | invc_dd_2  | INVENTORY_DOWN    | comp_dd      | 2024-09-22T06:00:00Z | -20 | 60  | WH_DD          |
+
+    # --- the reconciliation point is where this is actually fixed: once the manufacturing order is
+    # closed, its never-issued demand no longer counts, so the target is the physical stock alone -------
+    When metasfresh has date and time 2024-09-23T08:00:00+01:00[Europe/Berlin]
+    And the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as "reconcile_dd":
+      | M_Product_ID | IsDryRun |
+      | comp_dd      | false    |
+
+    # --- business-correct result: ATP is now 80, matching the physical stock --------------
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | fix_dd     | INVENTORY_UP      | ATP_RECONCILE             | comp_dd      | 2024-09-23T06:00:00Z | 20  | 80  | WH_DD          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_reconcile_process.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_reconcile_process.feature
@@ -1,0 +1,215 @@
+@from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F19000_Material_Dispo
+@ghActions:run_on_executor6
+Feature: ATP reconciliation process - dry run and selection filter
+## The MD_Candidate_Reconcile_ATP process is the operator's entry point into the reconciliation: it can be
+## restricted by warehouse/product/product category, and run in dry-run mode first to preview the effect.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-09-20T08:00:00+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+    And load M_Product_Category:
+      | Identifier             | Name     | Value    |
+      | standard_category_base | Standard | Standard |
+    And metasfresh contains M_Warehouse:
+      | Identifier |
+      | WH_BASE    |
+
+  @Id:ATPBASE_010
+  @from:cucumber
+  Scenario: A dry run reports the would-change value and writes nothing
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID  | C_UOM_ID.X12DE355 |
+      | p_dry_a    | standard_category_base | PCE               |
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_dry_a  | WH_BASE        | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_dry_a      | invl_dry_a | p_dry_a      | 0       | 100      | WH_BASE        | PCE          |
+    And the inventory identified by inv_dry_a is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_dry_a | INVENTORY_UP      | p_dry_a      | 2024-09-20T06:00:00Z | 100 | 100 | WH_BASE        |
+    # the customer's own cleanup zeroes the candidate, so the stored projection drifts to 0 although
+    # physical stock is still 100 - this is the divergence the dry run must report
+    When the MD_Candidate_Remove_From_ATP process is run
+      | MD_Candidate_ID |
+      | cand_dry_a      |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_dry_a | INVENTORY_UP      | p_dry_a      | 2024-09-20T06:00:00Z | 0   | 0   | WH_BASE        |
+
+    When metasfresh has date and time 2024-09-21T08:00:00+01:00[Europe/Berlin]
+    And the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as "dry_run":
+      | M_Product_ID | IsDryRun |
+      | p_dry_a      | true     |
+
+    Then the ATP reconciliation process log for the run id "dry_run" contains "would change to 100"
+    # nothing was written: still exactly the one, unchanged candidate from before the dry run
+    And after not more than 60s, the MD_Candidate table has only the following records
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_dry_a | INVENTORY_UP      | p_dry_a      | 2024-09-20T06:00:00Z | 0   | 0   | WH_BASE        |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_dry_a                 | 100       |
+
+  @Id:ATPBASE_011
+  @from:cucumber
+  Scenario: A run restricted by M_Product_ID changes only the selected key
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID  | C_UOM_ID.X12DE355 |
+      | p_sel_a    | standard_category_base | PCE               |
+      | p_out_a    | standard_category_base | PCE               |
+
+    # --- key inside the selection: physical stock 100, drifted to 0 -----------------------------------
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_sel_a  | WH_BASE        | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_sel_a      | invl_sel_a | p_sel_a      | 0       | 100      | WH_BASE        | PCE          |
+    And the inventory identified by inv_sel_a is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_sel_a | INVENTORY_UP      | p_sel_a      | 2024-09-20T06:00:00Z | 100 | 100 | WH_BASE        |
+    When the MD_Candidate_Remove_From_ATP process is run
+      | MD_Candidate_ID |
+      | cand_sel_a      |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_sel_a | INVENTORY_UP      | p_sel_a      | 2024-09-20T06:00:00Z | 0   | 0   | WH_BASE        |
+
+    # --- key outside the selection: physical stock 60, drifted to 0 the same way -----------------------
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_out_a  | WH_BASE        | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_out_a      | invl_out_a | p_out_a      | 0       | 60       | WH_BASE        | PCE          |
+    And the inventory identified by inv_out_a is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_out_a | INVENTORY_UP      | p_out_a      | 2024-09-20T06:00:00Z | 60  | 60  | WH_BASE        |
+    When the MD_Candidate_Remove_From_ATP process is run
+      | MD_Candidate_ID |
+      | cand_out_a      |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_out_a | INVENTORY_UP      | p_out_a      | 2024-09-20T06:00:00Z | 0   | 0   | WH_BASE        |
+
+    # --- run the process restricted to p_sel_a only ----------------------------------------------------
+    When metasfresh has date and time 2024-09-22T08:00:00+01:00[Europe/Berlin]
+    And the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as "selective_run":
+      | M_Product_ID | IsDryRun |
+      | p_sel_a      | false    |
+
+    # the selected key was corrected: a new candidate at the run date restores the physical quantity
+    Then after not more than 60s, the MD_Candidate table has only the following records
+      | Identifier    | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_sel_a    | INVENTORY_UP      |                           | p_sel_a      | 2024-09-20T06:00:00Z | 0   | 0   | WH_BASE        |
+      | cand_sel_a_fx | INVENTORY_UP      | ATP_RECONCILE             | p_sel_a      | 2024-09-22T06:00:00Z | 100 | 100 | WH_BASE        |
+    # the key outside the selection was left untouched: still exactly the one, drifted candidate
+    And after not more than 60s, the MD_Candidate table has only the following records
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_out_a | INVENTORY_UP      | p_out_a      | 2024-09-20T06:00:00Z | 0   | 0   | WH_BASE        |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_sel_a                 | 100       |
+      | p_out_a                 | 60        |
+
+  @Id:ATPBASE_012
+  @from:cucumber
+  Scenario: A liveness cutoff excludes an open demand dated before it from the target, previewed and applied
+
+    Given metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_cut     |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl_so_cut  | ps_cut             | DE           | EUR           | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_so_cut | pl_so_cut      |
+    And metasfresh contains C_BPartners:
+      | Identifier   | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | customer_cut | N        | Y          | ps_cut             |
+    And metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID  | C_UOM_ID.X12DE355 |
+      | p_cut_a    | standard_category_base | PCE               |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID |
+      | pp_cut_a   | plv_so_cut             | p_cut_a      | 10.0     | PCE               | Normal           |
+
+    # physical stock of 100 - the anchor the target expression starts from, unaffected by the cutoff
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_cut_a  | WH_BASE        | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_cut_a      | invl_cut_a | p_cut_a      | 0       | 100      | WH_BASE        | PCE          |
+    And the inventory identified by inv_cut_a is completed
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_cut_a                 | 100       |
+
+    # open sales order for 30, unshipped, prepared BEFORE the cutoff date
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | PreparationDate      | M_Warehouse_ID |
+      | so_cut_a   | true    | customer_cut  | 2024-09-20  | 2024-09-21T21:00:00Z | WH_BASE        |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_cut_a  | so_cut_a   | p_cut_a      | 30         |
+    And the order identified by so_cut_a is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | d_cut_a    | DEMAND            | SHIPMENT                  | p_cut_a      | 2024-09-21T21:00:00Z | -30 | 70  | WH_BASE        |
+
+    # a second open sales order for 20, unshipped, prepared AFTER the cutoff date
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | PreparationDate      | M_Warehouse_ID |
+      | so_cut_b   | true    | customer_cut  | 2024-09-23  | 2024-09-24T21:00:00Z | WH_BASE        |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_cut_b  | so_cut_b   | p_cut_a      | 20         |
+    And the order identified by so_cut_b is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | d_cut_b    | DEMAND            | SHIPMENT                  | p_cut_a      | 2024-09-24T21:00:00Z | -20 | 50  | WH_BASE        |
+
+    # WITHOUT a cutoff both open demands still count towards the target (100 - 30 - 20 = 50), which already
+    # matches the stored ATP of 50 above - nothing to reconcile, so this key produces no divergence at all
+    When metasfresh has date and time 2024-09-25T08:00:00+01:00[Europe/Berlin]
+    And the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as "no_cutoff_run":
+      | M_Product_ID | IsDryRun |
+      | p_cut_a      | true     |
+    Then the ATP reconciliation process log for the run id "no_cutoff_run" contains "0 of 1 matching key"
+
+    # WITH a cutoff strictly between the two demands' dates, the earlier 30-unit demand is treated as closed and
+    # drops out of the target; only the later 20-unit demand still counts: target = 100 - 20 = 80 - a 30
+    # divergence against the still-unchanged stored ATP of 50, so the cutoff alone (not merely the dry run) is
+    # what produces this result: without it the same key reported no divergence at all, just above
+    When the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as "with_cutoff_run":
+      | M_Product_ID | IsDryRun | LivenessCutoffDate |
+      | p_cut_a      | true     | 2024-09-23         |
+    Then the ATP reconciliation process log for the run id "with_cutoff_run" contains "would change to 80"
+
+    # --- the same cutoff on a REAL run. A real run is not performed by the process at all: it is enqueued as
+    # a work package and reconciled by the app server, so the cutoff has to survive that round trip - the two
+    # dry runs above prove nothing about it. Target 80 against the still-stored 50 => an INVENTORY_UP of 30 at
+    # the run date, leaving the projection at 80 instead of the 50 an uncut run would have left it at. -------
+    When metasfresh has date and time 2024-09-26T08:00:00+01:00[Europe/Berlin]
+    And the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as "real_cutoff_run":
+      | M_Product_ID | IsDryRun | LivenessCutoffDate |
+      | p_cut_a      | false    | 2024-09-23         |
+    Then the ATP reconciliation process log for the run id "real_cutoff_run" contains "Enqueued work package"
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | fix_cut_a  | INVENTORY_UP      | ATP_RECONCILE             | p_cut_a      | 2024-09-26T06:00:00Z | 30  | 80  | WH_BASE        |
+    And after not more than 60s, the persisted ATP reconciliation backup for M_Product_ID "p_cut_a" contains a row with QtyBefore "null" and QtyAfter "80"

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_reconcile_regression.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_reconcile_regression.feature
@@ -1,0 +1,276 @@
+@from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F19000_Material_Dispo
+@ghActions:run_on_executor6
+Feature: ATP reconciliation regression coverage
+## Closes the coverage gaps left after the baseline probe, the process, and the divergence report were
+## built: mixed closed/open liveness in one chain, a reconciliation surviving a later ordinary event, the
+## reconciliation's arithmetic against the engine's own, and a real (non-dry) run's log naming what it
+## changed.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-09-20T08:00:00+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+    And load M_Product_Category:
+      | Identifier            | Name     | Value    |
+      | standard_category_reg | Standard | Standard |
+    And metasfresh contains M_Warehouse:
+      | Identifier |
+      | WH_REG     |
+    And load S_Resource:
+      | S_Resource_ID.Identifier | S_Resource_ID |
+      | plant_reg                | 540006        |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_reg     |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl_so_reg  | ps_reg             | DE           | EUR           | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_so_reg | pl_so_reg      |
+    And metasfresh contains C_BPartners:
+      | Identifier   | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | customer_reg | N        | Y          | ps_reg             |
+
+  @Id:ATPREG_001
+  @from:cucumber
+  Scenario: A closed production demand and an open sales demand on the same product: only the open one contributes
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID | C_UOM_ID.X12DE355 |
+      | fin_reg1   | standard_category_reg | PCE               |
+      | comp_reg1  | standard_category_reg | PCE               |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID |
+      | pp_reg1    | plv_so_reg             | comp_reg1    | 10.0     | PCE               | Normal           |
+    And metasfresh contains PP_Product_BOM
+      | Identifier | M_Product_ID.Identifier | ValidFrom  | PP_Product_BOMVersions_ID.Identifier |
+      | bom_reg1   | fin_reg1                | 2024-09-01 | bomv_reg1                            |
+    And metasfresh contains PP_Product_BOMLines
+      | Identifier | PP_Product_BOM_ID.Identifier | M_Product_ID.Identifier | ValidFrom  | QtyBatch |
+      | boml_reg1  | bom_reg1                     | comp_reg1               | 2024-09-01 | 20       |
+    And the PP_Product_BOM identified by bom_reg1 is completed
+    And verify BOM for M_Product:
+      | M_Product_ID.Identifier |
+      | fin_reg1                |
+    And metasfresh contains PP_Product_Plannings
+      | Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan |
+      | ppln_reg1  | fin_reg1                | bomv_reg1                                | false        |
+
+    # --- component stock of 100, ATP 100 -------------------------------------------------
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_reg1   | WH_REG         | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_reg1       | invl_reg1  | comp_reg1    | 0       | 100      | WH_REG         | PCE          |
+    And the inventory identified by inv_reg1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID | M_HU_ID |
+      | invl_reg1          | hu_reg1 |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | comp_reg1               | 100       |
+
+    # --- a production order books a BOM demand of 20 for the component -------------------
+    When metasfresh has date and time 2024-09-21T08:00:00+01:00[Europe/Berlin]
+    And create PP_Order:
+      | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | OPT.M_Warehouse_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument |
+      | ppo_reg1               | MOP         | fin_reg1                | 1          | plant_reg                | WH_REG                        | 2024-09-21T07:00:00.00Z | 2024-09-21T07:00:00.00Z | 2024-09-21T07:00:00.00Z | Y                |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected           | Qty | ATP | M_Warehouse_ID |
+      | dem_reg1   | DEMAND            | PRODUCTION                | comp_reg1    | 2024-09-21T07:00:00.00Z | -20 | 80  | WH_REG         |
+
+    # --- the order is CLOSED without ever issuing the components: this demand is now a closed source
+    # document, and must stop contributing once reconciled -------------------------------
+    When the manufacturing order identified by ppo_reg1 is closed
+
+    # --- a genuinely open, unshipped sales order for the same component, dated after the closing -------
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | PreparationDate      | M_Warehouse_ID |
+      | so_reg1    | true    | customer_reg  | 2024-09-22  | 2024-09-22T21:00:00Z | WH_REG         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_reg1   | so_reg1    | comp_reg1    | 30         |
+    And the order identified by so_reg1 is completed
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | d_reg1     | DEMAND            | SHIPMENT                  | comp_reg1    | 2024-09-22T21:00:00Z | -30 | 50  | WH_REG         |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | comp_reg1               | 100       |
+
+    # --- reconcile: only the still-open sales demand (30) counts; the closed production demand (20)
+    # must not - target = physical 100 - open 30 = 70, not 100 - 30 - 20 = 50 (naive full inclusion,
+    # which would already match the stored 50 and reconcile as a no-op) and not 100 (bare physical,
+    # ignoring the open demand) -------------------------------------------------------------
+    When metasfresh has date and time 2024-09-23T08:00:00+01:00[Europe/Berlin]
+    And the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as "mixed_liveness":
+      | M_Product_ID | IsDryRun |
+      | comp_reg1    | false    |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | fix_reg1   | INVENTORY_UP      | ATP_RECONCILE             | comp_reg1    | 2024-09-23T06:00:00Z | 20  | 70  | WH_REG         |
+
+  @Id:ATPREG_002
+  @from:cucumber
+  Scenario: A reconciled chain stays consistent after an ordinary subsequent material event
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID | C_UOM_ID.X12DE355 |
+      | p_reg2     | standard_category_reg | PCE               |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID |
+      | pp_reg2    | plv_so_reg             | p_reg2       | 10.0     | PCE               | Normal           |
+
+    # --- physical stock 100, then the customer's own cleanup zeroes the stored candidate ----------------
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_reg2   | WH_REG         | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_reg2       | invl_reg2  | p_reg2       | 0       | 100      | WH_REG         | PCE          |
+    And the inventory identified by inv_reg2 is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_reg2  | INVENTORY_UP      | p_reg2       | 2024-09-20T06:00:00Z | 100 | 100 | WH_REG         |
+    When the MD_Candidate_Remove_From_ATP process is run
+      | MD_Candidate_ID |
+      | cand_reg2       |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_reg2  | INVENTORY_UP      | p_reg2       | 2024-09-20T06:00:00Z | 0   | 0   | WH_REG         |
+
+    # --- reconcile: the projection is restored to the physical stock ------------------------------------
+    When metasfresh has date and time 2024-09-21T08:00:00+01:00[Europe/Berlin]
+    And the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as "consistency_run":
+      | M_Product_ID | IsDryRun |
+      | p_reg2       | false    |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | fix_reg2   | INVENTORY_UP      | ATP_RECONCILE             | p_reg2       | 2024-09-21T06:00:00Z | 100 | 100 | WH_REG         |
+
+    # --- an ordinary, unrelated material event follows: a genuinely open, unshipped sales order ---------
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | PreparationDate      | M_Warehouse_ID |
+      | so_reg2    | true    | customer_reg  | 2024-09-22  | 2024-09-22T21:00:00Z | WH_REG         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_reg2   | so_reg2    | p_reg2       | 40         |
+    And the order identified by so_reg2 is completed
+
+    # --- the chain builds forward from the reconciled 100, not from the pre-reconciliation drift of 0:
+    # a silently discarded reconciliation would show ATP 0 - 40 = -40 here instead --------------------
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | d_reg2     | DEMAND            | SHIPMENT                  | p_reg2       | 2024-09-22T21:00:00Z | -40 | 60  | WH_REG         |
+
+  @Id:ATPREG_003
+  @from:cucumber
+  Scenario: The reconciliation's arithmetic agrees with the engine's own stock-impact rule
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID | C_UOM_ID.X12DE355 |
+      | p_reg3a    | standard_category_reg | PCE               |
+      | p_reg3b    | standard_category_reg | PCE               |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID |
+      | pp_reg3a   | plv_so_reg             | p_reg3a      | 10.0     | PCE               | Normal           |
+      | pp_reg3b   | plv_so_reg             | p_reg3b      | 10.0     | PCE               | Normal           |
+
+    # --- product A: driven purely by ordinary engine events, never touched by the reconciliation --------
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_reg3a  | WH_REG         | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_reg3a      | invl_reg3a | p_reg3a      | 0       | 100      | WH_REG         | PCE          |
+    And the inventory identified by inv_reg3a is completed
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | PreparationDate      | M_Warehouse_ID |
+      | so_reg3a   | true    | customer_reg  | 2024-09-20  | 2024-09-20T21:00:00Z | WH_REG         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_reg3a  | so_reg3a   | p_reg3a      | 25         |
+    And the order identified by so_reg3a is completed
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | d_reg3a    | DEMAND            | SHIPMENT                  | p_reg3a      | 2024-09-20T21:00:00Z | -25 | 75  | WH_REG         |
+
+    # --- product B: an identical physical chain, but its stored ATP is corrupted then reconciled --------
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_reg3b  | WH_REG         | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_reg3b      | invl_reg3b | p_reg3b      | 0       | 100      | WH_REG         | PCE          |
+    And the inventory identified by inv_reg3b is completed
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | PreparationDate      | M_Warehouse_ID |
+      | so_reg3b   | true    | customer_reg  | 2024-09-20  | 2024-09-20T21:00:00Z | WH_REG         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_reg3b  | so_reg3b   | p_reg3b      | 25         |
+    And the order identified by so_reg3b is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | d_reg3b    | DEMAND            | SHIPMENT                  | p_reg3b      | 2024-09-20T21:00:00Z | -25 | 75  | WH_REG         |
+    # corrupt the youngest STOCK candidate of the chain (the demand's own), so the stored balance
+    # diverges from the physical position while nothing physical actually changed
+    And the ATP of the STOCK candidate of d_reg3b is manually set to 999
+
+    # --- reconcile product B; the physical stock and the still-open demand are the same as A's ----------
+    When metasfresh has date and time 2024-09-21T08:00:00+01:00[Europe/Berlin]
+    And the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as "arithmetic_check":
+      | M_Product_ID | IsDryRun |
+      | p_reg3b      | false    |
+
+    # --- both chains land on the same ATP for the same physical position: 100 - 25 = 75 ------------------
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty  | ATP | M_Warehouse_ID |
+      | fix_reg3b  | INVENTORY_DOWN    | ATP_RECONCILE             | p_reg3b      | 2024-09-21T06:00:00Z | -924 | 75  | WH_REG         |
+
+  @Id:ATPREG_004
+  @from:cucumber
+  Scenario: A real reconciliation run's audit trail names the candidate it changed
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID | C_UOM_ID.X12DE355 |
+      | p_reg4     | standard_category_reg | PCE               |
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_reg4   | WH_REG         | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_reg4       | invl_reg4  | p_reg4       | 0       | 60       | WH_REG         | PCE          |
+    And the inventory identified by inv_reg4 is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_reg4  | INVENTORY_UP      | p_reg4       | 2024-09-20T06:00:00Z | 60  | 60  | WH_REG         |
+    When the MD_Candidate_Remove_From_ATP process is run
+      | MD_Candidate_ID |
+      | cand_reg4       |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_reg4  | INVENTORY_UP      | p_reg4       | 2024-09-20T06:00:00Z | 0   | 0   | WH_REG         |
+
+    # --- a real (non-dry) run: the audit trail must name the candidate it changed and its new value, not
+    # just report a count. It is read from the durable MD_ATP_Reconciliation_Backup rather than from the
+    # process log, because a real run is enqueued and reconciled in the app server: the process returns as
+    # soon as the work package exists, so its own log cannot contain what the run went on to change. ------
+    When metasfresh has date and time 2024-09-21T08:00:00+01:00[Europe/Berlin]
+    And the MD_Candidate_Reconcile_ATP process is run with parameters, storing the run id as "log_naming_run":
+      | M_Product_ID | IsDryRun |
+      | p_reg4       | false    |
+
+    Then the ATP reconciliation process log for the run id "log_naming_run" contains "Enqueued work package"
+    # QtyBefore "null" = the STOCK candidate the correction itself created, so there was no earlier value to
+    # back up; QtyAfter 60 is the physical stock the projection was brought back onto
+    And after not more than 60s, the persisted ATP reconciliation backup for M_Product_ID "p_reg4" contains a row with QtyBefore "null" and QtyAfter "60"
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | fix_reg4   | INVENTORY_UP      | ATP_RECONCILE             | p_reg4       | 2024-09-21T06:00:00Z | 60  | 60  | WH_REG         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_reconciliation_backup.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_reconciliation_backup.feature
@@ -1,0 +1,117 @@
+@from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F19000_Material_Dispo
+@ghActions:run_on_executor6
+Feature: ATP reconciliation backup survives the run and names what changed
+## Before the reconciliation writes anything, the affected rows must be backed up; the requirement is that the
+## pre-change values stay recoverable and the run log names what changed - reachable from a fresh database read,
+## not only from the return value of the call that ran the reconciliation.
+##
+## Scope note: this feature validates the command layer (AtpReconciliationCommand#reconcileAndLog) directly, not
+## the real operator-facing AD_Process - a real run through MD_Candidate_Reconcile_ATP is enqueued and never
+## returns its ReconciliationRunUUID to the caller, so these run-id-keyed assertions have nothing to read back
+## through that path today.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-09-20T08:00:00+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+    And load M_Product_Category:
+      | Identifier             | Name     | Value    |
+      | standard_category_base | Standard | Standard |
+    And metasfresh contains M_Warehouse:
+      | Identifier |
+      | WH_BASE    |
+
+  @Id:ATPBASE_016
+  @from:cucumber
+  Scenario: The backup is recoverable from the database, across several reconciled keys
+
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID  | C_UOM_ID.X12DE355 |
+      | p_bkp_a    | standard_category_base | PCE               |
+      | p_bkp_b    | standard_category_base | PCE               |
+
+    # --- key A: physical stock 100, then the customer's own cleanup zeroes the candidate --------------
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_bkp_a  | WH_BASE        | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_bkp_a      | invl_bkp_a | p_bkp_a      | 0       | 100      | WH_BASE        | PCE          |
+    And the inventory identified by inv_bkp_a is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_bkp_a | INVENTORY_UP      | p_bkp_a      | 2024-09-20T06:00:00Z | 100 | 100 | WH_BASE        |
+    When the MD_Candidate_Remove_From_ATP process is run
+      | MD_Candidate_ID |
+      | cand_bkp_a      |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_bkp_a | INVENTORY_UP      | p_bkp_a      | 2024-09-20T06:00:00Z | 0   | 0   | WH_BASE        |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_bkp_a                 | 100       |
+
+    # --- key B: physical stock 50, same cleanup ------------------------------------------------------
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_bkp_b  | WH_BASE        | 2024-09-20   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_bkp_b      | invl_bkp_b | p_bkp_b      | 0       | 50       | WH_BASE        | PCE          |
+    And the inventory identified by inv_bkp_b is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_bkp_b | INVENTORY_UP      | p_bkp_b      | 2024-09-20T06:00:00Z | 50  | 50  | WH_BASE        |
+    When the MD_Candidate_Remove_From_ATP process is run
+      | MD_Candidate_ID |
+      | cand_bkp_b      |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_bkp_b | INVENTORY_UP      | p_bkp_b      | 2024-09-20T06:00:00Z | 0   | 0   | WH_BASE        |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_bkp_b                 | 50        |
+
+    # --- reconcile both keys, one call per key, one run id each --------------------------------------
+    When metasfresh has date and time 2024-09-21T08:00:00+01:00[Europe/Berlin]
+    And the ATP reconciliation is run for M_Product_ID "p_bkp_a" and M_Warehouse_ID "WH_BASE", storing the run id as "run_a"
+    And the ATP reconciliation is run for M_Product_ID "p_bkp_b" and M_Warehouse_ID "WH_BASE", storing the run id as "run_b"
+
+    # --- both keys' pre-change values are recoverable from the database, not from the calls above -----
+    Then the persisted ATP reconciliation backup for the run id "run_a" contains a row with QtyBefore "null" and QtyAfter "100"
+    And the persisted ATP reconciliation backup for the run id "run_b" contains a row with QtyBefore "null" and QtyAfter "50"
+
+    # --- key A drifts a second time: a later stock count is zeroed the same way, so a real STOCK -----
+    # --- candidate (the one the first reconciliation just created) already exists in the second run's -
+    # --- scope - this is the path the two assertions above never reach ---------------------------------
+    When metasfresh has date and time 2024-09-25T08:00:00+01:00[Europe/Berlin]
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | inv_bkp_a2 | WH_BASE        | 2024-09-25   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | Identifier  | M_Product_ID | QtyBook | QtyCount | M_Warehouse_ID | UOM.X12DE355 |
+      | inv_bkp_a2     | invl_bkp_a2 | p_bkp_a      | 100     | 130      | WH_BASE        | PCE          |
+    And the inventory identified by inv_bkp_a2 is completed
+    And after not more than 60s, MD_Candidates are found
+      | Identifier  | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_bkp_a2 | INVENTORY_UP      | p_bkp_a      | 2024-09-25T06:00:00Z | 30  | 130 | WH_BASE        |
+    When the MD_Candidate_Remove_From_ATP process is run
+      | MD_Candidate_ID |
+      | cand_bkp_a2     |
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier  | MD_Candidate_Type | M_Product_ID | DateProjected        | Qty | ATP | M_Warehouse_ID |
+      | cand_bkp_a2 | INVENTORY_UP      | p_bkp_a      | 2024-09-25T06:00:00Z | 0   | 100 | WH_BASE        |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_bkp_a                 | 130       |
+
+    # --- reconciling key A again, as of the earlier run date, reaches forward into the newly-drifted --
+    # --- candidate above and recovers its real (non-null) prior quantity -------------------------------
+    When metasfresh has date and time 2024-09-21T08:00:00+01:00[Europe/Berlin]
+    And the ATP reconciliation is run for M_Product_ID "p_bkp_a" and M_Warehouse_ID "WH_BASE", storing the run id as "run_a2"
+
+    Then the persisted ATP reconciliation backup for the run id "run_a2" contains a row with QtyBefore "100" and QtyAfter "130"

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_remove_from_atp_errors.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/atp_remove_from_atp_errors.feature
@@ -1,0 +1,38 @@
+@from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F19000_Material_Dispo
+@ghActions:run_on_executor6
+Feature: MD_Candidate_Remove_From_ATP reports its errors instead of raising
+
+  Guard: MD_Candidate_Remove_From_ATP declares a 6-column result row (removed candidate id, stock
+  candidate id, current ATP qty, qty adjustment, impacted-candidates count, message). Before the fix,
+  the "candidate not found or not active" branch returned only 4 values, so the message text landed in
+  a numeric column and PostgreSQL raised "structure of query does not match function result type"
+  instead of returning a row an operator/caller can read. This feature proves the process now completes
+  successfully for an argument that never resolves to an active candidate.
+
+  The sibling branch (an existing, active, non-STOCK candidate whose STOCK sibling cannot be found) is
+  not reachable through a live business scenario: every code path that creates a demand/supply candidate
+  also creates its STOCK sibling in the same operation, and no operator action removes only the sibling
+  while leaving the candidate active. That branch is verified instead by a direct SQL probe against the
+  fixed function, run before and after the fix to confirm the discrimination.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+
+  @Id:ATPRFA_001
+  @from:cucumber
+  Scenario: removing a candidate ID that resolves to no active MD_Candidate reports a well-formed error, not a raised exception
+
+    When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/processes/MD_Candidate_RemoveFromATP/invoke' and fulfills with '200' status code
+    """
+{
+  "processParameters": [
+    {
+      "name": "MD_Candidate_ID",
+      "value": "999999999"
+    }
+  ]
+}
+    """

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/md_candidate_remove_from_atp.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/md_candidate_remove_from_atp.feature
@@ -148,8 +148,6 @@ Feature: MD_Candidate_Remove_From_ATP process
       | pol_atp_003 | po_atp_003 | product_atp  | 150        |
     And the order identified by po_atp_003 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
-
     # Verify all candidates
     And after not more than 10s, MD_Candidates are found
       | Identifier             | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty  | ATP | M_Warehouse_ID |
@@ -236,7 +234,6 @@ Feature: MD_Candidate_Remove_From_ATP process
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | sol_004_3  | so_004_3   | product_atp  | 35         |
     And the order identified by so_004_3 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     # Verify all candidates are present with correct ATP chain
     And after not more than 10s, MD_Candidates are found

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpDivergence.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpDivergence.java
@@ -1,0 +1,58 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.math.BigDecimal;
+
+/**
+ * How far one reconciliation key's stored projected ATP is from the target {@link AtpTargetCalculator} computes.
+ * <p>
+ * {@code difference} is always {@code expectedAtp - storedAtp} - computed here, not by callers, so the
+ * reconciliation (which writes it) and the divergence report (which only shows it) can't end up with opposite
+ * signs.
+ */
+@Value
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AtpDivergence
+{
+	/** The target: physical stock plus the key's still-open contributions. */
+	@NonNull BigDecimal expectedAtp;
+
+	/** What the stored projection currently says. */
+	@NonNull BigDecimal storedAtp;
+
+	/** {@code expectedAtp - storedAtp}. */
+	@NonNull BigDecimal difference;
+
+	public static AtpDivergence of(
+			@NonNull final BigDecimal expectedAtp,
+			@NonNull final BigDecimal storedAtp)
+	{
+		return new AtpDivergence(expectedAtp, storedAtp, expectedAtp.subtract(storedAtp));
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpKeySelection.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpKeySelection.java
@@ -1,0 +1,58 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.product.ProductCategoryId;
+import de.metas.product.ProductId;
+import lombok.Builder;
+import lombok.Value;
+import org.adempiere.warehouse.WarehouseId;
+
+import javax.annotation.Nullable;
+
+/**
+ * <i>Which</i> reconciliation keys a run covers: the optional warehouse / product / product-category filter an
+ * operator hands to {@code MD_Candidate_Reconcile_ATP} or {@code MD_Candidate_ATP_Divergence_Report}. An unset
+ * field is not restricted on, so {@link #ALL} selects the whole {@code MD_Stock} population.
+ * <p>
+ * Kept as a value object rather than three loose nullable parameters because it travels: the write path serialises
+ * it onto a {@code C_Queue_WorkPackage} in the webapi and reconstitutes it in the app server (see
+ * {@code de.metas.material.dispo.reconcile.async.AtpReconciliationEnqueueService}) - a tuple could be partially
+ * forgotten across that boundary.
+ */
+@Value
+@Builder
+public class AtpKeySelection
+{
+	/** No restriction at all: every reconciliation key in the system. */
+	public static final AtpKeySelection ALL = AtpKeySelection.builder().build();
+
+	/** {@code null} means "any warehouse". */
+	@Nullable WarehouseId warehouseId;
+
+	/** {@code null} means "any product". */
+	@Nullable ProductId productId;
+
+	/** {@code null} means "any product category". */
+	@Nullable ProductCategoryId productCategoryId;
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpKeySelectionDrainer.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpKeySelectionDrainer.java
@@ -1,0 +1,172 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.annotations.VisibleForTesting;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.cockpit.stock.StockRepository;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.Adempiere;
+import org.compiere.SpringContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Walks the reconciliation keys matching an {@link AtpKeySelection} in bounded pages and hands each one to a
+ * caller-supplied {@link KeyProcessor}.
+ * <p>
+ * <b>Why its own collaborator:</b> the reconciliation runs on two paths - the webapi's synchronous dry-run preview
+ * and the app server's real, writing run ({@code AtpReconciliationWorkpackageProcessor}) - and the page size,
+ * pagination arithmetic and runaway backstop must not drift apart between them; a preview walking a different key
+ * set than the run it previews would be worse than none.
+ * <p>
+ * Not folded in (yet): {@code MD_Candidate_ATP_Divergence_Report} carries a third, structurally identical drain -
+ * unifying it is a change to that process's own covering tests, not part of this split.
+ * <p>
+ * The actual persistence query stays in {@link StockRepository} - see {@code docs/REVIEW.md} on keeping
+ * {@code IQueryBL}/{@code IQueryBuilder} out of a {@code @Service}.
+ */
+@Service
+@RequiredArgsConstructor
+public class AtpKeySelectionDrainer
+{
+	/** How many matching keys are fetched and handed to the {@link KeyProcessor} per round. */
+	@VisibleForTesting
+	public static final int BATCH_SIZE = 500;
+
+	/**
+	 * Backstop against a pagination bug that never converges (e.g. an {@code OFFSET} that stops advancing): a
+	 * healthy run always empties the (static) selection in a bounded number of rounds. {@link #BATCH_SIZE} *
+	 * {@link #MAX_LOOPS} = 5,000,000 keys, far past any real selection size (the largest measured candidate chain
+	 * for this feature was 913 rows for a single product).
+	 */
+	@VisibleForTesting
+	public static final int MAX_LOOPS = 10_000;
+
+	@NonNull private final StockRepository stockRepository;
+
+	/**
+	 * @return an instance for a plain JUnit test - whatever is registered on {@link SpringContextHolder} wins, so a
+	 * test that registered a mocked {@link StockRepository} gets a drainer paging through that mock.
+	 */
+	@VisibleForTesting
+	public static AtpKeySelectionDrainer newInstanceForUnitTesting()
+	{
+		Adempiere.assertUnitTestMode();
+		//noinspection DataFlowIssue
+		return SpringContextHolder.getBeanOrSupply(
+				AtpKeySelectionDrainer.class,
+				() -> new AtpKeySelectionDrainer(SpringContextHolder.getBeanOrSupply(StockRepository.class, StockRepository::new)));
+	}
+
+	/**
+	 * Hands every key of {@code selection} to {@code keyProcessor} exactly once, one page of at most
+	 * {@link #BATCH_SIZE} keys at a time.
+	 * <p>
+	 * Pages are ordered by {@code MD_Stock_ID} (see {@link StockRepository#retrieveKeys}), so successive rounds
+	 * walk the same static selection without gaps or repeats. The loop ends on the first page that comes back
+	 * shorter than a full batch.
+	 *
+	 * @return how many keys were seen and how many of them the processor reported as changed
+	 * @throws AdempiereException when the selection never shrinks below a full batch within {@link #MAX_LOOPS}
+	 * rounds - see that constant's Javadoc
+	 */
+	public DrainSummary drain(
+			@NonNull final AtpKeySelection selection,
+			@NonNull final KeyProcessor keyProcessor)
+	{
+		int offset = 0;
+		int loops = 0;
+		int keysProcessed = 0;
+		int keysChanged = 0;
+
+		List<StockDataRecordIdentifier> batch;
+		do
+		{
+			loops++;
+			if (loops > MAX_LOOPS)
+			{
+				// a bounded, reportable failure instead of an infinite loop from a stuck OFFSET
+				throw new AdempiereException("ATP reconciliation key drain aborted after " + MAX_LOOPS
+						+ " rounds of " + BATCH_SIZE + " keys each - the selection never shrank below a full batch");
+			}
+
+			batch = retrieveKeys(selection, offset);
+			for (final StockDataRecordIdentifier key : batch)
+			{
+				keysProcessed++;
+				if (keyProcessor.process(key))
+				{
+					keysChanged++;
+				}
+			}
+			offset += BATCH_SIZE;
+		}
+		while (batch.size() == BATCH_SIZE);
+
+		return DrainSummary.of(keysProcessed, keysChanged);
+	}
+
+	private List<StockDataRecordIdentifier> retrieveKeys(
+			@NonNull final AtpKeySelection selection,
+			final int offset)
+	{
+		return stockRepository.retrieveKeys(
+				selection.getWarehouseId(),
+				selection.getProductId(),
+				selection.getProductCategoryId(),
+				BATCH_SIZE,
+				offset);
+	}
+
+	/**
+	 * What a caller does with one key. Deliberately not a {@code java.util.function.Predicate}: the return value
+	 * isn't a test on the key, it's the processor reporting whether that key needed a change - what
+	 * {@link DrainSummary#getKeysChanged()} counts.
+	 */
+	@FunctionalInterface
+	public interface KeyProcessor
+	{
+		/**
+		 * @return {@code true} when this key diverged - i.e. the caller reconciled it, or (previewing) found a
+		 * value it would have reconciled; {@code false} when the key was already correct and there is nothing to
+		 * report for it
+		 */
+		boolean process(@NonNull StockDataRecordIdentifier key);
+	}
+
+	/** The tally of one {@link #drain} call, which is all either path needs for its summary log line. */
+	@Value(staticConstructor = "of")
+	public static class DrainSummary
+	{
+		/** How many keys of the selection were handed to the processor. */
+		int keysProcessed;
+
+		/** How many of those the processor reported as diverging. */
+		int keysChanged;
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpReconciliationBackupRepository.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpReconciliationBackupRepository.java
@@ -1,0 +1,57 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.dispo.commons.candidate.Candidate;
+import lombok.NonNull;
+
+import java.util.List;
+
+/**
+ * Persists the pre-change {@code Qty} of every {@code STOCK} candidate a reconciliation run is about to touch, then
+ * completes that same row with the after-value once the run's outcome is known - turning it into a durable record
+ * of what changed. {@link AtpReconciliationCommand#reconcileAndLog} always calls the two methods in that order.
+ */
+public interface AtpReconciliationBackupRepository
+{
+	/**
+	 * Persists one row per candidate in {@code stockCandidatesInScope}, carrying its current {@code Qty} as the
+	 * recoverable pre-change value. Called before {@link AtpReconciliationCommand} writes anything, so a crash right
+	 * after this call still leaves every pre-change value recoverable.
+	 */
+	void backupBeforeWrite(
+			@NonNull String runUuid,
+			@NonNull StockDataRecordIdentifier key,
+			@NonNull List<Candidate> stockCandidatesInScope);
+
+	/**
+	 * Completes the durable record with the after-value of every candidate the run actually changed: updates the
+	 * row {@link #backupBeforeWrite} created for a pre-existing candidate, or inserts a fresh one (with no
+	 * pre-change value to carry) for a candidate the run itself created.
+	 */
+	void recordAfterWrite(
+			@NonNull String runUuid,
+			@NonNull StockDataRecordIdentifier key,
+			@NonNull List<AtpReconciliationRunLog.Entry> entries);
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpReconciliationBackupRepositoryImpl.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpReconciliationBackupRepositoryImpl.java
@@ -1,0 +1,123 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.dispo.commons.candidate.Candidate;
+import de.metas.material.dispo.model.I_MD_ATP_Reconciliation_Backup;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.util.TimeUtil;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static de.metas.util.Check.assumeNotNull;
+
+/**
+ * Repository Tables: MD_ATP_Reconciliation_Backup
+ * Repository Cluster: AtpReconciliationBackupRepositoryImpl,
+ * {@link de.metas.material.dispo.commons.repository.repohelpers.AtpReconciliationDetailRepo}
+ * <p>
+ * Default {@link AtpReconciliationBackupRepository}: persists rows to {@code MD_ATP_Reconciliation_Backup} via the
+ * ordinary {@link InterfaceWrapperHelper} save path (no bespoke SQL, matching every other repository in this
+ * package). {@code AtpReconciliationDetailRepo} writes/reads the SAME table's one-row-per-candidate
+ * {@code IsCandidateOwnDetail='Y'} rows - the two are disjoint by that column, never in contention.
+ */
+@Repository
+public class AtpReconciliationBackupRepositoryImpl implements AtpReconciliationBackupRepository
+{
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@Override
+	public void backupBeforeWrite(
+			@NonNull final String runUuid,
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final List<Candidate> stockCandidatesInScope)
+	{
+		for (final Candidate candidate : stockCandidatesInScope)
+		{
+			final I_MD_ATP_Reconciliation_Backup record = InterfaceWrapperHelper.newInstance(I_MD_ATP_Reconciliation_Backup.class);
+			record.setReconciliationRunUUID(runUuid);
+			record.setMD_Candidate_ID(candidate.getId().getRepoId());
+			record.setDateProjected(TimeUtil.asTimestamp(candidate.getMaterialDescriptor().getDate()));
+			record.setM_Warehouse_ID(key.getWarehouseId().getRepoId());
+			record.setM_Product_ID(key.getProductId().getRepoId());
+			record.setStorageAttributesKey(key.getStorageAttributesKey().getAsString());
+			record.setQtyBefore(candidate.getQuantity());
+			// unknown until recordAfterWrite completes this same row; the column is NOT NULL, so carry the
+			// pre-change value until then rather than leave a half-written row unreadable
+			record.setQtyAfter(candidate.getQuantity());
+			InterfaceWrapperHelper.save(record);
+		}
+	}
+
+	@Override
+	public void recordAfterWrite(
+			@NonNull final String runUuid,
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final List<AtpReconciliationRunLog.Entry> entries)
+	{
+		for (final AtpReconciliationRunLog.Entry entry : entries)
+		{
+			final I_MD_ATP_Reconciliation_Backup record = entry.isNewCandidate()
+					? newRecordFor(runUuid, key, entry)
+					: retrieveBackedUpRecord(runUuid, entry);
+			record.setQtyAfter(entry.getQtyAfter());
+			InterfaceWrapperHelper.save(record);
+		}
+	}
+
+	private static I_MD_ATP_Reconciliation_Backup newRecordFor(
+			@NonNull final String runUuid,
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final AtpReconciliationRunLog.Entry entry)
+	{
+		final I_MD_ATP_Reconciliation_Backup record = InterfaceWrapperHelper.newInstance(I_MD_ATP_Reconciliation_Backup.class);
+		record.setReconciliationRunUUID(runUuid);
+		record.setMD_Candidate_ID(entry.getCandidateId().getRepoId());
+		record.setDateProjected(TimeUtil.asTimestamp(entry.getDate()));
+		record.setM_Warehouse_ID(key.getWarehouseId().getRepoId());
+		record.setM_Product_ID(key.getProductId().getRepoId());
+		record.setStorageAttributesKey(key.getStorageAttributesKey().getAsString());
+		record.setQtyBefore(null);
+		return record;
+	}
+
+	/** @return the row {@link #backupBeforeWrite} already created for this exact run and candidate. */
+	private I_MD_ATP_Reconciliation_Backup retrieveBackedUpRecord(
+			@NonNull final String runUuid,
+			@NonNull final AtpReconciliationRunLog.Entry entry)
+	{
+		return assumeNotNull(
+				queryBL.createQueryBuilder(I_MD_ATP_Reconciliation_Backup.class)
+						.addEqualsFilter(I_MD_ATP_Reconciliation_Backup.COLUMNNAME_ReconciliationRunUUID, runUuid)
+						.addEqualsFilter(I_MD_ATP_Reconciliation_Backup.COLUMNNAME_MD_Candidate_ID, entry.getCandidateId().getRepoId())
+						.create()
+						.firstOnlyOptional(I_MD_ATP_Reconciliation_Backup.class)
+						.orElse(null),
+				"backupBeforeWrite must have already created a row for run={} candidateId={}", runUuid, entry.getCandidateId());
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpReconciliationCommand.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpReconciliationCommand.java
@@ -1,0 +1,330 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import de.metas.Profiles;
+import de.metas.material.commons.attributes.clasifiers.BPartnerClassifier;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.dispo.commons.candidate.Candidate;
+import de.metas.material.dispo.commons.candidate.CandidateBusinessCase;
+import de.metas.material.dispo.commons.candidate.CandidateId;
+import de.metas.material.dispo.commons.candidate.CandidateType;
+import de.metas.material.dispo.commons.candidate.businesscase.AtpReconciliationDetail;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
+import de.metas.material.dispo.commons.repository.DateAndSeqNo;
+import de.metas.material.dispo.commons.repository.query.CandidatesQuery;
+import de.metas.material.dispo.commons.repository.query.MaterialDescriptorQuery;
+import de.metas.material.dispo.service.candidatechange.CandidateChangeService;
+import de.metas.material.event.commons.MaterialDescriptor;
+import de.metas.material.event.commons.ProductDescriptor;
+import de.metas.organization.ClientAndOrgId;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Brings a reconciliation key's stored projected ATP back onto {@link AtpTargetCalculator#computeTarget}, without
+ * moving physical stock.
+ * <p>
+ * The correction is always a delta-carrying candidate handed to the engine's ordinary
+ * {@link CandidateChangeService#onCandidateNewOrChange(Candidate)}, never a direct write of a {@code STOCK}
+ * candidate's {@code Qty} (unlike the existing {@code MD_Candidate_Remove_From_ATP.sql} cleanup) - that is what lets
+ * the engine's own forward propagation re-derive every later candidate instead of the correction being silently
+ * overwritten by it.
+ * <p>
+ * <b>Why {@link Profiles#PROFILE_MaterialDispo}-only:</b> its collaborator {@link CandidateChangeService} (and the
+ * whole dispo engine behind it) carries the same profile, active only in the app server, never the webapi - both
+ * component-scan {@code de.metas}, so an unconditional {@code @Service} here would abort webapi startup with
+ * "required a bean of type CandidateChangeService that could not be found". Consequence: the webapi never calls this
+ * class directly - a real run is enqueued as a {@code C_Queue_WorkPackage} and processed by
+ * {@code AtpReconciliationWorkpackageProcessor} in the app server, where the profile is active.
+ * {@link AtpTargetCalculator} is deliberately left unguarded so the webapi can still preview a dry run without this
+ * bean.
+ */
+@Service
+@Profile(Profiles.PROFILE_MaterialDispo)
+@RequiredArgsConstructor(onConstructor_ = @__(@Autowired))
+public class AtpReconciliationCommand
+{
+	@NonNull private final AtpTargetCalculator atpTargetCalculator;
+	@NonNull private final CandidateChangeService candidateChangeHandler;
+	@NonNull private final CandidateRepositoryRetrieval candidateRepository;
+	@NonNull private final AtpReconciliationBackupRepository backupRepository;
+
+	/** Convenience overload for {@link #reconcile} callers, which never touch the backup repository. */
+	public AtpReconciliationCommand(
+			@NonNull final AtpTargetCalculator atpTargetCalculator,
+			@NonNull final CandidateChangeService candidateChangeHandler,
+			@NonNull final CandidateRepositoryRetrieval candidateRepository)
+	{
+		this(atpTargetCalculator, candidateChangeHandler, candidateRepository, new AtpReconciliationBackupRepositoryImpl());
+	}
+
+	/**
+	 * @param date the run date {@code D}
+	 * @param dryRun when {@code true}, only computes and returns the divergence - nothing is written
+	 * @return the divergence this call acted on (or would have, on a dry run or a no-op)
+	 */
+	public AtpDivergence reconcile(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date,
+			final boolean dryRun)
+	{
+		return reconcile(key, date, dryRun, null);
+	}
+
+	/**
+	 * Same as {@link #reconcile(StockDataRecordIdentifier, Instant, boolean)}, but a candidate dated strictly before
+	 * {@code livenessCutoff} is treated as closed regardless of its source document - see
+	 * {@link AtpTargetCalculator#computeTarget(StockDataRecordIdentifier, Instant, Instant)}.
+	 *
+	 * @param livenessCutoff {@code null} means no cutoff
+	 */
+	public AtpDivergence reconcile(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date,
+			final boolean dryRun,
+			@Nullable final Instant livenessCutoff)
+	{
+		final AtpDivergence divergence = atpTargetCalculator.computeDivergence(key, date, livenessCutoff);
+		if (isNoOpCorrection(divergence, dryRun))
+		{
+			return divergence;
+		}
+
+		// no caller-supplied run id on this path (unlike reconcileAndLog) - generate one just to tag the
+		// correction candidate's own ATP_RECONCILIATION detail; nothing else reads it.
+		writeCorrectionCandidate(key, date, divergence.getDifference(), UUID.randomUUID().toString());
+
+		return divergence;
+	}
+
+	/**
+	 * @return {@code true} when there's nothing to correct: a dry run, or a zero delta. Skipping the write here (not
+	 * writing a zero-qty candidate) is what makes a repeated/overlapping-selection run idempotent - {@link
+	 * #nextSeqNo}'s fresh-per-call seqNo would otherwise let each no-op run pile up a new candidate instead of
+	 * matching the previous one.
+	 */
+	private static boolean isNoOpCorrection(@NonNull final AtpDivergence divergence, final boolean dryRun)
+	{
+		return dryRun || divergence.getDifference().signum() == 0;
+	}
+
+	private void writeCorrectionCandidate(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date,
+			@NonNull final BigDecimal delta,
+			@NonNull final String runUuid)
+	{
+		final CandidateType type = delta.signum() > 0 ? CandidateType.INVENTORY_UP : CandidateType.INVENTORY_DOWN;
+		final Candidate candidate = buildCandidate(key, date, type, delta.abs(), runUuid);
+
+		candidateChangeHandler.onCandidateNewOrChange(candidate);
+	}
+
+	/**
+	 * Same correction as {@link #reconcile}, plus a durable audit trail in {@link AtpReconciliationBackupRepository}:
+	 * each changed candidate's pre-change {@code Qty} is persisted <b>before</b> the write, so it stays recoverable
+	 * even if the process ends right after.
+	 *
+	 * @return the run's audit trail (empty on a dry run or a no-op, since nothing was written)
+	 */
+	public AtpReconciliationRunLog reconcileAndLog(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date,
+			final boolean dryRun)
+	{
+		return reconcileAndLog(key, date, dryRun, null);
+	}
+
+	/**
+	 * Same as {@link #reconcileAndLog(StockDataRecordIdentifier, Instant, boolean)}, but honours a liveness cutoff -
+	 * see {@link #reconcile(StockDataRecordIdentifier, Instant, boolean, Instant)}.
+	 */
+	public AtpReconciliationRunLog reconcileAndLog(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date,
+			final boolean dryRun,
+			@Nullable final Instant livenessCutoff)
+	{
+		final AtpDivergence divergence = atpTargetCalculator.computeDivergence(key, date, livenessCutoff);
+		if (isNoOpCorrection(divergence, dryRun))
+		{
+			return AtpReconciliationRunLog.empty(divergence);
+		}
+
+		final String runUuid = UUID.randomUUID().toString();
+
+		final List<Candidate> stockCandidatesBeforeWrite = retrieveGeneralStockCandidatesFrom(key, date);
+		backupRepository.backupBeforeWrite(runUuid, key, stockCandidatesBeforeWrite);
+
+		writeCorrectionCandidate(key, date, divergence.getDifference(), runUuid);
+
+		final List<Candidate> stockCandidatesAfterWrite = retrieveGeneralStockCandidatesFrom(key, date);
+		final ImmutableList<AtpReconciliationRunLog.Entry> entries = buildEntries(stockCandidatesBeforeWrite, stockCandidatesAfterWrite);
+		backupRepository.recordAfterWrite(runUuid, key, entries);
+
+		return new AtpReconciliationRunLog(divergence, entries, runUuid);
+	}
+
+	/**
+	 * @return every general (not customer-reserved) {@code STOCK} candidate of {@code key} at or after {@code date}.
+	 * Deliberately wider than what {@link #reconcile} actually changes (no {@code SeqNo} cutoff) - the harmless
+	 * over-inclusion just costs an unchanged-snapshot row, since {@link #buildEntries} drops before==after pairs.
+	 */
+	private List<Candidate> retrieveGeneralStockCandidatesFrom(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date)
+	{
+		final MaterialDescriptorQuery materialDescriptorQuery = MaterialDescriptorQuery.builder()
+				.warehouseId(key.getWarehouseId())
+				.productId(key.getProductId().getRepoId())
+				.storageAttributesKey(key.getStorageAttributesKey())
+				.customer(BPartnerClassifier.none())
+				.timeRangeStart(DateAndSeqNo.atTimeNoSeqNo(date).withOperator(DateAndSeqNo.Operator.INCLUSIVE))
+				.build();
+
+		return candidateRepository.retrieveOrderedByDateAndSeqNo(
+				CandidatesQuery.builder()
+						.materialDescriptorQuery(materialDescriptorQuery)
+						.matchExactStorageAttributesKey(true)
+						.type(CandidateType.STOCK)
+						.build());
+	}
+
+	/**
+	 * Pairs each after-write candidate with whatever {@code Qty} it carried before the write - {@code null} when the
+	 * candidate did not exist yet, i.e. this run created it - and keeps only the ones that actually changed, which
+	 * is exactly "a candidate this run touched".
+	 */
+	private static ImmutableList<AtpReconciliationRunLog.Entry> buildEntries(
+			@NonNull final List<Candidate> stockCandidatesBeforeWrite,
+			@NonNull final List<Candidate> stockCandidatesAfterWrite)
+	{
+		final ImmutableMap<CandidateId, BigDecimal> qtyBeforeByCandidateId = stockCandidatesBeforeWrite.stream()
+				.collect(ImmutableMap.toImmutableMap(Candidate::getId, Candidate::getQuantity));
+
+		final ImmutableList.Builder<AtpReconciliationRunLog.Entry> entries = ImmutableList.builder();
+		for (final Candidate candidateAfterWrite : stockCandidatesAfterWrite)
+		{
+			final BigDecimal qtyBefore = qtyBeforeByCandidateId.get(candidateAfterWrite.getId());
+			final BigDecimal qtyAfter = candidateAfterWrite.getQuantity();
+			if (qtyBefore == null || qtyBefore.compareTo(qtyAfter) != 0)
+			{
+				entries.add(new AtpReconciliationRunLog.Entry(
+						candidateAfterWrite.getId(),
+						candidateAfterWrite.getMaterialDescriptor().getDate(),
+						qtyBefore,
+						qtyAfter));
+			}
+		}
+		return entries.build();
+	}
+
+	/**
+	 * Builds the correction candidate with a fresh, per-call {@link Candidate#getSeqNo()} (see {@link #nextSeqNo}) -
+	 * without it, a second same-{@code D} correction would natural-key-match the first on {@code DateProjected}
+	 * alone ({@code RepositoryCommons#configureBuilderDateFilters} only adds a {@code SeqNo} filter when
+	 * {@code seqNo > 0}) and overwrite it in place instead of adding a further delta. Measured: this turned a
+	 * correctly-reconciled 100 into 0 before {@code seqNo} was assigned here (see
+	 * {@code AtpReconciliationCommandTest#reconcilingTwiceInSuccession_leavesTheStoredValueUnchanged}).
+	 */
+	private Candidate buildCandidate(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date,
+			@NonNull final CandidateType type,
+			@NonNull final BigDecimal qty,
+			@NonNull final String runUuid)
+	{
+		final MaterialDescriptor materialDescriptor = MaterialDescriptor.builder()
+				.date(date)
+				.productDescriptor(ProductDescriptor.forProductAndAttributes(key.getProductId().getRepoId(), key.getStorageAttributesKey()))
+				.warehouseId(key.getWarehouseId())
+				// targets the general chain, matching the customer-agnostic MD_Stock.QtyOnHand it's anchored on
+				.customerId(null)
+				.quantity(qty)
+				.build();
+
+		// null qtyBefore: this candidate did not exist before the run, matching the same convention
+		// AtpReconciliationBackupRepositoryImpl.newRecordFor uses for the STOCK candidates a run creates.
+		final AtpReconciliationDetail businessCaseDetail = AtpReconciliationDetail.builder()
+				.reconciliationRunUUID(runUuid)
+				.qtyBefore(null)
+				.qtyAfter(qty)
+				.build();
+
+		return Candidate.builder()
+				.clientAndOrgId(ClientAndOrgId.ofClientAndOrg(key.getClientId(), key.getOrgId()))
+				.type(type)
+				.businessCase(CandidateBusinessCase.ATP_RECONCILIATION)
+				.businessCaseDetail(businessCaseDetail)
+				.materialDescriptor(materialDescriptor)
+				.seqNo(nextSeqNo(key, date))
+				.build();
+	}
+
+	/**
+	 * @return one past the key's general {@code STOCK} candidate's current {@code SeqNo} at exactly {@code date}, or
+	 * {@code 1} if none yet. Read fresh from the store (not a counter field) so a JVM restart can't collide with a
+	 * value a previous JVM already wrote - same "next slot" pattern as
+	 * {@code DDOrderAdvisedOrCreatedHandler#expectedSeqNoForDemandCandidate}.
+	 * <p>
+	 * <b>Known gap, accepted:</b> read-then-write with no lock/uniqueness constraint on {@code (key, date, SeqNo)} -
+	 * two racing {@link #reconcile} calls for the same key/date could compute the same next value and overwrite
+	 * each other. Not hardened: this is a single-operator workflow, and the two current callers are each already
+	 * serialised - the webapi dry-run process via {@code AD_Process.IsOneInstanceOnly = 'Y'}, the async write path
+	 * via {@code C_Queue_Processor.PoolSize = 1}. The gap itself stays open: a future caller of {@link #reconcile}
+	 * is not automatically covered by either guard.
+	 */
+	private int nextSeqNo(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date)
+	{
+		final MaterialDescriptorQuery materialDescriptorQuery = MaterialDescriptorQuery.builder()
+				.warehouseId(key.getWarehouseId())
+				.productId(key.getProductId().getRepoId())
+				.storageAttributesKey(key.getStorageAttributesKey())
+				.customer(BPartnerClassifier.none())
+				.atTime(DateAndSeqNo.atTimeNoSeqNo(date))
+				.build();
+
+		final Candidate stockCandidateAtDate = candidateRepository.retrieveLatestMatchOrNull(
+				CandidatesQuery.builder()
+						.materialDescriptorQuery(materialDescriptorQuery)
+						.matchExactStorageAttributesKey(true)
+						.type(CandidateType.STOCK)
+						.build());
+
+		return stockCandidateAtDate != null ? stockCandidateAtDate.getSeqNo() + 1 : 1;
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpReconciliationRunLog.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpReconciliationRunLog.java
@@ -1,0 +1,89 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableList;
+import de.metas.material.dispo.commons.candidate.CandidateId;
+import lombok.NonNull;
+import lombok.Value;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * The audit trail of one {@link AtpReconciliationCommand#reconcileAndLog} run: which {@code STOCK} candidates it
+ * changed, and what {@code Qty} each one carried immediately before the run touched it.
+ * <p>
+ * That before-value is read from the store before {@link AtpReconciliationCommand#reconcile} writes anything, so
+ * nothing is lost even though this in-process object does not itself outlive the run - {@link #getRunUuid()} is
+ * the key under which {@link AtpReconciliationBackupRepository} persists the same before/after values durably.
+ * <p>
+ * A candidate absent from {@link #getEntries()} was not touched by the run: either the run wrote nothing (a dry
+ * run, or a zero delta), or the candidate falls outside the general {@code STOCK} chain from the run's date onward.
+ */
+@Value
+public class AtpReconciliationRunLog
+{
+	@NonNull AtpDivergence divergence;
+	@NonNull ImmutableList<Entry> entries;
+
+	/**
+	 * Groups this run's persisted {@link AtpReconciliationBackupRepository} rows; {@code null} when nothing was
+	 * written (a dry run, or a zero delta).
+	 */
+	@Nullable String runUuid;
+
+	public static AtpReconciliationRunLog empty(@NonNull final AtpDivergence divergence)
+	{
+		return new AtpReconciliationRunLog(divergence, ImmutableList.of(), null);
+	}
+
+	public boolean isEmpty()
+	{
+		return entries.isEmpty();
+	}
+
+	/**
+	 * One {@code STOCK} candidate this run changed.
+	 */
+	@Value
+	public static class Entry
+	{
+		@NonNull CandidateId candidateId;
+		@NonNull Instant date;
+
+		/**
+		 * The candidate's {@code Qty} immediately before this run touched it, or {@code null} when the run itself
+		 * created this candidate (nothing to back up).
+		 */
+		@Nullable BigDecimal qtyBefore;
+
+		@NonNull BigDecimal qtyAfter;
+
+		public boolean isNewCandidate()
+		{
+			return qtyBefore == null;
+		}
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpReconciliationRunRequest.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpReconciliationRunRequest.java
@@ -1,0 +1,57 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * One whole reconciliation run as the operator asked for it: <i>which</i> keys, at <i>which</i> date, under
+ * <i>which</i> liveness rule.
+ * <p>
+ * This is the payload that crosses the JVM boundary - a real run is enqueued in the webapi and reconciled in the
+ * app server (see {@code de.metas.material.dispo.reconcile.async.AtpReconciliationEnqueueService}). The
+ * <b>run date</b> in particular must be captured here rather than derived in the app server, where it would
+ * silently become "whenever the queue got around to it" - a different reconciliation point, and therefore a
+ * different result.
+ */
+@Value
+@Builder
+public class AtpReconciliationRunRequest
+{
+	@NonNull AtpKeySelection selection;
+
+	/** The reconciliation point {@code D}: candidates dated after it are not part of the target. */
+	@NonNull Instant runDate;
+
+	/**
+	 * When set, a candidate dated strictly before this instant is treated as closed regardless of what its source
+	 * document says - see {@link AtpTargetCalculator#computeTarget(de.metas.material.cockpit.stock.StockDataRecordIdentifier, Instant, Instant)}.
+	 * {@code null} means no candidate is cut off.
+	 */
+	@Nullable Instant livenessCutoff;
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpTargetCalculator.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/AtpTargetCalculator.java
@@ -1,0 +1,246 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import de.metas.document.dimension.DimensionService;
+import de.metas.document.dimension.MDCandidateDimensionFactory;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.cockpit.stock.StockRepository;
+import de.metas.material.commons.attributes.clasifiers.BPartnerClassifier;
+import de.metas.material.dispo.commons.candidate.Candidate;
+import de.metas.material.dispo.commons.candidate.CandidateId;
+import de.metas.material.dispo.commons.candidate.CandidateType;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
+import de.metas.material.dispo.commons.repository.DateAndSeqNo;
+import de.metas.material.dispo.commons.repository.query.CandidatesQuery;
+import de.metas.material.dispo.commons.repository.query.MaterialDescriptorQuery;
+import de.metas.material.dispo.commons.repository.repohelpers.StockChangeDetailRepo;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.compiere.Adempiere;
+import org.compiere.SpringContextHolder;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Computes, for one reconciliation key and one date {@code D}, the projected ATP that key <i>ought</i> to
+ * have:
+ *
+ * <pre>
+ * target(key, D) = MD_Stock.QtyOnHand(key)
+ *                + &Sigma; signed(Qty - QtyFulfilled)   over the non-STOCK candidates c of key
+ *                                                  with date(c) &le; D and liveness(c) == STILL_OPEN
+ * </pre>
+ * <p>
+ * Candidates dated <b>after</b> D are excluded: the reconciliation hands its correction to the engine's ordinary
+ * candidate-change handling at D, whose forward propagation re-derives every later stock candidate from those
+ * later positions - counting them here too would double them.
+ * <p>
+ * Single expression behind both the reconciliation (which writes the delta) and the divergence report (which only
+ * shows it), so the two cannot disagree about what "correct" means.
+ */
+@Service
+@RequiredArgsConstructor
+public class AtpTargetCalculator
+{
+	@NonNull private final StockRepository stockRepository;
+	@NonNull private final CandidateRepositoryRetrieval candidateRepository;
+	@NonNull private final SourceDocumentLivenessService livenessService;
+
+	@VisibleForTesting
+	public static AtpTargetCalculator newInstanceForUnitTesting()
+	{
+		Adempiere.assertUnitTestMode();
+		//noinspection DataFlowIssue
+		return SpringContextHolder.getBeanOrSupply(
+				AtpTargetCalculator.class,
+				() -> new AtpTargetCalculator(
+						SpringContextHolder.getBeanOrSupply(StockRepository.class, StockRepository::new),
+						SpringContextHolder.getBeanOrSupply(
+								CandidateRepositoryRetrieval.class,
+								() -> new CandidateRepositoryRetrieval(
+										new DimensionService(ImmutableList.of(new MDCandidateDimensionFactory())),
+										new StockChangeDetailRepo())),
+						SourceDocumentLivenessService.newInstanceForUnitTesting()));
+	}
+
+	/**
+	 * @param date the run date {@code D}; candidates dated after it are excluded
+	 * @return the projected ATP the given key ought to have at the given date
+	 */
+	public BigDecimal computeTarget(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date)
+	{
+		return computeTarget(key, date, null);
+	}
+
+	/**
+	 * Same as {@link #computeTarget(StockDataRecordIdentifier, Instant)}, but a candidate dated strictly before
+	 * {@code livenessCutoff} is treated as {@link de.metas.material.dispo.commons.reconcile.SourceDocumentStatus#CLOSED}
+	 * regardless of its source document - see {@link SourceDocumentLivenessService#getStatus(Candidate, Instant)}.
+	 * The operator-facing escape hatch for an era whose document statuses are themselves unreliable.
+	 *
+	 * @param livenessCutoff {@code null} means no cutoff - same as the two-arg overload
+	 */
+	public BigDecimal computeTarget(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date,
+			@Nullable final Instant livenessCutoff)
+	{
+		final List<Candidate> candidates = candidateRepository
+				.retrieveOrderedByDateAndSeqNo(createCandidatesQueryUntilDate(key, date, BPartnerClassifier.any()));
+
+		// QtyFulfilled is not part of the Candidate value object, so it is fetched separately - in one query
+		// for the whole chain, see CandidateRepositoryRetrieval#getQtyFulfilledByCandidateIds
+		final ImmutableMap<CandidateId, BigDecimal> qtyFulfilledByCandidateId = candidateRepository.getQtyFulfilledByCandidateIds(
+				candidates.stream()
+						.map(Candidate::getId)
+						.collect(ImmutableList.toImmutableList()));
+
+		BigDecimal target = stockRepository.getQtyOnHand(key);
+		for (final Candidate candidate : candidates)
+		{
+			if (candidate.getType() == CandidateType.STOCK)
+			{
+				// a STOCK candidate is the running balance itself, not a position contributing to it
+				continue;
+			}
+			if (!livenessService.getStatus(candidate, livenessCutoff).isContributingToAtp())
+			{
+				continue;
+			}
+
+			target = target.add(computeSignedOpenQty(candidate, qtyFulfilledByCandidateId));
+		}
+
+		return target;
+	}
+
+	/**
+	 * @return the divergence between {@link #computeTarget(StockDataRecordIdentifier, Instant)} and the
+	 * projected ATP currently stored for the given key at the given date
+	 */
+	public AtpDivergence computeDivergence(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date)
+	{
+		return computeDivergence(key, date, null);
+	}
+
+	/**
+	 * Same as {@link #computeDivergence(StockDataRecordIdentifier, Instant)}, but honours a liveness cutoff - see
+	 * {@link #computeTarget(StockDataRecordIdentifier, Instant, Instant)}.
+	 */
+	public AtpDivergence computeDivergence(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date,
+			@Nullable final Instant livenessCutoff)
+	{
+		return AtpDivergence.of(
+				computeTarget(key, date, livenessCutoff),
+				retrieveStoredAtp(key, date));
+	}
+
+	/**
+	 * @return the {@code Qty} of the key's youngest <b>general</b> {@code STOCK} candidate at or before the given
+	 * date - the running balance the system currently believes in - or {@link BigDecimal#ZERO} if none.
+	 * <p>
+	 * "General" means {@code C_BPartner_Customer_ID IS NULL} ({@link BPartnerClassifier#none()}). Unlike the sum
+	 * in {@link #computeTarget(StockDataRecordIdentifier, Instant)}, this lookup must NOT be customer-agnostic:
+	 * {@code StockCandidateService} propagates the customer id onto a {@code STOCK} candidate reserved for a
+	 * customer, so such a candidate's {@code Qty} balances only that customer's rows plus the null-customer rows -
+	 * not the general population, which is what an {@code expectedAtp} anchored on {@code MD_Stock.QtyOnHand} (no
+	 * customer dimension) has to be compared against.
+	 */
+	private BigDecimal retrieveStoredAtp(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date)
+	{
+		final Candidate stockCandidate = candidateRepository.retrieveLatestMatchOrNull(
+				createCandidatesQueryUntilDate(key, date, BPartnerClassifier.none())
+						.withType(CandidateType.STOCK));
+
+		return stockCandidate != null ? stockCandidate.getQuantity() : BigDecimal.ZERO;
+	}
+
+	/**
+	 * The open remainder is {@code Qty - QtyFulfilled}; its <i>sign</i> depends on the candidate's type, and that
+	 * mapping exists exactly once, in {@link Candidate#getStockImpactPlannedQuantity()} - so the remainder is put
+	 * back onto the candidate and run through that one authoritative formula instead of switching on type again
+	 * here.
+	 * <p>
+	 * Not cosmetic: {@code openQty.abs()} plus a {@code signum()} of the candidate's own signed quantity would
+	 * break for {@code Qty = 0}, whose {@code signum()} carries no direction - and zero-quantity
+	 * {@code INVENTORY_DOWN} candidates do occur in real data (a zero-movement inventory creates one).
+	 *
+	 * @return the candidate's still-open quantity, signed by its effect on stock
+	 */
+	private static BigDecimal computeSignedOpenQty(
+			@NonNull final Candidate candidate,
+			@NonNull final ImmutableMap<CandidateId, BigDecimal> qtyFulfilledByCandidateId)
+	{
+		final BigDecimal qtyFulfilled = qtyFulfilledByCandidateId.getOrDefault(candidate.getId(), BigDecimal.ZERO);
+		final BigDecimal openQty = candidate.getQuantity().subtract(qtyFulfilled);
+
+		return candidate.withQuantity(openQty).getStockImpactPlannedQuantity();
+	}
+
+	/**
+	 * @param customer how the query treats {@code MD_Candidate.C_BPartner_Customer_ID}: the sum over the key's
+	 * positions is customer-agnostic ({@link BPartnerClassifier#any()}) because customer-reserved demand still
+	 * consumes real physical stock, while the stored-balance lookup stays on the general chain
+	 * ({@link BPartnerClassifier#none()}) - see {@link #retrieveStoredAtp}.
+	 */
+	private static CandidatesQuery createCandidatesQueryUntilDate(
+			@NonNull final StockDataRecordIdentifier key,
+			@NonNull final Instant date,
+			@NonNull final BPartnerClassifier customer)
+	{
+		final MaterialDescriptorQuery materialDescriptorQuery = MaterialDescriptorQuery.builder()
+				.warehouseId(key.getWarehouseId())
+				.productId(key.getProductId().getRepoId())
+				.storageAttributesKey(key.getStorageAttributesKey())
+				.customer(customer)
+				// client/org aren't filtered here: a warehouse belongs to exactly one org of one client, so
+				// M_Warehouse_ID already pins both (MD_Stock's side does filter them, since it carries them in its key)
+				// seqNo stays at 0 -> plain "DateProjected <= date"; seqNo > 0 would add "(date < D OR (date = D AND seqNo <= n))"
+				.timeRangeEnd(DateAndSeqNo.atTimeNoSeqNo(date).withOperator(DateAndSeqNo.Operator.INCLUSIVE))
+				.build();
+
+		return CandidatesQuery.builder()
+				.materialDescriptorQuery(materialDescriptorQuery)
+				.matchExactStorageAttributesKey(true)
+				// type left unset on purpose: CandidatesQuery can't express "type != STOCK", so STOCK candidates
+				// come back too and are dropped in computeTarget - immaterial here (largest measured chain: 913
+				// rows for one product). (retrieveStoredAtp narrows this query to exactly CandidateType.STOCK.)
+				.build();
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/SourceDocumentLivenessService.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/SourceDocumentLivenessService.java
@@ -1,0 +1,295 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.annotations.VisibleForTesting;
+import de.metas.document.engine.DocStatus;
+import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.material.dispo.commons.candidate.Candidate;
+import de.metas.material.dispo.commons.candidate.CandidateBusinessCase;
+import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
+import de.metas.material.dispo.commons.candidate.businesscase.DistributionDetail;
+import de.metas.material.dispo.commons.candidate.businesscase.ProductionDetail;
+import de.metas.material.dispo.commons.candidate.businesscase.PurchaseDetail;
+import de.metas.material.dispo.commons.reconcile.SourceDocumentStatus;
+import de.metas.material.event.ddorder.DDOrderRef;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.compiere.Adempiere;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_M_Forecast;
+import org.compiere.model.I_M_ForecastLine;
+import org.eevolution.api.PPOrderId;
+import org.eevolution.model.I_DD_Order;
+import org.eevolution.model.I_PP_Order;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * Decides whether an {@link de.metas.material.dispo.commons.candidate.CandidateType#DEMAND}/supply
+ * candidate still contributes to the projected ATP, by looking at the status of the document the
+ * candidate was created from.
+ * <p>
+ * The candidate's own quantities cannot answer that question: a position that was never moved and a
+ * position that will never be moved both read {@code Qty = 20, QtyFulfilled = 0}. Measured on
+ * {@code modus_operandi_hotfix} with cucumber scenario {@code @Id:ATPBASE_006}: after a manufacturing
+ * order is CLOSED with its components never issued, the {@code DEMAND}/{@code PRODUCTION} candidate
+ * still carries {@code Qty = 20} and still decrements ATP. For the same reason the denormalized
+ * {@code ProductionDetail#getPpOrderDocStatus()} / {@code DistributionDetail#getDdOrderDocStatus()}
+ * snapshots on the candidate are deliberately NOT used here — only the live source document is.
+ * <p>
+ * The still-open condition per business case:
+ * <table>
+ * <caption>liveness predicates</caption>
+ * <tr><th>business case</th><th>source document</th><th>still open when</th></tr>
+ * <tr><td>SHIPMENT</td><td>{@code M_ShipmentSchedule}</td><td>{@code Processed='N' AND IsActive='Y'}</td></tr>
+ * <tr><td>PURCHASE</td><td>{@code M_ReceiptSchedule}</td><td>{@code Processed='N' AND IsActive='Y'}</td></tr>
+ * <tr><td>PRODUCTION</td><td>{@code PP_Order}</td><td>{@code DocStatus IN ('DR','IP','CO')}</td></tr>
+ * <tr><td>DISTRIBUTION</td><td>{@code DD_Order}</td><td>{@code DocStatus IN ('DR','IP','CO')}</td></tr>
+ * <tr><td>FORECAST</td><td>{@code M_Forecast} (via {@code M_ForecastLine})</td><td>{@code DocStatus IN ('DR','IP','CO')}</td></tr>
+ * </table>
+ * <p>
+ * {@code STOCK_CHANGE} and every candidate without a business case (i.e. every {@code STOCK}
+ * candidate) yield {@link SourceDocumentStatus#NO_SOURCE_DOCUMENT}, and that is deliberate rather than
+ * a gap: those candidates describe a change that has already been realized, so its effect is already
+ * inside the {@code MD_Stock.QtyOnHand} term of the target expression. Letting them contribute a second
+ * time would double-count them against physical stock — the same failure family as the drift this
+ * service exists to reconcile.
+ * <p>
+ * A candidate whose source document cannot be found at all — because the document was purged — likewise
+ * yields {@link SourceDocumentStatus#NO_SOURCE_DOCUMENT}, and must never abort the run: that dangling
+ * reference is itself part of the drifted state this feature exists to find and report. Hence the lookups
+ * go through {@link SourceDocumentRepository}, whose by-id lookup is null-tolerant.
+ */
+@Service
+@RequiredArgsConstructor
+public class SourceDocumentLivenessService
+{
+	@NonNull private final SourceDocumentRepository sourceDocumentRepository;
+
+	@VisibleForTesting
+	public static SourceDocumentLivenessService newInstanceForUnitTesting()
+	{
+		Adempiere.assertUnitTestMode();
+		//noinspection DataFlowIssue
+		return SpringContextHolder.getBeanOrSupply(
+				SourceDocumentLivenessService.class,
+				() -> new SourceDocumentLivenessService(
+						SpringContextHolder.getBeanOrSupply(
+								SourceDocumentRepository.class,
+								SourceDocumentRepository::new)));
+	}
+
+	/**
+	 * @return the status of the given candidate's source document
+	 */
+	public SourceDocumentStatus getStatus(@NonNull final Candidate candidate)
+	{
+		final CandidateBusinessCase businessCase = candidate.getBusinessCase();
+		if (businessCase == null)
+		{
+			// stock candidates carry no business case, and thus no source document
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		switch (businessCase)
+		{
+			case SHIPMENT:
+				return getShipmentScheduleStatus(candidate);
+			case PURCHASE:
+				return getReceiptScheduleStatus(candidate);
+			case PRODUCTION:
+				return getPPOrderStatus(candidate);
+			case DISTRIBUTION:
+				return getDDOrderStatus(candidate);
+			case FORECAST:
+				return getForecastStatus(candidate);
+			case STOCK_CHANGE:
+			default:
+				return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+	}
+
+	/**
+	 * Same as {@link #getStatus(Candidate)}, but a candidate dated strictly before the given cutoff is
+	 * considered {@link SourceDocumentStatus#CLOSED} no matter what its source document says. That
+	 * covers an era whose document statuses are themselves not trustworthy: orders that were long since
+	 * fulfilled but never processed still look open, so their candidates must not contribute to ATP.
+	 *
+	 * @param livenessCutoff may be {@code null}, in which case no candidate is cut off
+	 */
+	public SourceDocumentStatus getStatus(
+			@NonNull final Candidate candidate,
+			@Nullable final Instant livenessCutoff)
+	{
+		if (livenessCutoff != null && candidate.getDate().isBefore(livenessCutoff))
+		{
+			return SourceDocumentStatus.CLOSED;
+		}
+
+		return getStatus(candidate);
+	}
+
+	private SourceDocumentStatus getShipmentScheduleStatus(@NonNull final Candidate candidate)
+	{
+		final DemandDetail demandDetail = DemandDetail.castOrNull(candidate.getBusinessCaseDetail());
+		if (demandDetail == null)
+		{
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		final I_M_ShipmentSchedule shipmentSchedule = sourceDocumentRepository.getByIdOrNull(
+				I_M_ShipmentSchedule.class,
+				I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID,
+				demandDetail.getShipmentScheduleId());
+		if (shipmentSchedule == null)
+		{
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		return toStatus(!shipmentSchedule.isProcessed() && shipmentSchedule.isActive());
+	}
+
+	private SourceDocumentStatus getReceiptScheduleStatus(@NonNull final Candidate candidate)
+	{
+		final PurchaseDetail purchaseDetail = PurchaseDetail.castOrNull(candidate.getBusinessCaseDetail());
+		if (purchaseDetail == null)
+		{
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		final I_M_ReceiptSchedule receiptSchedule = sourceDocumentRepository.getByIdOrNull(
+				I_M_ReceiptSchedule.class,
+				I_M_ReceiptSchedule.COLUMNNAME_M_ReceiptSchedule_ID,
+				purchaseDetail.getReceiptScheduleRepoId());
+		if (receiptSchedule == null)
+		{
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		return toStatus(!receiptSchedule.isProcessed() && receiptSchedule.isActive());
+	}
+
+	private SourceDocumentStatus getPPOrderStatus(@NonNull final Candidate candidate)
+	{
+		final ProductionDetail productionDetail = ProductionDetail.castOrNull(candidate.getBusinessCaseDetail());
+		if (productionDetail == null)
+		{
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		final PPOrderId ppOrderId = productionDetail.getPpOrderId();
+		if (ppOrderId == null)
+		{
+			// the candidate references a PP_Order_Candidate only; there is no manufacturing order yet
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		final I_PP_Order ppOrder = sourceDocumentRepository.getByIdOrNull(
+				I_PP_Order.class,
+				I_PP_Order.COLUMNNAME_PP_Order_ID,
+				ppOrderId.getRepoId());
+		if (ppOrder == null)
+		{
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		return toStatus(isStillOpenDocStatus(ppOrder.getDocStatus()));
+	}
+
+	private SourceDocumentStatus getDDOrderStatus(@NonNull final Candidate candidate)
+	{
+		final DistributionDetail distributionDetail = DistributionDetail.castOrNull(candidate.getBusinessCaseDetail());
+		if (distributionDetail == null)
+		{
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		final DDOrderRef ddOrderRef = distributionDetail.getDdOrderRef();
+		if (ddOrderRef == null)
+		{
+			// the candidate references a DD_Order_Candidate only; there is no distribution order yet
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		final I_DD_Order ddOrder = sourceDocumentRepository.getByIdOrNull(
+				I_DD_Order.class,
+				I_DD_Order.COLUMNNAME_DD_Order_ID,
+				ddOrderRef.getDdOrderId());
+		if (ddOrder == null)
+		{
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		return toStatus(isStillOpenDocStatus(ddOrder.getDocStatus()));
+	}
+
+	private SourceDocumentStatus getForecastStatus(@NonNull final Candidate candidate)
+	{
+		final DemandDetail demandDetail = DemandDetail.castOrNull(candidate.getBusinessCaseDetail());
+		if (demandDetail == null)
+		{
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		// the demand detail references the forecast LINE; the DocStatus lives on the forecast header
+		final I_M_ForecastLine forecastLine = sourceDocumentRepository.getByIdOrNull(
+				I_M_ForecastLine.class,
+				I_M_ForecastLine.COLUMNNAME_M_ForecastLine_ID,
+				demandDetail.getForecastLineId());
+		if (forecastLine == null)
+		{
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		final I_M_Forecast forecast = sourceDocumentRepository.getByIdOrNull(
+				I_M_Forecast.class,
+				I_M_Forecast.COLUMNNAME_M_Forecast_ID,
+				forecastLine.getM_Forecast_ID());
+		if (forecast == null)
+		{
+			return SourceDocumentStatus.NO_SOURCE_DOCUMENT;
+		}
+
+		return toStatus(isStillOpenDocStatus(forecast.getDocStatus()));
+	}
+
+	/**
+	 * @return {@code true} if the given code is one of {@code DR}, {@code IP} or {@code CO}
+	 */
+	private static boolean isStillOpenDocStatus(@Nullable final String docStatusCode)
+	{
+		final DocStatus docStatus = DocStatus.ofNullableCode(docStatusCode);
+		return docStatus != null && docStatus.isDraftedInProgressOrCompleted();
+	}
+
+	private static SourceDocumentStatus toStatus(final boolean stillOpen)
+	{
+		return stillOpen
+				? SourceDocumentStatus.STILL_OPEN
+				: SourceDocumentStatus.CLOSED;
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/SourceDocumentRepository.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/SourceDocumentRepository.java
@@ -1,0 +1,195 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.common.util.IdConstants;
+import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.material.dispo.model.I_MD_Candidate_Demand_Detail;
+import de.metas.material.dispo.model.I_MD_Candidate_Purchase_Detail;
+import de.metas.product.ProductCategoryId;
+import de.metas.product.ProductId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryBuilder;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_M_Product;
+import org.springframework.stereotype.Repository;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * Repository Tables: M_ShipmentSchedule, M_ReceiptSchedule, PP_Order, DD_Order, M_ForecastLine, M_Forecast,
+ * MD_Candidate_Demand_Detail, MD_Candidate_Purchase_Detail
+ * Repository Cluster: SourceDocumentRepository
+ * <p>
+ * READ-ONLY, and owns none of those tables - each keeps its own DAO as persistence owner (see the
+ * {@link IQueryBL} note below). It claims no write ownership, so a table above later gaining a declared owner
+ * elsewhere is the accepted reader/owner split, not a second-writer conflict. {@code MD_Candidate_Demand_Detail}/
+ * {@code MD_Candidate_Purchase_Detail} are read only as an existence check ({@code NOT IN} subquery) in
+ * {@link #retrieveOpenShipmentScheduleIdsWithoutCandidate}/{@link #retrieveOpenReceiptScheduleIdsWithoutCandidate}
+ * - the owning module's repositories still write them.
+ * <p>
+ * Loads the source document behind an {@code MD_Candidate} for {@link SourceDocumentLivenessService}, tolerating
+ * a miss.
+ * <p>
+ * Goes through {@link IQueryBL} rather than each source document's own DAO because no null-tolerant by-id lookup
+ * exists across all five: {@code ShipmentSchedulePA.getById}/{@code IForecastDAO.getById} throw on a miss, and the
+ * receipt-schedule/{@code PP_Order}/{@code DD_Order} DAOs NPE on one in unit-test POJO mode - {@code DD_Order}
+ * and the {@code M_ForecastLine} hop offer no null-tolerant batch alternative either. A candidate referencing a
+ * purged document must degrade to
+ * {@link de.metas.material.dispo.commons.reconcile.SourceDocumentStatus#NO_SOURCE_DOCUMENT}, never abort the run
+ * - that dangling reference is precisely the drift this feature exists to find and report.
+ */
+@Repository
+public class SourceDocumentRepository
+{
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	/**
+	 * @return the record with the given id, or {@code null} if there is no such record - or if the given id
+	 * is unset
+	 */
+	@Nullable
+	public <T> T getByIdOrNull(
+			@NonNull final Class<T> modelClass,
+			@NonNull final String idColumnName,
+			final int recordId)
+	{
+		// note that an unset id is IdConstants.UNSPECIFIED_REPO_ID, which is positive
+		final int repoId = IdConstants.toRepoId(recordId);
+		if (repoId <= 0)
+		{
+			return null;
+		}
+
+		return queryBL.createQueryBuilder(modelClass)
+				.addEqualsFilter(idColumnName, repoId)
+				.create()
+				.firstOnly(modelClass);
+	}
+
+	/**
+	 * @return {@code M_ShipmentSchedule_ID} of every open ({@code Processed='N'}, active) shipment schedule that no
+	 * active {@code MD_Candidate_Demand_Detail} row references, restricted by the optional
+	 * warehouse/product/product-category filter - one page of at most {@code limit} at {@code offset}, ordered by
+	 * {@code M_ShipmentSchedule_ID} for stable pagination.
+	 * <p>
+	 * This is the one drift {@link AtpTargetCalculator}'s recompute cannot close: there is no candidate to correct,
+	 * so it has to be surfaced instead of silently absorbed.
+	 */
+	public List<Integer> retrieveOpenShipmentScheduleIdsWithoutCandidate(
+			@Nullable final WarehouseId warehouseId,
+			@Nullable final ProductId productId,
+			@Nullable final ProductCategoryId productCategoryId,
+			final int limit,
+			final int offset)
+	{
+		final IQueryBuilder<I_M_ShipmentSchedule> queryBuilder = queryBL.createQueryBuilder(I_M_ShipmentSchedule.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_Processed, false)
+				.addNotInSubQueryFilter(
+						I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID,
+						I_MD_Candidate_Demand_Detail.COLUMNNAME_M_ShipmentSchedule_ID,
+						queryBL.createQueryBuilder(I_MD_Candidate_Demand_Detail.class)
+								.addOnlyActiveRecordsFilter()
+								.create());
+
+		addLocationFilters(queryBuilder,
+				I_M_ShipmentSchedule.COLUMNNAME_M_Warehouse_ID, I_M_ShipmentSchedule.COLUMNNAME_M_Product_ID,
+				warehouseId, productId, productCategoryId);
+
+		return queryBuilder
+				.orderBy().addColumnAscending(I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID).endOrderBy()
+				.create()
+				.setLimit(limit, offset)
+				.listIds();
+	}
+
+	/**
+	 * Same as {@link #retrieveOpenShipmentScheduleIdsWithoutCandidate}, for {@code M_ReceiptSchedule} /
+	 * {@code MD_Candidate_Purchase_Detail}.
+	 */
+	public List<Integer> retrieveOpenReceiptScheduleIdsWithoutCandidate(
+			@Nullable final WarehouseId warehouseId,
+			@Nullable final ProductId productId,
+			@Nullable final ProductCategoryId productCategoryId,
+			final int limit,
+			final int offset)
+	{
+		final IQueryBuilder<I_M_ReceiptSchedule> queryBuilder = queryBL.createQueryBuilder(I_M_ReceiptSchedule.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_Processed, false)
+				.addNotInSubQueryFilter(
+						I_M_ReceiptSchedule.COLUMNNAME_M_ReceiptSchedule_ID,
+						I_MD_Candidate_Purchase_Detail.COLUMNNAME_M_ReceiptSchedule_ID,
+						queryBL.createQueryBuilder(I_MD_Candidate_Purchase_Detail.class)
+								.addOnlyActiveRecordsFilter()
+								.create());
+
+		addLocationFilters(queryBuilder,
+				I_M_ReceiptSchedule.COLUMNNAME_M_Warehouse_ID, I_M_ReceiptSchedule.COLUMNNAME_M_Product_ID,
+				warehouseId, productId, productCategoryId);
+
+		return queryBuilder
+				.orderBy().addColumnAscending(I_M_ReceiptSchedule.COLUMNNAME_M_ReceiptSchedule_ID).endOrderBy()
+				.create()
+				.setLimit(limit, offset)
+				.listIds();
+	}
+
+	/**
+	 * Applies the shared optional warehouse/product/product-category filter to a source-document query
+	 * builder - extracted because {@link #retrieveOpenShipmentScheduleIdsWithoutCandidate} and
+	 * {@link #retrieveOpenReceiptScheduleIdsWithoutCandidate} need the identical filter over two different
+	 * model classes that happen to share both column names.
+	 */
+	private <T> void addLocationFilters(
+			@NonNull final IQueryBuilder<T> queryBuilder,
+			@NonNull final String warehouseColumnName,
+			@NonNull final String productColumnName,
+			@Nullable final WarehouseId warehouseId,
+			@Nullable final ProductId productId,
+			@Nullable final ProductCategoryId productCategoryId)
+	{
+		if (warehouseId != null)
+		{
+			queryBuilder.addEqualsFilter(warehouseColumnName, warehouseId);
+		}
+		if (productId != null)
+		{
+			queryBuilder.addEqualsFilter(productColumnName, productId);
+		}
+		if (productCategoryId != null)
+		{
+			queryBuilder.addInSubQueryFilter(
+					productColumnName,
+					I_M_Product.COLUMNNAME_M_Product_ID,
+					queryBL.createQueryBuilder(I_M_Product.class)
+							.addEqualsFilter(I_M_Product.COLUMNNAME_M_Product_Category_ID, productCategoryId)
+							.create());
+		}
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/UncoveredSourceDocumentService.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/UncoveredSourceDocumentService.java
@@ -1,0 +1,82 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.annotations.VisibleForTesting;
+import de.metas.product.ProductCategoryId;
+import de.metas.product.ProductId;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.Adempiere;
+import org.compiere.SpringContextHolder;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * Exposes {@link SourceDocumentRepository}'s uncovered-open-document lookups to
+ * {@code de.metas.material.dispo.reconcile.process.MD_Candidate_ATP_Divergence_Report} - a plain
+ * {@code JavaProcess} may not call a {@code @Repository} bean directly (see {@code docs/REVIEW.md} §
+ * "JavaProcess subclasses are thin glue"), so this thin {@code @Service} sits between them.
+ */
+@Service
+@RequiredArgsConstructor
+public class UncoveredSourceDocumentService
+{
+	@NonNull private final SourceDocumentRepository sourceDocumentRepository;
+
+	@VisibleForTesting
+	public static UncoveredSourceDocumentService newInstanceForUnitTesting()
+	{
+		Adempiere.assertUnitTestMode();
+		//noinspection DataFlowIssue
+		return SpringContextHolder.getBeanOrSupply(
+				UncoveredSourceDocumentService.class,
+				() -> new UncoveredSourceDocumentService(
+						SpringContextHolder.getBeanOrSupply(SourceDocumentRepository.class, SourceDocumentRepository::new)));
+	}
+
+	/** @see SourceDocumentRepository#retrieveOpenShipmentScheduleIdsWithoutCandidate */
+	public List<Integer> retrieveOpenShipmentScheduleIdsWithoutCandidate(
+			@Nullable final WarehouseId warehouseId,
+			@Nullable final ProductId productId,
+			@Nullable final ProductCategoryId productCategoryId,
+			final int limit,
+			final int offset)
+	{
+		return sourceDocumentRepository.retrieveOpenShipmentScheduleIdsWithoutCandidate(warehouseId, productId, productCategoryId, limit, offset);
+	}
+
+	/** @see SourceDocumentRepository#retrieveOpenReceiptScheduleIdsWithoutCandidate */
+	public List<Integer> retrieveOpenReceiptScheduleIdsWithoutCandidate(
+			@Nullable final WarehouseId warehouseId,
+			@Nullable final ProductId productId,
+			@Nullable final ProductCategoryId productCategoryId,
+			final int limit,
+			final int offset)
+	{
+		return sourceDocumentRepository.retrieveOpenReceiptScheduleIdsWithoutCandidate(warehouseId, productId, productCategoryId, limit, offset);
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/async/AtpReconciliationEnqueueService.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/async/AtpReconciliationEnqueueService.java
@@ -1,0 +1,189 @@
+package de.metas.material.dispo.reconcile.async;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.async.api.IWorkPackageBuilder;
+import de.metas.async.api.IWorkPackageQueue;
+import de.metas.async.model.I_C_Queue_WorkPackage;
+import de.metas.async.processor.IWorkPackageQueueFactory;
+import de.metas.material.cockpit.model.I_MD_Stock;
+import de.metas.material.dispo.reconcile.AtpKeySelection;
+import de.metas.material.dispo.reconcile.AtpReconciliationRunRequest;
+import de.metas.product.ProductCategoryId;
+import de.metas.product.ProductId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.util.api.IParams;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_M_Product;
+import org.compiere.util.Env;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.Properties;
+
+/**
+ * Puts one {@link AtpReconciliationRunRequest} on the async queue, and reads it back off again.
+ * <p>
+ * <b>Why enqueued at all:</b> the real run needs {@code AtpReconciliationCommand}, which is
+ * {@code @Profile(Profiles.PROFILE_MaterialDispo)} and so only lives in the app server - never the webapi, where
+ * the WebUI-launched {@code AD_Process} actually executes. The queue is the established route between the two;
+ * {@link AtpReconciliationWorkpackageProcessor} does the work once the app server drains it.
+ * <p>
+ * Parameters travel via {@code C_Queue_WorkPackage_Param} ({@link IWorkPackageBuilder#parameter(String, Object)}
+ * out, {@link IParams} back in - the same mechanism as {@code DDOrderCandidateEnqueueService} and
+ * {@code RecreateInvoiceWorkpackageProcessor}), as plain {@code int}s so
+ * {@link IParams#getParameterAsInt(String, int)} is all the read-back needs. Parameter names match the
+ * {@code AD_Process_Para} column names, and {@link #extractRunRequest(IParams)} is the only reader, so the wire
+ * format can't drift.
+ * <p>
+ * <b>Construction must stay side-effect-free:</b> this bean is created while the app server's own spring context
+ * is still refreshing, so it must not resolve anything reaching back into that context - see
+ * {@link #workPackageQueueFactory()}.
+ */
+@Service
+public class AtpReconciliationEnqueueService
+{
+	/**
+	 * Resolved on first use by {@link #workPackageQueueFactory()} - the lazy-accessor shape
+	 * {@code docs/coding-rules/service-injection.md} §3 prescribes; see that method for the concrete failure.
+	 */
+	@Nullable private IWorkPackageQueueFactory _workPackageQueueFactory;
+
+	/** Work-package parameter names - deliberately the {@code AD_Process_Para} column names of the process. */
+	private static final String WP_PARAM_M_Warehouse_ID = I_MD_Stock.COLUMNNAME_M_Warehouse_ID;
+	private static final String WP_PARAM_M_Product_ID = I_MD_Stock.COLUMNNAME_M_Product_ID;
+	private static final String WP_PARAM_M_Product_Category_ID = I_M_Product.COLUMNNAME_M_Product_Category_ID;
+	private static final String WP_PARAM_LivenessCutoffDate = "LivenessCutoffDate";
+
+	/**
+	 * The run date - no {@code AD_Process_Para} counterpart, since the operator doesn't choose it: the process
+	 * derives it at launch time and carries it so the app server reconciles at that point, not whenever it drains
+	 * the queue.
+	 */
+	private static final String WP_PARAM_RunDate = "RunDate";
+
+	/**
+	 * Enqueues {@code request} for {@link AtpReconciliationWorkpackageProcessor}. An empty filter is not written as
+	 * a parameter at all, so {@link #extractRunRequest(IParams)} reads back "not restricted" from its absence
+	 * rather than a sentinel value.
+	 *
+	 * @return the enqueued work package - the run's result is reported there, not in the launching process's log
+	 */
+	public I_C_Queue_WorkPackage enqueue(@NonNull final AtpReconciliationRunRequest request)
+	{
+		final Properties ctx = Env.getCtx();
+		final IWorkPackageQueue queue = workPackageQueueFactory()
+				.getQueueForEnqueuing(ctx, AtpReconciliationWorkpackageProcessor.class);
+		final AtpKeySelection selection = request.getSelection();
+
+		final IWorkPackageBuilder workPackageBuilder = queue.newWorkPackage()
+				// the operator who launched the process - the one who needs to hear if it fails in the app server,
+				// where nobody is watching a process window
+				.setUserInChargeId(Env.getLoggedUserIdIfExists(ctx).orElse(null))
+				.parameter(WP_PARAM_RunDate, request.getRunDate());
+
+		if (selection.getWarehouseId() != null)
+		{
+			workPackageBuilder.parameter(WP_PARAM_M_Warehouse_ID, selection.getWarehouseId().getRepoId());
+		}
+		if (selection.getProductId() != null)
+		{
+			workPackageBuilder.parameter(WP_PARAM_M_Product_ID, selection.getProductId().getRepoId());
+		}
+		if (selection.getProductCategoryId() != null)
+		{
+			workPackageBuilder.parameter(WP_PARAM_M_Product_Category_ID, selection.getProductCategoryId().getRepoId());
+		}
+		if (request.getLivenessCutoff() != null)
+		{
+			workPackageBuilder.parameter(WP_PARAM_LivenessCutoffDate, request.getLivenessCutoff());
+		}
+
+		return workPackageBuilder.buildAndEnqueue();
+	}
+
+	/**
+	 * The inverse of {@link #enqueue(AtpReconciliationRunRequest)}: rebuilds the run exactly as it was launched,
+	 * from the work package's own parameters.
+	 *
+	 * @throws AdempiereException when the work package carries no run date - it was not
+	 * produced by {@link #enqueue(AtpReconciliationRunRequest)}, and reconciling at a guessed date would write a
+	 * correction at the wrong reconciliation point
+	 */
+	public static AtpReconciliationRunRequest extractRunRequest(@NonNull final IParams params)
+	{
+		final Instant runDate = params.getParameterAsInstant(WP_PARAM_RunDate);
+		if (runDate == null)
+		{
+			throw new AdempiereException(
+					"The ATP reconciliation work package carries no " + WP_PARAM_RunDate + " parameter")
+					.appendParametersToMessage()
+					.setParameter("parameterNames", params.getParameterNames());
+		}
+
+		return AtpReconciliationRunRequest.builder()
+				.selection(AtpKeySelection.builder()
+						.warehouseId(WarehouseId.ofRepoIdOrNull(params.getParameterAsInt(WP_PARAM_M_Warehouse_ID, -1)))
+						.productId(ProductId.ofRepoIdOrNull(params.getParameterAsInt(WP_PARAM_M_Product_ID, -1)))
+						.productCategoryId(ProductCategoryId.ofRepoIdOrNull(params.getParameterAsInt(WP_PARAM_M_Product_Category_ID, -1)))
+						.build())
+				.runDate(runDate)
+				.livenessCutoff(livenessCutoffOrNull(params))
+				.build();
+	}
+
+	/**
+	 * @return the work-package queue factory, resolved on first use and cached for the life of this bean.
+	 * <p>
+	 * Concrete failure this prevents: the app server creates this {@code @Service} while its own spring context is
+	 * still being refreshed, and {@code WorkPackageQueueFactory}'s constructor reaches back into that context
+	 * ({@code QueueProcessorDescriptorIndex.getInstance()} -> {@code SpringContextHolder}). Resolving it from a
+	 * field initializer aborted app-server startup with "SpringApplicationContext not configured yet" - reproduced
+	 * by the cucumber suite (which boots {@code ServerBoot} for real; no unit test sees it). Deferring to first use
+	 * puts the lookup after the refresh, where the context is live.
+	 * <p>
+	 * ({@code DDOrderCandidateEnqueueService} holds this factory in a field and happens to survive purely by
+	 * bean-creation order - do not copy it. This is the {@code @Nullable}-field-plus-memoizing-accessor shape
+	 * {@code docs/coding-rules/service-injection.md} §3 prescribes, not a bare per-call {@code Services.get}.)
+	 */
+	private IWorkPackageQueueFactory workPackageQueueFactory()
+	{
+		IWorkPackageQueueFactory result = _workPackageQueueFactory;
+		if (result == null)
+		{
+			result = _workPackageQueueFactory = Services.get(IWorkPackageQueueFactory.class);
+		}
+		return result;
+	}
+
+	@Nullable
+	private static Instant livenessCutoffOrNull(@NonNull final IParams params)
+	{
+		return params.hasParameter(WP_PARAM_LivenessCutoffDate)
+				? params.getParameterAsInstant(WP_PARAM_LivenessCutoffDate)
+				: null;
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/async/AtpReconciliationWorkpackageProcessor.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/async/AtpReconciliationWorkpackageProcessor.java
@@ -1,0 +1,143 @@
+package de.metas.material.dispo.reconcile.async;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.Profiles;
+import de.metas.async.model.I_C_Queue_WorkPackage;
+import de.metas.async.spi.WorkpackageProcessorAdapter;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.dispo.reconcile.AtpDivergence;
+import de.metas.material.dispo.reconcile.AtpKeySelectionDrainer;
+import de.metas.material.dispo.reconcile.AtpReconciliationCommand;
+import de.metas.material.dispo.reconcile.AtpReconciliationRunLog;
+import de.metas.material.dispo.reconcile.AtpReconciliationRunRequest;
+import de.metas.util.Loggables;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.SpringContextHolder;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+
+import javax.annotation.Nullable;
+
+/**
+ * Performs the real, data-writing ATP reconciliation that {@code MD_Candidate_Reconcile_ATP} enqueued - in the
+ * app server, the only JVM with the material disposition engine. The dry-run preview stays synchronous in the
+ * launching process instead (it needs only the un-{@code @Profile}-guarded {@code AtpTargetCalculator}); see
+ * {@link AtpReconciliationEnqueueService} for why the write half can't.
+ * <p>
+ * Drains the selection through the same {@link AtpKeySelectionDrainer} the preview uses, so the two can't walk
+ * different key sets. Per-key results go to the work package's own log via {@link Loggables} - the launching
+ * process has already returned by the time this runs, so its own log can't carry them.
+ */
+public class AtpReconciliationWorkpackageProcessor extends WorkpackageProcessorAdapter
+{
+	private final AtpKeySelectionDrainer keyDrainer =
+			SpringContextHolder.getBeanOrSupply(AtpKeySelectionDrainer.class, AtpKeySelectionDrainer::newInstanceForUnitTesting);
+
+	/**
+	 * @return {@code false} - the reconciliation hands every correction to {@code CandidateChangeService}, which
+	 * manages its own transactions (also why the launching process is {@code @RunOutOfTrx}). One enclosing
+	 * transaction here would also make a possibly large drain all-or-nothing, discarding every correct correction
+	 * for a single bad key.
+	 */
+	@Override
+	public boolean isRunInTransaction()
+	{
+		return false;
+	}
+
+	@Override
+	public Result processWorkPackage(
+			@NonNull final I_C_Queue_WorkPackage workPackage,
+			@Nullable final String localTrxName)
+	{
+		final AtpReconciliationRunRequest request = AtpReconciliationEnqueueService.extractRunRequest(getParameters());
+		final AtpReconciliationCommand reconciliationCommand = reconciliationCommand();
+
+		final AtpKeySelectionDrainer.DrainSummary summary = keyDrainer.drain(
+				request.getSelection(),
+				key -> reconcileOneKey(reconciliationCommand, request, key));
+
+		Loggables.addLog("Reconciled {} of {} matching key(s)", summary.getKeysChanged(), summary.getKeysProcessed());
+
+		return Result.SUCCESS;
+	}
+
+	/**
+	 * @return the {@link AtpReconciliationCommand} bean, or throws with an actionable message.
+	 * <p>
+	 * {@link AtpReconciliationCommand} is {@code @Profile(Profiles.PROFILE_MaterialDispo)} (see its Javadoc); a
+	 * deployment whose app server doesn't list that profile in {@code de.metas.spring.profiles.active} has no such
+	 * bean. Without this wrapper the work package would fail with Spring's bare
+	 * {@code NoSuchBeanDefinitionException} - buried in the queue, with no operator watching. This names the
+	 * missing profile, the sysconfig, and the JVM that needs it.
+	 */
+	private AtpReconciliationCommand reconciliationCommand()
+	{
+		try
+		{
+			return SpringContextHolder.instance.getBean(AtpReconciliationCommand.class);
+		}
+		catch (final NoSuchBeanDefinitionException e)
+		{
+			throw new AdempiereException("The ATP reconciliation work package needs the material disposition"
+					+ " engine, which is not present in the application that picked it up: the spring profile "
+					+ Profiles.PROFILE_MaterialDispo + " is not active here."
+					+ " This work package is meant to be drained by the app server, which reads its active"
+					+ " profiles from the de.metas.spring.profiles.active sysconfigs - add "
+					+ Profiles.PROFILE_MaterialDispo + " there and restart the app server, then re-enqueue this"
+					+ " work package.", e);
+		}
+	}
+
+	/**
+	 * Reconciles one key and writes what changed to the work package log.
+	 *
+	 * @return {@code true} when the key's stored projection diverged from the target, i.e. this call corrected it;
+	 * {@code false} when the key was already correct, so there is nothing to report for it
+	 */
+	private static boolean reconcileOneKey(
+			@NonNull final AtpReconciliationCommand reconciliationCommand,
+			@NonNull final AtpReconciliationRunRequest request,
+			@NonNull final StockDataRecordIdentifier key)
+	{
+		final AtpReconciliationRunLog runLog = reconciliationCommand.reconcileAndLog(
+				key,
+				request.getRunDate(),
+				false, // never a dry run: a dry run is previewed synchronously and is never enqueued
+				request.getLivenessCutoff());
+
+		final AtpDivergence divergence = runLog.getDivergence();
+		if (divergence.getDifference().signum() == 0)
+		{
+			return false;
+		}
+
+		for (final AtpReconciliationRunLog.Entry entry : runLog.getEntries())
+		{
+			Loggables.addLog("{}: STOCK candidate {} changed from {} to {}",
+					key, entry.getCandidateId(), entry.getQtyBefore(), entry.getQtyAfter());
+		}
+		return true;
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/process/MD_Candidate_ATP_Divergence_Report.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/process/MD_Candidate_ATP_Divergence_Report.java
@@ -1,0 +1,223 @@
+package de.metas.material.dispo.reconcile.process;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.common.util.time.SystemTime;
+import de.metas.material.cockpit.model.I_MD_Stock;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.cockpit.stock.StockRepository;
+import de.metas.material.dispo.reconcile.AtpDivergence;
+import de.metas.material.dispo.reconcile.AtpTargetCalculator;
+import de.metas.material.dispo.reconcile.UncoveredSourceDocumentService;
+import de.metas.process.JavaProcess;
+import de.metas.process.Param;
+import de.metas.process.RunOutOfTrx;
+import de.metas.product.ProductCategoryId;
+import de.metas.product.ProductId;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_M_Product;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+
+/**
+ * The read-only counterpart of {@code MD_Candidate_Reconcile_ATP}: reports, per reconciliation key, the
+ * divergence {@link AtpTargetCalculator#computeDivergence} finds between the stored and the expected ATP,
+ * and separately every open {@code M_ShipmentSchedule}/{@code M_ReceiptSchedule} that no candidate
+ * references at all - the one gap a recompute cannot close, so it is surfaced here instead of silently
+ * absorbed. Writes nothing: no {@code MD_Candidate}, no {@code MD_Stock}, no backup row, no run log -
+ * the process log is the only output.
+ * <p>
+ * Structured after the sibling {@code MD_Candidate_Reconcile_ATP}: a plain {@link JavaProcess} with
+ * {@link RunOutOfTrx} on {@link #doIt()}, and the selection drained in bounded batches of
+ * {@link #BATCH_SIZE}, backstopped by {@link #MAX_LOOPS} against a pagination bug that never terminates.
+ * <p>
+ * Every collaborator here - {@link StockRepository}, {@link AtpTargetCalculator},
+ * {@link UncoveredSourceDocumentService} - is a plain, un-{@code @Profile}-guarded bean (see
+ * {@link AtpTargetCalculator}'s own package Javadoc), so unlike the write-side process this class needs no
+ * profile-presence check: it is invocable from the WebUI (the webapi JVM) exactly as it is from the app
+ * server.
+ */
+public class MD_Candidate_ATP_Divergence_Report extends JavaProcess
+{
+	/** How many rows are fetched and reported per round, for every one of the three selections below. */
+	private static final int BATCH_SIZE = 500;
+
+	/**
+	 * Backstop against a pagination bug that never converges (e.g. an {@code OFFSET} that stops advancing): every
+	 * selection this process reads is static, so a healthy run always drains it in a small, bounded number of
+	 * rounds. {@link #BATCH_SIZE} * {@link #MAX_LOOPS} = 5,000,000 rows, far past any real selection size for this
+	 * feature (the largest real candidate chain measured for this issue was 913 rows for a single product).
+	 */
+	private static final int MAX_LOOPS = 10_000;
+
+	// Justification for >1 collaborator (docs/coding-rules/architecture.md §4 "at most one service"):
+	// this process reports two functionally disjoint things in one run - the stored-vs-expected ATP
+	// divergence (stockRepository + atpTargetCalculator) and the separate "uncovered open source document"
+	// gap (uncoveredSourceDocumentService) - each needing its own collaborator subset, with no overlap
+	// between the two that would justify merging them into a single service.
+	private final StockRepository stockRepository = SpringContextHolder.getBeanOrSupply(StockRepository.class, StockRepository::new);
+	private final AtpTargetCalculator atpTargetCalculator =
+			SpringContextHolder.getBeanOrSupply(AtpTargetCalculator.class, AtpTargetCalculator::newInstanceForUnitTesting);
+	private final UncoveredSourceDocumentService uncoveredSourceDocumentService =
+			SpringContextHolder.getBeanOrSupply(UncoveredSourceDocumentService.class, UncoveredSourceDocumentService::newInstanceForUnitTesting);
+
+	@Param(parameterName = I_MD_Stock.COLUMNNAME_M_Warehouse_ID, mandatory = false)
+	private int p_M_Warehouse_ID;
+
+	@Param(parameterName = I_MD_Stock.COLUMNNAME_M_Product_ID, mandatory = false)
+	private int p_M_Product_ID;
+
+	@Param(parameterName = I_M_Product.COLUMNNAME_M_Product_Category_ID, mandatory = false)
+	private int p_M_Product_Category_ID;
+
+	@Override
+	@RunOutOfTrx
+	protected String doIt()
+	{
+		final Instant runDate = SystemTime.asInstant();
+		final WarehouseId warehouseId = p_M_Warehouse_ID > 0 ? WarehouseId.ofRepoId(p_M_Warehouse_ID) : null;
+		final ProductId productId = p_M_Product_ID > 0 ? ProductId.ofRepoId(p_M_Product_ID) : null;
+		final ProductCategoryId productCategoryId = p_M_Product_Category_ID > 0 ? ProductCategoryId.ofRepoId(p_M_Product_Category_ID) : null;
+
+		reportDivergences(runDate, warehouseId, productId, productCategoryId);
+		reportUncoveredOpenDocuments(warehouseId, productId, productCategoryId);
+
+		return MSG_OK;
+	}
+
+	/**
+	 * Reports every key whose stored ATP diverges from {@link AtpTargetCalculator#computeDivergence}'s target -
+	 * a key that is already correct produces no log line at all, only the summary count.
+	 */
+	private void reportDivergences(
+			@NonNull final Instant runDate,
+			@Nullable final WarehouseId warehouseId,
+			@Nullable final ProductId productId,
+			@Nullable final ProductCategoryId productCategoryId)
+	{
+		int keysChecked = 0;
+		int keysDiverged = 0;
+		int offset = 0;
+		int loops = 0;
+
+		List<StockDataRecordIdentifier> batch;
+		do
+		{
+			loops++;
+			if (loops > MAX_LOOPS)
+			{
+				// concrete failure this prevents: a pagination bug (e.g. an OFFSET that never advances) turning
+				// this into an infinite loop instead of a bounded, reportable failure
+				throw new AdempiereException("MD_Candidate_ATP_Divergence_Report aborted after " + MAX_LOOPS
+						+ " rounds of " + BATCH_SIZE + " keys each - the selection never shrank below a full batch");
+			}
+
+			batch = stockRepository.retrieveKeys(warehouseId, productId, productCategoryId, BATCH_SIZE, offset);
+			for (final StockDataRecordIdentifier key : batch)
+			{
+				keysChecked++;
+				final AtpDivergence divergence = atpTargetCalculator.computeDivergence(key, runDate);
+				if (divergence.getDifference().signum() != 0)
+				{
+					keysDiverged++;
+					addLog("{}: expectedAtp={}, storedAtp={}, difference={}",
+							key, divergence.getExpectedAtp(), divergence.getStoredAtp(), divergence.getDifference());
+				}
+			}
+			offset += BATCH_SIZE;
+		}
+		while (batch.size() == BATCH_SIZE);
+
+		addLog("Checked {} key(s); {} diverged", keysChecked, keysDiverged);
+	}
+
+	/**
+	 * Reports every open source document - {@code M_ShipmentSchedule} and {@code M_ReceiptSchedule} - that no
+	 * candidate references at all: the one gap {@link AtpTargetCalculator} cannot close by recomputing, since
+	 * there is no candidate to correct.
+	 */
+	private void reportUncoveredOpenDocuments(
+			@Nullable final WarehouseId warehouseId,
+			@Nullable final ProductId productId,
+			@Nullable final ProductCategoryId productCategoryId)
+	{
+		final int shipmentScheduleCount = drainAndLog(
+				offset -> uncoveredSourceDocumentService.retrieveOpenShipmentScheduleIdsWithoutCandidate(
+						warehouseId, productId, productCategoryId, BATCH_SIZE, offset),
+				id -> addLog("Uncovered open M_ShipmentSchedule {}", id));
+
+		final int receiptScheduleCount = drainAndLog(
+				offset -> uncoveredSourceDocumentService.retrieveOpenReceiptScheduleIdsWithoutCandidate(
+						warehouseId, productId, productCategoryId, BATCH_SIZE, offset),
+				id -> addLog("Uncovered open M_ReceiptSchedule {}", id));
+
+		addLog("{} open source document(s) with no candidate at all", shipmentScheduleCount + receiptScheduleCount);
+	}
+
+	/**
+	 * Drains a paginated {@code (offset) -> page} source in rounds of {@link #BATCH_SIZE}, logging every item via
+	 * {@code perItemLogger} - the shape shared by {@link #reportUncoveredOpenDocuments}'s two selections, extracted
+	 * so the {@link #MAX_LOOPS} backstop exists exactly once instead of being copy-pasted per selection.
+	 *
+	 * @return the total number of items drained
+	 */
+	private int drainAndLog(
+			@NonNull final IntFunction<List<Integer>> pageFetcher,
+			@NonNull final Consumer<Integer> perItemLogger)
+	{
+		int count = 0;
+		int offset = 0;
+		int loops = 0;
+
+		List<Integer> batch;
+		do
+		{
+			loops++;
+			if (loops > MAX_LOOPS)
+			{
+				// same concrete failure as reportDivergences' own backstop: a pagination bug must abort visibly
+				// instead of looping forever
+				throw new AdempiereException("MD_Candidate_ATP_Divergence_Report aborted after " + MAX_LOOPS
+						+ " rounds of " + BATCH_SIZE + " rows each - the selection never shrank below a full batch");
+			}
+
+			batch = pageFetcher.apply(offset);
+			for (final Integer id : batch)
+			{
+				count++;
+				perItemLogger.accept(id);
+			}
+			offset += BATCH_SIZE;
+		}
+		while (batch.size() == BATCH_SIZE);
+
+		return count;
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/process/MD_Candidate_Reconcile_ATP.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/material/dispo/reconcile/process/MD_Candidate_Reconcile_ATP.java
@@ -1,0 +1,202 @@
+package de.metas.material.dispo.reconcile.process;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.async.model.I_C_Queue_WorkPackage;
+import de.metas.common.util.time.SystemTime;
+import de.metas.material.cockpit.model.I_MD_Stock;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.dispo.reconcile.AtpDivergence;
+import de.metas.material.dispo.reconcile.AtpKeySelection;
+import de.metas.material.dispo.reconcile.AtpKeySelectionDrainer;
+import de.metas.material.dispo.reconcile.AtpReconciliationCommand;
+import de.metas.material.dispo.reconcile.AtpReconciliationRunRequest;
+import de.metas.material.dispo.reconcile.AtpTargetCalculator;
+import de.metas.material.dispo.reconcile.async.AtpReconciliationEnqueueService;
+import de.metas.material.dispo.reconcile.async.AtpReconciliationWorkpackageProcessor;
+import de.metas.process.JavaProcess;
+import de.metas.process.Param;
+import de.metas.process.RunOutOfTrx;
+import de.metas.product.ProductCategoryId;
+import de.metas.product.ProductId;
+import lombok.NonNull;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_M_Product;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * The operator-invocable entry point into the ATP reconciliation: selects reconciliation keys by an optional
+ * warehouse/product/product-category filter and either previews or performs the reconciliation of each one.
+ * <p>
+ * <b>The two paths are deliberately different, and this is the class where they part.</b>
+ * <ul>
+ * <li><b>Dry run</b> ({@code IsDryRun = 'Y'}) is computed here, synchronously, and reported in this process's own
+ * log. It needs only the un-{@code @Profile}-guarded {@link AtpTargetCalculator#computeDivergence}, so the
+ * preview works in the webapi - the JVM a WebUI-launched {@code AD_Process} actually executes in. Nothing is
+ * written, and {@link AtpReconciliationCommand} is never touched.</li>
+ * <li><b>A real run</b> is <i>enqueued</i>: this process writes a {@code C_Queue_WorkPackage} and returns, and
+ * {@link AtpReconciliationWorkpackageProcessor} performs the reconciliation in the app server - the only JVM
+ * where {@link AtpReconciliationCommand}'s {@code @Profile(Profiles.PROFILE_MaterialDispo)} is active
+ * ({@code AD_Process.IsServerProcess} is not an escape hatch - it only affects Swing class loading). So a real
+ * run's result is <b>asynchronous</b>, reported on the work package instead.</li>
+ * </ul>
+ * Both paths share the batched key drain (page size, pagination, runaway backstop) via
+ * {@link AtpKeySelectionDrainer}, so they can't drift apart.
+ * <p>
+ * {@code IsDryRun} defaults to {@code 'N'} - matching the house convention for comparable process-level
+ * preview/simulation parameters (e.g. {@code IsSimulation} on the Commission Overview process) - so an operator
+ * who accepts every default runs a real, data-writing reconciliation; the checkbox must be ticked explicitly to
+ * preview only.
+ * <p>
+ * <b>Liveness cutoff:</b> {@code LivenessCutoffDate}, when given, is converted to an {@link Instant} at the start
+ * of that day in the system time zone, so a candidate dated strictly before it is treated as closed regardless of
+ * what its source document says.
+ */
+public class MD_Candidate_Reconcile_ATP extends JavaProcess
+{
+	// Justification for >1 collaborator (docs/coding-rules/architecture.md §4 "at most one service"):
+	// the dry-run and real-run paths are disjoint by design (see class Javadoc) and each needs its own
+	// collaborator - atpTargetCalculator for the synchronous dry-run preview, keyDrainer for the shared
+	// batched key selection both paths use, and enqueueService only for a real (non-dry) run. None of the
+	// three overlaps in responsibility, so folding them into one service would just relocate the branching
+	// into that service instead of removing it.
+	private final AtpTargetCalculator atpTargetCalculator =
+			SpringContextHolder.getBeanOrSupply(AtpTargetCalculator.class, AtpTargetCalculator::newInstanceForUnitTesting);
+	private final AtpKeySelectionDrainer keyDrainer =
+			SpringContextHolder.getBeanOrSupply(AtpKeySelectionDrainer.class, AtpKeySelectionDrainer::newInstanceForUnitTesting);
+	private final AtpReconciliationEnqueueService enqueueService =
+			SpringContextHolder.getBeanOrSupply(AtpReconciliationEnqueueService.class, AtpReconciliationEnqueueService::new);
+
+	@Param(parameterName = I_MD_Stock.COLUMNNAME_M_Warehouse_ID, mandatory = false)
+	private int p_M_Warehouse_ID;
+
+	@Param(parameterName = I_MD_Stock.COLUMNNAME_M_Product_ID, mandatory = false)
+	private int p_M_Product_ID;
+
+	@Param(parameterName = I_M_Product.COLUMNNAME_M_Product_Category_ID, mandatory = false)
+	private int p_M_Product_Category_ID;
+
+	@Param(parameterName = "IsDryRun", mandatory = true)
+	private boolean p_IsDryRun;
+
+	@Param(parameterName = "LivenessCutoffDate", mandatory = false)
+	private LocalDate p_LivenessCutoffDate;
+
+	@Override
+	@RunOutOfTrx
+	protected String doIt()
+	{
+		final AtpReconciliationRunRequest request = createRunRequest();
+
+		if (p_IsDryRun)
+		{
+			previewInline(request);
+		}
+		else
+		{
+			enqueueForTheAppServer(request);
+		}
+
+		return MSG_OK;
+	}
+
+	/**
+	 * Reports, per key of the selection, the divergence a real run would correct - and writes nothing.
+	 * <p>
+	 * Deliberately computed from {@link AtpTargetCalculator#computeDivergence} rather than
+	 * {@link AtpReconciliationCommand#reconcileAndLog}'s {@code dryRun} path (same numbers either way): going
+	 * through the command would require the command <i>bean</i>, which doesn't exist in the webapi - so the
+	 * preview would fail there instead of previewing.
+	 */
+	private void previewInline(@NonNull final AtpReconciliationRunRequest request)
+	{
+		final AtpKeySelectionDrainer.DrainSummary summary = keyDrainer.drain(
+				request.getSelection(),
+				key -> previewOneKey(request, key));
+
+		addLog("Dry run: {} of {} matching key(s) would change; nothing was written",
+				summary.getKeysChanged(), summary.getKeysProcessed());
+	}
+
+	/**
+	 * @return {@code true} when this key's stored projection diverges from the target, i.e. a real run would
+	 * change it - and logs by how much; {@code false} when the key is already correct, so there is nothing to
+	 * report for it
+	 */
+	private boolean previewOneKey(
+			@NonNull final AtpReconciliationRunRequest request,
+			@NonNull final StockDataRecordIdentifier key)
+	{
+		final AtpDivergence divergence = atpTargetCalculator.computeDivergence(
+				key, request.getRunDate(), request.getLivenessCutoff());
+
+		if (divergence.getDifference().signum() == 0)
+		{
+			return false;
+		}
+
+		addLog("{}: stored ATP {} would change to {} (difference {})",
+				key, divergence.getStoredAtp(), divergence.getExpectedAtp(), divergence.getDifference());
+		return true;
+	}
+
+	/**
+	 * Hands the run to the async queue and tells the operator where its result will appear.
+	 * <p>
+	 * The selection is deliberately <i>not</i> drained here: one work package carries the filter itself, so the
+	 * keys are read in the JVM that can also reconcile them. Reading them here would only produce a snapshot that
+	 * is already stale by the time the app server picks the package up.
+	 */
+	private void enqueueForTheAppServer(@NonNull final AtpReconciliationRunRequest request)
+	{
+		final I_C_Queue_WorkPackage workPackage = enqueueService.enqueue(request);
+
+		addLog("Enqueued work package {} for the reconciliation - it runs in the application server, where the"
+						+ " material disposition engine is, and reports what it changed on that work package",
+				workPackage.getC_Queue_WorkPackage_ID());
+	}
+
+	/** @return this run exactly as the operator parameterised it, with the run date pinned to now */
+	private AtpReconciliationRunRequest createRunRequest()
+	{
+		return AtpReconciliationRunRequest.builder()
+				.selection(AtpKeySelection.builder()
+						.warehouseId(WarehouseId.ofRepoIdOrNull(p_M_Warehouse_ID))
+						.productId(ProductId.ofRepoIdOrNull(p_M_Product_ID))
+						.productCategoryId(ProductCategoryId.ofRepoIdOrNull(p_M_Product_Category_ID))
+						.build())
+				.runDate(SystemTime.asInstant())
+				.livenessCutoff(toInstantOrNull(p_LivenessCutoffDate))
+				.build();
+	}
+
+	@Nullable
+	private static Instant toInstantOrNull(@Nullable final LocalDate date)
+	{
+		return date != null ? date.atStartOfDay(SystemTime.zoneId()).toInstant() : null;
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/AtpReconcileContextStartupTest.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/AtpReconcileContextStartupTest.java
@@ -1,0 +1,162 @@
+package de.metas.material.dispo;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.Profiles;
+import de.metas.material.cockpit.stock.StockRepository;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
+import de.metas.material.dispo.reconcile.AtpKeySelectionDrainer;
+import de.metas.material.dispo.reconcile.AtpReconciliationCommand;
+import de.metas.material.dispo.reconcile.AtpTargetCalculator;
+import de.metas.material.dispo.reconcile.UncoveredSourceDocumentService;
+import de.metas.material.dispo.reconcile.async.AtpReconciliationEnqueueService;
+import de.metas.material.dispo.service.candidatechange.CandidateChangeService;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the spring wiring of the {@code de.metas.material.dispo.reconcile} package against the one context no other
+ * test of that package can see: <b>an application context that does not have the material disposition engine</b>.
+ * <p>
+ * <b>The concrete failure this prevents.</b> The webapi ({@code WebRestApiApplication}) and the app server
+ * ({@code ServerBoot}) both component-scan {@code de.metas}, but only the app server activates the
+ * {@link Profiles#PROFILE_MaterialDispo} profile (it reads it from the {@code de.metas.spring.profiles.active}
+ * sysconfigs; the webapi reads a different prefix). So a bean of the reconcile package that injects a
+ * profile-guarded {@code dispo-service} collaborator - {@link CandidateChangeService} and the engine behind it -
+ * without carrying that profile itself is instantiated in the webapi too, where its constructor cannot be
+ * satisfied. Spring then aborts webapi startup: the container never comes up, so the entire WebUI is down, not
+ * merely this one feature. That happened here once and no test saw it - the unit tests of the reconcile package
+ * construct their services by hand, and the cucumber suite boots {@code ServerBoot}, i.e. precisely the context
+ * that <i>does</i> have the profile.
+ * <p>
+ * {@link #webapiLikeContext_startsWithoutTheMaterialDispoEngine()} stands in for that missing coverage: a real
+ * context, a real component scan of the package, and no {@code material-dispo} profile - the webapi's situation -
+ * which must refresh. {@link #appServerLikeContext_registersTheReconciliationCommand()} is its necessary other
+ * half: it proves the profile guard withholds the bean only where the engine is missing, and not on the app
+ * server, where the operator process actually runs.
+ * <p>
+ * <b>This test deliberately lives outside {@code de.metas.material.dispo.reconcile}.</b> {@link ComponentScan} is
+ * recursive and does not distinguish main from test classes, so a {@link Configuration} class of this test placed
+ * in (or under) the scanned package would be picked up by the scan itself and would hand the context the very bean
+ * whose absence is the whole point - which silently blinds the guard. That is not a hypothetical: it happened while
+ * this test was being written, and the belt to the braces is
+ * {@link #webapiLikeContext_startsWithoutTheMaterialDispoEngine()}'s explicit assertion that no
+ * {@link CandidateChangeService} bean exists in that context.
+ */
+class AtpReconcileContextStartupTest
+{
+	@BeforeEach
+	void beforeEach()
+	{
+		// SourceDocumentRepository resolves IQueryBL in a field initializer, so the Services registry must be up
+		// before the component scan instantiates it
+		AdempiereTestHelper.get().init();
+	}
+
+	/**
+	 * The collaborators the reconcile package needs from OTHER modules. Both are unguarded {@code @Service}s in
+	 * their own module ({@code cockpit} / {@code dispo-commons}), i.e. genuinely present in every metasfresh
+	 * application - they are mocked here only to keep the component scan off the database, never to stand in for a
+	 * bean that a real context would lack.
+	 */
+	@Configuration
+	@ComponentScan("de.metas.material.dispo.reconcile")
+	static class ReconcilePackageConfig
+	{
+		@Bean
+		StockRepository stockRepository() {return Mockito.mock(StockRepository.class);}
+
+		@Bean
+		CandidateRepositoryRetrieval candidateRepositoryRetrieval() {return Mockito.mock(CandidateRepositoryRetrieval.class);}
+	}
+
+	/** Adds the one bean that exists only where the material disposition engine does. */
+	@Configuration
+	static class MaterialDispoEngineConfig
+	{
+		@Bean
+		CandidateChangeService candidateChangeService() {return Mockito.mock(CandidateChangeService.class);}
+	}
+
+	@Test
+	void webapiLikeContext_startsWithoutTheMaterialDispoEngine()
+	{
+		try (final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext())
+		{
+			// no active profile at all: strictly less than the webapi has, so whatever starts here starts there too
+			context.register(ReconcilePackageConfig.class);
+			context.refresh(); // must not throw - a throw here is a webapi that will not boot
+
+			assertThat(context.getBeanNamesForType(CandidateChangeService.class))
+					.as("precondition: this context must be engine-less, or it cannot stand in for the webapi")
+					.isEmpty();
+
+			assertThat(context.getBeanNamesForType(AtpReconciliationCommand.class))
+					.as("the write path needs CandidateChangeService, so it must NOT be registered without the engine")
+					.isEmpty();
+
+			assertThat(context.getBeanNamesForType(AtpTargetCalculator.class))
+					.as("the read-only divergence computation needs nothing from dispo-service, so it stays available")
+					.isNotEmpty();
+
+			assertThat(context.getBeanNamesForType(UncoveredSourceDocumentService.class))
+					.as("the read-only uncovered-open-document report needs nothing from dispo-service either, so"
+							+ " it must be resolvable in the same webapi-like context that the divergence report"
+							+ " process runs in")
+					.isNotEmpty();
+
+			assertThat(context.getBeanNamesForType(AtpKeySelectionDrainer.class))
+					.as("the key drain needs nothing from dispo-service either, so it must be resolvable in the"
+							+ " webapi-like context the operator's process runs in")
+					.isNotEmpty();
+
+			assertThat(context.getBeanNamesForType(AtpReconciliationEnqueueService.class))
+					.as("a real run is enqueued FROM the webapi (that is where a WebUI-launched AD_Process runs),"
+							+ " so the enqueue service is the one write-path bean that must exist there")
+					.isNotEmpty();
+		}
+	}
+
+	@Test
+	void appServerLikeContext_registersTheReconciliationCommand()
+	{
+		try (final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext())
+		{
+			context.getEnvironment().setActiveProfiles(Profiles.PROFILE_MaterialDispo);
+			context.register(ReconcilePackageConfig.class, MaterialDispoEngineConfig.class);
+			context.refresh();
+
+			assertThat(context.getBeanNamesForType(AtpReconciliationCommand.class))
+					.as("where the engine is present, the operator process must find its command bean")
+					.isNotEmpty();
+		}
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/AtpKeySelectionDrainerTest.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/AtpKeySelectionDrainerTest.java
@@ -1,0 +1,193 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableList;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.cockpit.stock.StockRepository;
+import de.metas.material.event.commons.AttributesKey;
+import de.metas.organization.OrgId;
+import de.metas.product.ProductCategoryId;
+import de.metas.product.ProductId;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the batched key drain both reconciliation paths share - the operator's synchronous dry-run preview in
+ * {@code MD_Candidate_Reconcile_ATP} and the real, enqueued run in
+ * {@code AtpReconciliationWorkpackageProcessor}.
+ * <p>
+ * These two behaviours - pagination advancing across rounds, and the {@link AtpKeySelectionDrainer#MAX_LOOPS}
+ * backstop - were covered by {@code MD_Candidate_Reconcile_ATPTest} while the drain lived inside that process.
+ * They moved here with the drain itself, unchanged in substance: they are now asserted once, on the one
+ * collaborator, instead of once per path. Their original motivation still holds - the cucumber scenarios for
+ * this feature never approach 500 rows, so a selection spanning more than one page, and the backstop, are
+ * exercised at no other layer.
+ */
+class AtpKeySelectionDrainerTest
+{
+	private static final ClientId CLIENT_ID = ClientId.ofRepoId(1000000);
+	private static final OrgId ORG_ID = OrgId.ofRepoId(1000001);
+	private static final WarehouseId WAREHOUSE_ID = WarehouseId.ofRepoId(1000002);
+
+	private static final int BATCH_SIZE = AtpKeySelectionDrainer.BATCH_SIZE;
+	private static final int MAX_LOOPS = AtpKeySelectionDrainer.MAX_LOOPS;
+
+	private StockRepository stockRepository;
+	private AtpKeySelectionDrainer drainer;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		stockRepository = Mockito.mock(StockRepository.class);
+		drainer = new AtpKeySelectionDrainer(stockRepository);
+	}
+
+	@Test
+	void selectionLargerThanOneBatch_handsOverEveryKeyExactlyOnce()
+	{
+		// 750 = one full batch (BATCH_SIZE) plus a partial second page, so pagination MUST advance for the second
+		// page's 250 keys to be seen at all
+		final List<StockDataRecordIdentifier> allKeys = distinctKeys(BATCH_SIZE + 250);
+
+		when(stockRepository.retrieveKeys(any(), any(), any(), anyInt(), anyInt()))
+				.thenAnswer(invocation -> {
+					final int limit = invocation.getArgument(3);
+					final int offset = invocation.getArgument(4);
+					final int from = Math.min(offset, allKeys.size());
+					final int to = Math.min(offset + limit, allKeys.size());
+					return ImmutableList.copyOf(allKeys.subList(from, to));
+				});
+
+		final List<StockDataRecordIdentifier> keysSeen = new ArrayList<>();
+
+		final AtpKeySelectionDrainer.DrainSummary summary = drainer.drain(
+				AtpKeySelection.ALL,
+				key -> {
+					keysSeen.add(key);
+					return false; // nothing changed, so keysChanged must stay 0
+				});
+
+		// retrieveKeys must have been called for offset 0 (full batch) and offset BATCH_SIZE (the trailing partial
+		// batch, which is what actually stops the loop) - no more, no fewer
+		final ArgumentCaptor<Integer> offsetCaptor = ArgumentCaptor.forClass(Integer.class);
+		verify(stockRepository, times(2)).retrieveKeys(any(), any(), any(), anyInt(), offsetCaptor.capture());
+		assertThat(offsetCaptor.getAllValues()).containsExactly(0, BATCH_SIZE);
+
+		// every key handed out by the fake repository must have reached the processor exactly once: nothing
+		// silently truncated (all 750 seen) and nothing double-processed (no key seen twice)
+		assertThat(keysSeen).hasSize(allKeys.size());
+		assertThat(new HashSet<>(keysSeen)).hasSize(allKeys.size()); // no duplicates
+		assertThat(keysSeen).containsExactlyInAnyOrderElementsOf(allKeys); // nothing missing, nothing foreign
+
+		assertThat(summary.getKeysProcessed()).isEqualTo(allKeys.size());
+		assertThat(summary.getKeysChanged()).isZero();
+	}
+
+	@Test
+	void selectionThatNeverShrinksBelowAFullBatch_abortsAfterMaxLoops()
+	{
+		// a pagination bug that never advances (e.g. a stuck OFFSET): every page comes back full, so the drain
+		// loop never sees the batch.size() < BATCH_SIZE signal that would end it normally
+		final List<StockDataRecordIdentifier> fullBatch = distinctKeys(BATCH_SIZE);
+		when(stockRepository.retrieveKeys(any(), any(), any(), anyInt(), anyInt()))
+				.thenReturn(ImmutableList.copyOf(fullBatch));
+
+		// only a counter, no key recording: 10,000 rounds * 500 keys/round = 5,000,000 calls, and retaining that
+		// many keys would itself blow the test heap
+		final AtomicLong processorCalls = new AtomicLong();
+
+		assertThatThrownBy(() -> drainer.drain(AtpKeySelection.ALL, key -> {
+			processorCalls.incrementAndGet();
+			return false;
+		}))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("aborted after " + MAX_LOOPS)
+				.hasMessageContaining("never shrank below a full batch");
+
+		// exactly MAX_LOOPS rounds must have been drawn before the backstop fires - not one more, not one fewer
+		verify(stockRepository, times(MAX_LOOPS)).retrieveKeys(any(), any(), any(), anyInt(), anyInt());
+		assertThat(processorCalls.get()).isEqualTo(((long)MAX_LOOPS) * BATCH_SIZE);
+	}
+
+	/**
+	 * The selection is what makes the drain restrictable, so it must reach the repository verbatim - a filter
+	 * silently dropped here would widen a run the operator restricted on purpose to the whole database.
+	 */
+	@Test
+	void selectionFilters_areHandedToTheRepositoryVerbatim()
+	{
+		when(stockRepository.retrieveKeys(any(), any(), any(), anyInt(), anyInt()))
+				.thenReturn(ImmutableList.of());
+
+		final ProductId productId = ProductId.ofRepoId(1000003);
+		final ProductCategoryId productCategoryId = ProductCategoryId.ofRepoId(1000004);
+
+		drainer.drain(
+				AtpKeySelection.builder()
+						.warehouseId(WAREHOUSE_ID)
+						.productId(productId)
+						.productCategoryId(productCategoryId)
+						.build(),
+				key -> false);
+
+		verify(stockRepository).retrieveKeys(WAREHOUSE_ID, productId, productCategoryId, BATCH_SIZE, 0);
+	}
+
+	private static List<StockDataRecordIdentifier> distinctKeys(final int count)
+	{
+		final List<StockDataRecordIdentifier> keys = new ArrayList<>(count);
+		for (int i = 0; i < count; i++)
+		{
+			keys.add(StockDataRecordIdentifier.builder()
+					.clientId(CLIENT_ID)
+					.orgId(ORG_ID)
+					.warehouseId(WAREHOUSE_ID)
+					.productId(ProductId.ofRepoId(2_000_000 + i))
+					.storageAttributesKey(AttributesKey.NONE)
+					.build());
+		}
+		return keys;
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/AtpReconciliationBackupTest.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/AtpReconciliationBackupTest.java
@@ -1,0 +1,405 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableList;
+import de.metas.document.dimension.DimensionService;
+import de.metas.document.dimension.MDCandidateDimensionFactory;
+import de.metas.material.cockpit.model.I_MD_Stock;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.commons.attributes.clasifiers.BPartnerClassifier;
+import de.metas.material.dispo.commons.candidate.Candidate;
+import de.metas.material.dispo.commons.candidate.CandidateBusinessCase;
+import de.metas.material.dispo.commons.candidate.CandidateType;
+import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
+import de.metas.material.dispo.commons.repository.CandidateQtyDetailsRepository;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryWriteService;
+import de.metas.material.dispo.commons.repository.DateAndSeqNo;
+import de.metas.material.dispo.commons.repository.atp.AvailableToPromiseRepository;
+import de.metas.material.dispo.commons.repository.query.CandidatesQuery;
+import de.metas.material.dispo.commons.repository.query.MaterialDescriptorQuery;
+import de.metas.material.dispo.commons.repository.repohelpers.StockChangeDetailRepo;
+import de.metas.material.dispo.model.I_MD_ATP_Reconciliation_Backup;
+import de.metas.material.dispo.service.candidatechange.CandidateChangeService;
+import de.metas.material.dispo.service.candidatechange.StockCandidateService;
+import de.metas.material.dispo.service.candidatechange.handler.DemandCandiateHandler;
+import de.metas.material.dispo.service.candidatechange.handler.SupplyCandidateHandler;
+import de.metas.material.event.PostMaterialEventService;
+import de.metas.material.event.commons.AttributesKey;
+import de.metas.material.event.commons.MaterialDescriptor;
+import de.metas.material.event.commons.ProductDescriptor;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.organization.ClientAndOrgId;
+import de.metas.organization.OrgId;
+import de.metas.product.ProductId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.util.TimeUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests {@link AtpReconciliationCommand#reconcileAndLog} - the durable backup and run log this reconciliation
+ * needs so the pre-change values stay recoverable after the run's process has ended.
+ * <p>
+ * Wiring mirrors {@link AtpReconciliationCommandTest} exactly, for the same reason documented there: a real
+ * {@link CandidateChangeService}, built from real {@link SupplyCandidateHandler}/{@link DemandCandiateHandler},
+ * mocking only {@link PostMaterialEventService}.
+ */
+public class AtpReconciliationBackupTest
+{
+	private static final Instant D1 = Instant.parse("2026-09-08T00:00:00Z");
+	private static final Instant D2 = D1.plus(1, ChronoUnit.DAYS);
+	private static final Instant FAR_FUTURE = D1.plus(3650, ChronoUnit.DAYS);
+
+	private static final ClientId CLIENT_ID = ClientId.ofRepoId(1000000);
+	private static final OrgId ORG_ID = OrgId.ofRepoId(1000001);
+	private static final WarehouseId WAREHOUSE_ID = WarehouseId.ofRepoId(1000002);
+	private static final ProductId PRODUCT_ID = ProductId.ofRepoId(1000003);
+
+	private static final StockDataRecordIdentifier KEY = StockDataRecordIdentifier.builder()
+			.clientId(CLIENT_ID)
+			.orgId(ORG_ID)
+			.warehouseId(WAREHOUSE_ID)
+			.productId(PRODUCT_ID)
+			.storageAttributesKey(AttributesKey.NONE)
+			.build();
+
+	private CandidateRepositoryRetrieval candidateRepository;
+	private CandidateChangeService candidateChangeService;
+	private AtpTargetCalculator atpTargetCalculator;
+	private AtpReconciliationCommand atpReconciliationCommand;
+
+	@BeforeEach
+	public void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		final DimensionService dimensionService = new DimensionService(ImmutableList.of(new MDCandidateDimensionFactory()));
+		final StockChangeDetailRepo stockChangeDetailRepo = new StockChangeDetailRepo();
+		candidateRepository = new CandidateRepositoryRetrieval(dimensionService, stockChangeDetailRepo);
+		final CandidateRepositoryWriteService candidateRepositoryWriteService = new CandidateRepositoryWriteService(
+				dimensionService, stockChangeDetailRepo, candidateRepository, new CandidateQtyDetailsRepository());
+		final StockCandidateService stockCandidateService = new StockCandidateService(candidateRepository, candidateRepositoryWriteService);
+
+		final SupplyCandidateHandler supplyCandidateHandler = new SupplyCandidateHandler(candidateRepositoryWriteService, stockCandidateService);
+		final DemandCandiateHandler demandCandiateHandler = new DemandCandiateHandler(
+				candidateRepository,
+				candidateRepositoryWriteService,
+				Mockito.mock(PostMaterialEventService.class),
+				new AvailableToPromiseRepository(),
+				stockCandidateService,
+				supplyCandidateHandler);
+
+		candidateChangeService = new CandidateChangeService(ImmutableList.of(supplyCandidateHandler, demandCandiateHandler));
+
+		atpTargetCalculator = AtpTargetCalculator.newInstanceForUnitTesting();
+		atpReconciliationCommand = new AtpReconciliationCommand(
+				atpTargetCalculator, candidateChangeService, candidateRepository, new AtpReconciliationBackupRepositoryImpl());
+	}
+
+	@Test
+	public void reconcileAndLog_persistsARecoverableBackupAndRunLogForEveryTouchedCandidate()
+	{
+		final int stockId = createStockRecord(new BigDecimal("100"));
+		atpReconciliationCommand.reconcile(KEY, D1, false);
+		assertThat(retrieveStockQtyUpTo(D1)).isEqualByComparingTo("100");
+
+		// an ordinary later demand, dated after D1: the engine's own propagation creates the STOCK candidate at D2
+		final int shipmentScheduleId = createShipmentSchedule(false /* processed */);
+		postShipmentDemand(D2, new BigDecimal("30"), shipmentScheduleId);
+		assertThat(retrieveStockQtyUpTo(D2)).isEqualByComparingTo("70"); // 100 - 30
+
+		// physical stock drifts again, out of band - exactly the divergence a second reconciliation exists to fix
+		updateStockQtyOnHand(stockId, new BigDecimal("150"));
+
+		final AtpReconciliationRunLog runLog = atpReconciliationCommand.reconcileAndLog(KEY, D1, false);
+
+		// the correction: target(D1) = 150 (no candidate dated <= D1 contributes), stored(D1) = 100 -> delta 50
+		assertThat(runLog.getDivergence().getDifference()).isEqualByComparingTo("50");
+		assertThat(retrieveStockQtyUpTo(FAR_FUTURE)).isEqualByComparingTo("120"); // 70 shifted forward by the +50 delta
+		assertThat(runLog.getRunUuid()).isNotNull();
+
+		// Recoverability is proven against the PERSISTED backup, looked up fresh by the run id - never by reading
+		// runLog.getEntries() itself, which would still pass even if nothing had actually been written to the store.
+		final List<I_MD_ATP_Reconciliation_Backup> backedUpRows = retrieveBackupRows(runLog.getRunUuid());
+
+		final I_MD_ATP_Reconciliation_Backup backedUpD2Candidate = backedUpRows.stream()
+				.filter(row -> TimeUtil.asInstant(row.getDateProjected()).equals(D2))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("no persisted backup row for the D2 STOCK candidate: " + backedUpRows));
+		assertThat(backedUpD2Candidate.getQtyBefore()).isEqualByComparingTo("70");
+		assertThat(backedUpD2Candidate.getQtyAfter()).isEqualByComparingTo("120");
+		assertThat(backedUpD2Candidate.getM_Warehouse_ID()).isEqualTo(WAREHOUSE_ID.getRepoId());
+		assertThat(backedUpD2Candidate.getM_Product_ID()).isEqualTo(PRODUCT_ID.getRepoId());
+
+		// the correction's own new STOCK child at D1: nothing to back up (it did not exist before), but the
+		// persisted row still names the run's own effect. Disambiguated by MD_Candidate_ID from the correction
+		// candidate's OWN backup row below - both share DateProjected=D1 and a null QtyBefore.
+		// Nullness of QtyBefore is checked via InterfaceWrapperHelper.isNull, not row.getQtyBefore() == null: the
+		// generated accessor for a nullable Quantity column coalesces a null value to BigDecimal.ZERO (the standard
+		// metasfresh model-generator behaviour for numeric columns), so the getter itself cannot tell "never backed
+		// up because the candidate is new" apart from "backed up with quantity zero".
+		final Candidate stockCandidateAtD1 = retrieveStockCandidateUpTo(D1);
+		final I_MD_ATP_Reconciliation_Backup backedUpNewD1Candidate = backedUpRows.stream()
+				.filter(row -> TimeUtil.asInstant(row.getDateProjected()).equals(D1)
+						&& InterfaceWrapperHelper.isNull(row, I_MD_ATP_Reconciliation_Backup.COLUMNNAME_QtyBefore)
+						&& row.getMD_Candidate_ID() == stockCandidateAtD1.getId().getRepoId())
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("no persisted backup row for the newly created D1 STOCK candidate: " + backedUpRows));
+		assertThat(backedUpNewD1Candidate.getQtyAfter()).isEqualByComparingTo("150");
+
+		// the correction candidate itself (INVENTORY_UP, not its STOCK child) also gets a backup row - via its
+		// ATP_RECONCILIATION business-case detail, not via backupRepository - naming its own qty, not the running
+		// balance. Same (D1, null QtyBefore) signature as the STOCK child above; excluded by candidate id instead.
+		final I_MD_ATP_Reconciliation_Backup backedUpCorrectionCandidate = backedUpRows.stream()
+				.filter(row -> TimeUtil.asInstant(row.getDateProjected()).equals(D1)
+						&& InterfaceWrapperHelper.isNull(row, I_MD_ATP_Reconciliation_Backup.COLUMNNAME_QtyBefore)
+						&& row.getMD_Candidate_ID() != stockCandidateAtD1.getId().getRepoId())
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("no persisted backup row for the correction candidate itself: " + backedUpRows));
+		assertThat(backedUpCorrectionCandidate.getQtyAfter()).isEqualByComparingTo("50");
+	}
+
+	/**
+	 * A STOCK candidate backed up by one reconciliation run can legitimately be backed up again by a LATER
+	 * run whose window still reaches it - {@code MD_ATP_Reconciliation_Backup} has no uniqueness on
+	 * {@code MD_Candidate_ID} (its own migration header: "one row per STOCK candidate a run touched"), so
+	 * that candidate ends up with two rows sharing its id. {@code AtpReconciliationDetailRepo} reuses the
+	 * same table for a DIFFERENT purpose - naming the correction candidate's OWN business-case detail - and
+	 * originally looked a candidate up by {@code MD_Candidate_ID} alone, so re-reading a twice-audited STOCK
+	 * candidate hit {@code DBMoreThanOneRecordsFoundException}. This is the normal, expected operational
+	 * pattern (reconciling the same key repeatedly over time), not an edge case.
+	 */
+	@Test
+	public void reconcilingTwiceOverlappingTheSameStockCandidate_doesNotThrow()
+	{
+		final int stockId = createStockRecord(new BigDecimal("100"));
+
+		final AtpReconciliationRunLog firstRun = atpReconciliationCommand.reconcileAndLog(KEY, D1, false);
+		assertThat(firstRun.getRunUuid()).isNotNull();
+		assertThat(retrieveStockQtyUpTo(D1)).isEqualByComparingTo("100");
+
+		// a second, later divergence reconciled at the SAME D1 - its before/after STOCK read reaches the
+		// very STOCK candidate the first run's own correction already created and backed up
+		updateStockQtyOnHand(stockId, new BigDecimal("150"));
+
+		final AtpReconciliationRunLog secondRun = atpReconciliationCommand.reconcileAndLog(KEY, D1, false);
+
+		assertThat(secondRun.getRunUuid()).isNotNull();
+		assertThat(secondRun.getDivergence().getDifference()).isEqualByComparingTo("50");
+		assertThat(retrieveStockQtyUpTo(D1)).isEqualByComparingTo("150");
+
+		// the twice-audited STOCK candidate must still resolve to a Candidate with no business-case detail -
+		// re-reading it is exactly the operation that used to throw
+		assertThat(retrieveStockCandidateUpTo(D1).getBusinessCase()).isNull();
+	}
+
+	@Test
+	public void reconcileAndLog_writesNothingOnADryRun()
+	{
+		createStockRecord(new BigDecimal("100"));
+
+		final AtpReconciliationRunLog runLog = atpReconciliationCommand.reconcileAndLog(KEY, D1, true);
+
+		assertThat(runLog.isEmpty()).isTrue();
+		assertThat(runLog.getRunUuid()).isNull();
+		assertThat(runLog.getDivergence().getExpectedAtp()).isEqualByComparingTo("100");
+		assertThat(retrieveAllBackupRows()).isEmpty();
+	}
+
+	@Test
+	public void reconcileAndLog_writesTheBackupBeforeTheCandidateChange_notAfter()
+	{
+		final int stockId = createStockRecord(new BigDecimal("100"));
+		atpReconciliationCommand.reconcile(KEY, D1, false);
+		assertThat(retrieveStockQtyUpTo(D1)).isEqualByComparingTo("100");
+
+		// a fresh divergence for the crashing run to attempt to correct
+		updateStockQtyOnHand(stockId, new BigDecimal("150"));
+
+		// really persists the backup (so the test can prove it survives), then throws before the caller can
+		// possibly reach writeCorrectionCandidate - if the ordering were reversed (write, then back up), the
+		// STOCK candidate below would already show 150 by the time this exception is caught
+		final CrashAfterBackupRepository crashingRepository = new CrashAfterBackupRepository();
+		final AtpReconciliationCommand commandWithCrashingRepository = new AtpReconciliationCommand(
+				atpTargetCalculator, candidateChangeService, candidateRepository, crashingRepository);
+
+		assertThatThrownBy(() -> commandWithCrashingRepository.reconcileAndLog(KEY, D1, false))
+				.hasMessageContaining("simulated crash right after the backup was written");
+
+		assertThat(crashingRepository.backupWasCalled).isTrue();
+		assertThat(crashingRepository.capturedRunUuid).isNotNull();
+
+		// the candidate chain is UNCHANGED: the crash happened before writeCorrectionCandidate ever ran, proving
+		// the backup call precedes the write rather than following it
+		assertThat(retrieveStockQtyUpTo(D1)).isEqualByComparingTo("100");
+
+		// yet the backup itself is durably there despite the crash - recoverable even though the write never happened
+		final List<I_MD_ATP_Reconciliation_Backup> backedUpRows = retrieveBackupRows(crashingRepository.capturedRunUuid);
+		assertThat(backedUpRows).isNotEmpty();
+		assertThat(backedUpRows).allSatisfy(row -> assertThat(row.getQtyBefore()).isEqualByComparingTo("100"));
+	}
+
+	/** Really persists the backup (delegating to the real implementation), then throws - see the test above. */
+	private static final class CrashAfterBackupRepository implements AtpReconciliationBackupRepository
+	{
+		private final AtpReconciliationBackupRepository delegate = new AtpReconciliationBackupRepositoryImpl();
+
+		private boolean backupWasCalled = false;
+		private String capturedRunUuid = null;
+
+		@Override
+		public void backupBeforeWrite(
+				@NonNull final String runUuid,
+				@NonNull final StockDataRecordIdentifier key,
+				@NonNull final List<Candidate> stockCandidatesInScope)
+		{
+			delegate.backupBeforeWrite(runUuid, key, stockCandidatesInScope);
+			backupWasCalled = true;
+			capturedRunUuid = runUuid;
+			throw new RuntimeException("simulated crash right after the backup was written");
+		}
+
+		@Override
+		public void recordAfterWrite(
+				@NonNull final String runUuid,
+				@NonNull final StockDataRecordIdentifier key,
+				@NonNull final List<AtpReconciliationRunLog.Entry> entries)
+		{
+			throw new IllegalStateException("must not be reached: reconcileAndLog should have already failed after backupBeforeWrite");
+		}
+	}
+
+	private int createStockRecord(final BigDecimal qtyOnHand)
+	{
+		final I_MD_Stock record = InterfaceWrapperHelper.newInstance(I_MD_Stock.class);
+		// AD_Client_ID has no setter on the model interface
+		InterfaceWrapperHelper.setValue(record, I_MD_Stock.COLUMNNAME_AD_Client_ID, CLIENT_ID.getRepoId());
+		record.setAD_Org_ID(ORG_ID.getRepoId());
+		record.setM_Warehouse_ID(WAREHOUSE_ID.getRepoId());
+		record.setM_Product_ID(PRODUCT_ID.getRepoId());
+		record.setAttributesKey(AttributesKey.NONE.getAsString());
+		record.setQtyOnHand(qtyOnHand);
+		InterfaceWrapperHelper.save(record);
+		return record.getMD_Stock_ID();
+	}
+
+	/** Simulates a physical stock movement that never went through the material-dispo candidate chain. */
+	private void updateStockQtyOnHand(final int stockId, final BigDecimal qtyOnHand)
+	{
+		final I_MD_Stock record = InterfaceWrapperHelper.load(stockId, I_MD_Stock.class);
+		record.setQtyOnHand(qtyOnHand);
+		InterfaceWrapperHelper.save(record);
+	}
+
+	private int createShipmentSchedule(final boolean processed)
+	{
+		final I_M_ShipmentSchedule record = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule.class);
+		record.setProcessed(processed);
+		record.setIsActive(true);
+		InterfaceWrapperHelper.save(record);
+		return record.getM_ShipmentSchedule_ID();
+	}
+
+	/** Posts a {@code DEMAND} candidate through the real engine, so its {@code STOCK} propagation is the real one. */
+	private void postShipmentDemand(
+			final Instant date,
+			final BigDecimal qty,
+			final int shipmentScheduleId)
+	{
+		final Candidate candidate = Candidate.builder()
+				.clientAndOrgId(ClientAndOrgId.ofClientAndOrg(CLIENT_ID.getRepoId(), ORG_ID.getRepoId()))
+				.type(CandidateType.DEMAND)
+				.businessCase(CandidateBusinessCase.SHIPMENT)
+				.businessCaseDetail(DemandDetail.forShipmentScheduleIdAndOrderLineId(shipmentScheduleId, -1, -1, qty))
+				.materialDescriptor(MaterialDescriptor.builder()
+						.date(date)
+						.productDescriptor(ProductDescriptor.completeForProductIdAndEmptyAttribute(PRODUCT_ID.getRepoId()))
+						.warehouseId(WAREHOUSE_ID)
+						.quantity(qty)
+						.build())
+				.build();
+
+		candidateChangeService.onCandidateNewOrChange(candidate);
+	}
+
+	/** @return the {@code Qty} of the key's youngest general {@code STOCK} candidate dated at or before {@code date}. */
+	private BigDecimal retrieveStockQtyUpTo(final Instant date)
+	{
+		final Candidate stockCandidate = retrieveStockCandidateUpTo(date);
+		return stockCandidate != null ? stockCandidate.getQuantity() : BigDecimal.ZERO;
+	}
+
+	@Nullable
+	private Candidate retrieveStockCandidateUpTo(final Instant date)
+	{
+		final MaterialDescriptorQuery materialDescriptorQuery = MaterialDescriptorQuery.builder()
+				.warehouseId(WAREHOUSE_ID)
+				.productId(PRODUCT_ID.getRepoId())
+				.storageAttributesKey(AttributesKey.NONE)
+				.customer(BPartnerClassifier.none())
+				.timeRangeEnd(DateAndSeqNo.atTimeNoSeqNo(date).withOperator(DateAndSeqNo.Operator.INCLUSIVE))
+				.build();
+
+		return candidateRepository.retrieveLatestMatchOrNull(
+				CandidatesQuery.builder()
+						.materialDescriptorQuery(materialDescriptorQuery)
+						.matchExactStorageAttributesKey(true)
+						.type(CandidateType.STOCK)
+						.build());
+	}
+
+	private static List<I_MD_ATP_Reconciliation_Backup> retrieveBackupRows(@NonNull final String runUuid)
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_MD_ATP_Reconciliation_Backup.class)
+				.addEqualsFilter(I_MD_ATP_Reconciliation_Backup.COLUMNNAME_ReconciliationRunUUID, runUuid)
+				.create()
+				.list();
+	}
+
+	private static List<I_MD_ATP_Reconciliation_Backup> retrieveAllBackupRows()
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_MD_ATP_Reconciliation_Backup.class)
+				.create()
+				.list();
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/AtpReconciliationCommandTest.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/AtpReconciliationCommandTest.java
@@ -1,0 +1,378 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableList;
+import de.metas.document.dimension.DimensionService;
+import de.metas.document.dimension.MDCandidateDimensionFactory;
+import de.metas.material.cockpit.model.I_MD_Stock;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.commons.attributes.clasifiers.BPartnerClassifier;
+import de.metas.material.dispo.commons.candidate.Candidate;
+import de.metas.material.dispo.commons.candidate.CandidateBusinessCase;
+import de.metas.material.dispo.commons.candidate.CandidateId;
+import de.metas.material.dispo.commons.candidate.CandidateType;
+import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
+import de.metas.material.dispo.commons.repository.CandidateQtyDetailsRepository;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryWriteService;
+import de.metas.material.dispo.commons.repository.DateAndSeqNo;
+import de.metas.material.dispo.commons.repository.atp.AvailableToPromiseRepository;
+import de.metas.material.dispo.commons.repository.query.CandidatesQuery;
+import de.metas.material.dispo.commons.repository.query.MaterialDescriptorQuery;
+import de.metas.material.dispo.commons.repository.repohelpers.StockChangeDetailRepo;
+import de.metas.material.dispo.model.I_MD_Candidate;
+import de.metas.material.dispo.service.candidatechange.CandidateChangeService;
+import de.metas.material.dispo.service.candidatechange.StockCandidateService;
+import de.metas.material.dispo.service.candidatechange.handler.DemandCandiateHandler;
+import de.metas.material.dispo.service.candidatechange.handler.SupplyCandidateHandler;
+import de.metas.material.event.PostMaterialEventService;
+import de.metas.material.event.commons.AttributesKey;
+import de.metas.material.event.commons.MaterialDescriptor;
+import de.metas.material.event.commons.ProductDescriptor;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.organization.ClientAndOrgId;
+import de.metas.organization.OrgId;
+import de.metas.product.ProductId;
+import de.metas.util.Services;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_M_Transaction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests {@link AtpReconciliationCommand#reconcile}.
+ * <p>
+ * The wiring below deliberately builds its own {@link CandidateChangeService} (real {@link SupplyCandidateHandler}
+ * and {@link DemandCandiateHandler}, mocked only {@link PostMaterialEventService}) instead of resolving it through a
+ * {@code newInstanceForUnitTesting()} on {@link AtpReconciliationCommand} itself: {@link DemandCandiateHandler}
+ * needs a working {@link PostMaterialEventService}, and outside an active transaction
+ * {@code ITrxManager#accumulateAndProcessAfterCommit} runs its callback <b>eagerly</b> (see
+ * {@code ITrxManager.java:530-538}) - so a real one would attempt a genuine event-bus publish from inside this
+ * test. A main-source factory can't depend on Mockito, so {@link AtpReconciliationCommand} does not get a
+ * {@code newInstanceForUnitTesting()} of its own; this is the established pattern this package's engine tests
+ * already use for the same reason (e.g. {@code ShipmentScheduleCreatedHandlerTests}).
+ */
+public class AtpReconciliationCommandTest
+{
+	private static final Instant D = Instant.parse("2026-09-08T00:00:00Z");
+	private static final Instant BEFORE_D = D.minus(1, ChronoUnit.DAYS);
+
+	/** Far enough after every date used in this test to read the chain's current, fully-propagated balance. */
+	private static final Instant FAR_FUTURE = D.plus(3650, ChronoUnit.DAYS);
+
+	private static final ClientId CLIENT_ID = ClientId.ofRepoId(1000000);
+	private static final OrgId ORG_ID = OrgId.ofRepoId(1000001);
+	private static final WarehouseId WAREHOUSE_ID = WarehouseId.ofRepoId(1000002);
+	private static final ProductId PRODUCT_ID = ProductId.ofRepoId(1000003);
+
+	private static final StockDataRecordIdentifier KEY = StockDataRecordIdentifier.builder()
+			.clientId(CLIENT_ID)
+			.orgId(ORG_ID)
+			.warehouseId(WAREHOUSE_ID)
+			.productId(PRODUCT_ID)
+			.storageAttributesKey(AttributesKey.NONE)
+			.build();
+
+	private CandidateRepositoryRetrieval candidateRepository;
+	private CandidateChangeService candidateChangeService;
+	private AtpReconciliationCommand atpReconciliationCommand;
+
+	@BeforeEach
+	public void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		final DimensionService dimensionService = new DimensionService(ImmutableList.of(new MDCandidateDimensionFactory()));
+		final StockChangeDetailRepo stockChangeDetailRepo = new StockChangeDetailRepo();
+		candidateRepository = new CandidateRepositoryRetrieval(dimensionService, stockChangeDetailRepo);
+		final CandidateRepositoryWriteService candidateRepositoryWriteService = new CandidateRepositoryWriteService(
+				dimensionService, stockChangeDetailRepo, candidateRepository, new CandidateQtyDetailsRepository());
+		final StockCandidateService stockCandidateService = new StockCandidateService(candidateRepository, candidateRepositoryWriteService);
+
+		final SupplyCandidateHandler supplyCandidateHandler = new SupplyCandidateHandler(candidateRepositoryWriteService, stockCandidateService);
+		final DemandCandiateHandler demandCandiateHandler = new DemandCandiateHandler(
+				candidateRepository,
+				candidateRepositoryWriteService,
+				Mockito.mock(PostMaterialEventService.class),
+				new AvailableToPromiseRepository(),
+				stockCandidateService,
+				supplyCandidateHandler);
+
+		candidateChangeService = new CandidateChangeService(ImmutableList.of(supplyCandidateHandler, demandCandiateHandler));
+
+		final AtpTargetCalculator atpTargetCalculator = AtpTargetCalculator.newInstanceForUnitTesting();
+		atpReconciliationCommand = new AtpReconciliationCommand(atpTargetCalculator, candidateChangeService, candidateRepository);
+	}
+
+	@Test
+	public void chainZeroedWithPhysicalStock_reconcileWritesThePhysicalStockAsTheStockCandidate()
+	{
+		final int stockId = createStockRecord(new BigDecimal("100"));
+
+		final AtpDivergence divergence = atpReconciliationCommand.reconcile(KEY, D, false);
+
+		assertThat(divergence.getExpectedAtp()).isEqualByComparingTo("100");
+		assertThat(divergence.getStoredAtp()).isEqualByComparingTo("0");
+		assertThat(retrieveCurrentProjectedAtp()).isEqualByComparingTo("100");
+		// reconciling never moves physical stock or posts a transaction: both are asserted unchanged here
+		assertThat(retrieveStockQtyOnHand(stockId)).isEqualByComparingTo("100");
+		assertThat(countTransactionRecords()).isZero();
+	}
+
+	@Test
+	public void reconcilingTwiceInSuccession_leavesTheStoredValueUnchanged()
+	{
+		createStockRecord(new BigDecimal("100"));
+
+		atpReconciliationCommand.reconcile(KEY, D, false);
+		assertThat(retrieveCurrentProjectedAtp()).isEqualByComparingTo("100");
+		final int candidateCountAfterFirstRun = countCandidateRecords();
+
+		final AtpDivergence secondRun = atpReconciliationCommand.reconcile(KEY, D, false);
+
+		assertThat(secondRun.getDifference()).isEqualByComparingTo("0");
+		assertThat(retrieveCurrentProjectedAtp()).isEqualByComparingTo("100");
+		// the second run has nothing to correct (the delta is zero) - it must not write a phantom zero-qty
+		// candidate (and its paired STOCK child) on top of the first run's rows
+		assertThat(countCandidateRecords()).isEqualTo(candidateCountAfterFirstRun);
+	}
+
+	@Test
+	public void secondCorrectionWithANonZeroDelta_composesOnTopOfTheFirstInsteadOfReplacingIt()
+	{
+		final int stockId = createStockRecord(new BigDecimal("100"));
+
+		atpReconciliationCommand.reconcile(KEY, D, false);
+		assertThat(retrieveCurrentProjectedAtp()).isEqualByComparingTo("100");
+
+		// physical stock moves by another +100 without going through the candidate chain at all - exactly the
+		// kind of divergence this feature exists to catch (unlike laterDemandDatedBeforeD_..., where the engine's
+		// own propagation already keeps the projection correct without any help from this class). The second
+		// correction's own delta (100) deliberately comes out equal to the first correction's own quantity: that
+		// is precisely the case a natural-key match keyed on "same qty, same reset-pinstance value" cannot tell
+		// apart from "the same candidate as before" (see buildCandidate's Javadoc) - a same-key, differently-sized
+		// second correction would not exercise that trap.
+		updateStockQtyOnHand(stockId, new BigDecimal("200"));
+
+		// a *fresh* AtpReconciliationCommand instance for the second call - sharing no in-memory state with the
+		// first (e.g. after an app-server restart, or handled by a second node): correctness must not depend on
+		// any in-process continuity between two reconcile() calls for the same key and date. A per-instance
+		// counter (as opposed to reading the disambiguator back from the store) would pass this test if the same
+		// instance were reused for both calls, without covering the actual failure this finding is about.
+		final AtpReconciliationCommand secondInstance = new AtpReconciliationCommand(
+				AtpTargetCalculator.newInstanceForUnitTesting(), candidateChangeService, candidateRepository);
+
+		final AtpDivergence secondRun = secondInstance.reconcile(KEY, D, false);
+
+		assertThat(secondRun.getDifference()).isEqualByComparingTo("100");
+		// if the second correction natural-key-matched the first one and replaced its qty instead of composing,
+		// this would read 100 (the second correction's own qty, same as the first's) instead of 100 + 100
+		assertThat(retrieveCurrentProjectedAtp()).isEqualByComparingTo("200");
+	}
+
+	@Test
+	public void aDryRun_computesTheDivergenceButWritesNothing()
+	{
+		createStockRecord(new BigDecimal("100"));
+
+		final AtpDivergence divergence = atpReconciliationCommand.reconcile(KEY, D, true);
+
+		assertThat(divergence.getExpectedAtp()).isEqualByComparingTo("100");
+		assertThat(retrieveCurrentProjectedAtp()).isEqualByComparingTo("0");
+		assertThat(countTransactionRecords()).isZero();
+	}
+
+	@Test
+	public void laterDemandDatedBeforeD_shiftsTheReconciledProjectionByExactlyItsOwnQty()
+	{
+		createStockRecord(new BigDecimal("100"));
+		atpReconciliationCommand.reconcile(KEY, D, false);
+		assertThat(retrieveCurrentProjectedAtp()).isEqualByComparingTo("100");
+
+		final int shipmentScheduleId = createShipmentSchedule(false /* processed */);
+		postShipmentDemand(null, BEFORE_D, new BigDecimal("30"), shipmentScheduleId);
+
+		// the reconciled 100 is not discarded - it is adjusted by exactly the new demand's -30
+		assertThat(retrieveCurrentProjectedAtp()).isEqualByComparingTo("70");
+	}
+
+	@Test
+	public void laterQuantityChangeOfAPreDCandidate_shiftsTheReconciledProjectionByExactlyTheDifference()
+	{
+		createStockRecord(new BigDecimal("100"));
+		final int shipmentScheduleId = createShipmentSchedule(false /* processed */);
+		final Candidate demand = postShipmentDemand(null, BEFORE_D, new BigDecimal("20"), shipmentScheduleId);
+
+		atpReconciliationCommand.reconcile(KEY, D, false);
+		assertThat(retrieveCurrentProjectedAtp()).isEqualByComparingTo("80"); // 100 - 20
+
+		// bump the same pre-D candidate's qty up: 20 -> 50, a further -30
+		postShipmentDemand(demand.getId(), BEFORE_D, new BigDecimal("50"), shipmentScheduleId);
+		assertThat(retrieveCurrentProjectedAtp()).isEqualByComparingTo("50"); // 80 - 30
+
+		// ...and back down: 50 -> 10, a +40 relative to the last value
+		postShipmentDemand(demand.getId(), BEFORE_D, new BigDecimal("10"), shipmentScheduleId);
+		assertThat(retrieveCurrentProjectedAtp()).isEqualByComparingTo("90"); // 50 + 40, i.e. 100 - 10
+	}
+
+	@Test
+	public void voidingAPreDCandidate_shiftsTheProjectionBackByExactlyItsFormerContribution()
+	{
+		createStockRecord(new BigDecimal("100"));
+		final int shipmentScheduleId = createShipmentSchedule(false /* processed */);
+		final Candidate demand = postShipmentDemand(null, BEFORE_D, new BigDecimal("30"), shipmentScheduleId);
+
+		atpReconciliationCommand.reconcile(KEY, D, false);
+		assertThat(retrieveCurrentProjectedAtp()).isEqualByComparingTo("70"); // 100 - 30
+
+		candidateChangeService.onCandidateDelete(demand);
+
+		// the demand's former -30 contribution is gone; the reconciled balance shifts back by exactly that
+		assertThat(retrieveCurrentProjectedAtp()).isEqualByComparingTo("100");
+	}
+
+	private int createStockRecord(final BigDecimal qtyOnHand)
+	{
+		final I_MD_Stock record = InterfaceWrapperHelper.newInstance(I_MD_Stock.class);
+		// AD_Client_ID has no setter on the model interface
+		InterfaceWrapperHelper.setValue(record, I_MD_Stock.COLUMNNAME_AD_Client_ID, CLIENT_ID.getRepoId());
+		record.setAD_Org_ID(ORG_ID.getRepoId());
+		record.setM_Warehouse_ID(WAREHOUSE_ID.getRepoId());
+		record.setM_Product_ID(PRODUCT_ID.getRepoId());
+		record.setAttributesKey(AttributesKey.NONE.getAsString());
+		record.setQtyOnHand(qtyOnHand);
+		InterfaceWrapperHelper.save(record);
+		return record.getMD_Stock_ID();
+	}
+
+	private BigDecimal retrieveStockQtyOnHand(final int stockId)
+	{
+		return InterfaceWrapperHelper.load(stockId, I_MD_Stock.class).getQtyOnHand();
+	}
+
+	/** Simulates a physical stock movement that never went through the material-dispo candidate chain. */
+	private void updateStockQtyOnHand(final int stockId, final BigDecimal qtyOnHand)
+	{
+		final I_MD_Stock record = InterfaceWrapperHelper.load(stockId, I_MD_Stock.class);
+		record.setQtyOnHand(qtyOnHand);
+		InterfaceWrapperHelper.save(record);
+	}
+
+	private int countTransactionRecords()
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_M_Transaction.class)
+				.create()
+				.list()
+				.size();
+	}
+
+	/** @return how many {@code MD_Candidate} rows (of any type) exist for {@link #KEY}'s product and warehouse. */
+	private int countCandidateRecords()
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_MD_Candidate.class)
+				.addEqualsFilter(I_MD_Candidate.COLUMNNAME_M_Product_ID, PRODUCT_ID.getRepoId())
+				.addEqualsFilter(I_MD_Candidate.COLUMNNAME_M_Warehouse_ID, WAREHOUSE_ID.getRepoId())
+				.create()
+				.list()
+				.size();
+	}
+
+	private int createShipmentSchedule(final boolean processed)
+	{
+		final I_M_ShipmentSchedule record = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule.class);
+		record.setProcessed(processed);
+		record.setIsActive(true);
+		InterfaceWrapperHelper.save(record);
+		return record.getM_ShipmentSchedule_ID();
+	}
+
+	/**
+	 * Posts a {@code DEMAND} candidate through the real {@link CandidateChangeService}, so the resulting
+	 * {@code STOCK} propagation is the engine's real one - not a direct write, matching how an ordinary
+	 * subsequent material event reaches the chain in production.
+	 *
+	 * @param id when {@code null}, creates a new candidate; when set, updates the existing candidate with that id
+	 * (mirrors how {@code CandidatesQuery.fromCandidate} dispatches - see its {@code candidate.getId()} check)
+	 */
+	private Candidate postShipmentDemand(
+			@Nullable final CandidateId id,
+			final Instant date,
+			final BigDecimal qty,
+			final int shipmentScheduleId)
+	{
+		final Candidate candidate = Candidate.builder()
+				.id(id)
+				.clientAndOrgId(ClientAndOrgId.ofClientAndOrg(CLIENT_ID.getRepoId(), ORG_ID.getRepoId()))
+				.type(CandidateType.DEMAND)
+				.businessCase(CandidateBusinessCase.SHIPMENT)
+				.businessCaseDetail(DemandDetail.forShipmentScheduleIdAndOrderLineId(shipmentScheduleId, -1, -1, qty))
+				.materialDescriptor(MaterialDescriptor.builder()
+						.date(date)
+						.productDescriptor(ProductDescriptor.completeForProductIdAndEmptyAttribute(PRODUCT_ID.getRepoId()))
+						.warehouseId(WAREHOUSE_ID)
+						.quantity(qty)
+						.build())
+				.build();
+
+		return candidateChangeService.onCandidateNewOrChange(candidate).getCandidate();
+	}
+
+	/**
+	 * @return the {@code Qty} of the key's youngest general {@code STOCK} candidate, i.e. the chain's current,
+	 * fully-propagated running balance - mirrors {@code AtpTargetCalculator#retrieveStoredAtp}, which is private.
+	 */
+	private BigDecimal retrieveCurrentProjectedAtp()
+	{
+		final MaterialDescriptorQuery materialDescriptorQuery = MaterialDescriptorQuery.builder()
+				.warehouseId(WAREHOUSE_ID)
+				.productId(PRODUCT_ID.getRepoId())
+				.storageAttributesKey(AttributesKey.NONE)
+				.customer(BPartnerClassifier.none())
+				.timeRangeEnd(DateAndSeqNo.atTimeNoSeqNo(FAR_FUTURE).withOperator(DateAndSeqNo.Operator.INCLUSIVE))
+				.build();
+
+		final Candidate stockCandidate = candidateRepository.retrieveLatestMatchOrNull(
+				CandidatesQuery.builder()
+						.materialDescriptorQuery(materialDescriptorQuery)
+						.matchExactStorageAttributesKey(true)
+						.type(CandidateType.STOCK)
+						.build());
+
+		return stockCandidate != null ? stockCandidate.getQuantity() : BigDecimal.ZERO;
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/AtpTargetCalculatorTest.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/AtpTargetCalculatorTest.java
@@ -1,0 +1,312 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableList;
+import de.metas.bpartner.BPartnerId;
+import de.metas.document.dimension.DimensionService;
+import de.metas.document.dimension.MDCandidateDimensionFactory;
+import de.metas.document.engine.DocStatus;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.material.cockpit.model.I_MD_Stock;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.dispo.commons.candidate.Candidate;
+import de.metas.material.dispo.commons.candidate.CandidateBusinessCase;
+import de.metas.material.dispo.commons.candidate.CandidateId;
+import de.metas.material.dispo.commons.candidate.CandidateType;
+import de.metas.material.dispo.commons.candidate.businesscase.BusinessCaseDetail;
+import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
+import de.metas.material.dispo.commons.candidate.businesscase.Flag;
+import de.metas.material.dispo.commons.candidate.businesscase.ProductionDetail;
+import de.metas.material.dispo.commons.repository.CandidateQtyDetailsRepository;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryWriteService;
+import de.metas.material.dispo.commons.repository.repohelpers.StockChangeDetailRepo;
+import de.metas.material.dispo.model.I_MD_Candidate;
+import de.metas.material.event.commons.AttributesKey;
+import de.metas.material.event.commons.MaterialDescriptor;
+import de.metas.material.event.commons.ProductDescriptor;
+import de.metas.material.event.pporder.PPOrderRef;
+import de.metas.organization.ClientAndOrgId;
+import de.metas.organization.OrgId;
+import de.metas.product.ProductId;
+import de.metas.product.ResourceId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.eevolution.model.I_PP_Order;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AtpTargetCalculatorTest
+{
+	private static final Instant D = Instant.parse("2026-09-08T00:00:00Z");
+	private static final Instant BEFORE_D = D.minus(1, ChronoUnit.DAYS);
+	private static final Instant AFTER_D = D.plus(1, ChronoUnit.DAYS);
+
+	private static final ClientId CLIENT_ID = ClientId.ofRepoId(1000000);
+	private static final OrgId ORG_ID = OrgId.ofRepoId(1000001);
+	private static final WarehouseId WAREHOUSE_ID = WarehouseId.ofRepoId(1000002);
+	private static final ProductId PRODUCT_ID = ProductId.ofRepoId(1000003);
+	private static final BPartnerId CUSTOMER_ID = BPartnerId.ofRepoId(1000004);
+
+	/** The key every fixture of this test belongs to. */
+	private static final StockDataRecordIdentifier KEY = StockDataRecordIdentifier.builder()
+			.clientId(CLIENT_ID)
+			.orgId(ORG_ID)
+			.warehouseId(WAREHOUSE_ID)
+			.productId(PRODUCT_ID)
+			.storageAttributesKey(AttributesKey.NONE)
+			.build();
+
+	private AtpTargetCalculator atpTargetCalculator;
+	private CandidateRepositoryWriteService candidateRepositoryWriteService;
+
+	@BeforeEach
+	public void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		final DimensionService dimensionService = new DimensionService(ImmutableList.of(new MDCandidateDimensionFactory()));
+		final StockChangeDetailRepo stockChangeDetailRepo = new StockChangeDetailRepo();
+		final CandidateRepositoryRetrieval candidateRepository = new CandidateRepositoryRetrieval(dimensionService, stockChangeDetailRepo);
+		candidateRepositoryWriteService = new CandidateRepositoryWriteService(
+				dimensionService,
+				stockChangeDetailRepo,
+				candidateRepository,
+				new CandidateQtyDetailsRepository());
+
+		atpTargetCalculator = AtpTargetCalculator.newInstanceForUnitTesting();
+	}
+
+	@Test
+	public void noCandidates_targetIsThePhysicalQtyOnHand()
+	{
+		createStockRecord(new BigDecimal("100"));
+
+		assertThat(atpTargetCalculator.computeTarget(KEY, D)).isEqualByComparingTo("100");
+	}
+
+	@Test
+	public void openShipmentDemandDatedBeforeD_isSubtracted()
+	{
+		createStockRecord(new BigDecimal("200"));
+		addShipmentDemand(BEFORE_D, new BigDecimal("30"), createShipmentSchedule(false /* processed */));
+
+		assertThat(atpTargetCalculator.computeTarget(KEY, D)).isEqualByComparingTo("170");
+	}
+
+	@Test
+	public void openShipmentDemandDatedAfterD_isExcluded()
+	{
+		createStockRecord(new BigDecimal("200"));
+		addShipmentDemand(AFTER_D, new BigDecimal("30"), createShipmentSchedule(false /* processed */));
+
+		assertThat(atpTargetCalculator.computeTarget(KEY, D)).isEqualByComparingTo("200");
+	}
+
+	@Test
+	public void productionDemandOfAClosedPPOrder_isExcluded()
+	{
+		createStockRecord(new BigDecimal("80"));
+		addProductionDemand(BEFORE_D, new BigDecimal("20"), createPPOrder(DocStatus.Closed));
+
+		assertThat(atpTargetCalculator.computeTarget(KEY, D)).isEqualByComparingTo("80");
+	}
+
+	@Test
+	public void partlyFulfilledShipmentDemand_contributesOnlyItsOpenRemainder()
+	{
+		createStockRecord(new BigDecimal("200"));
+		final CandidateId candidateId = addShipmentDemand(BEFORE_D, new BigDecimal("30"), createShipmentSchedule(false /* processed */));
+		setQtyFulfilled(candidateId, new BigDecimal("10"));
+
+		assertThat(atpTargetCalculator.computeTarget(KEY, D)).isEqualByComparingTo("180");
+	}
+
+	@Test
+	public void driftedKey_divergenceIsExpectedMinusStored()
+	{
+		createStockRecord(new BigDecimal("200"));
+		addShipmentDemand(BEFORE_D, new BigDecimal("30"), createShipmentSchedule(false /* processed */));
+		// the stored projection says 500 although the key's target is 200 - 30 = 170
+		addStockCandidate(D, new BigDecimal("500"));
+
+		final AtpDivergence divergence = atpTargetCalculator.computeDivergence(KEY, D);
+
+		assertThat(divergence.getExpectedAtp()).isEqualByComparingTo("170");
+		assertThat(divergence.getStoredAtp()).isEqualByComparingTo("500");
+		assertThat(divergence.getDifference())
+				.isEqualByComparingTo(divergence.getExpectedAtp().subtract(divergence.getStoredAtp()))
+				.isEqualByComparingTo("-330");
+	}
+
+	/**
+	 * The stored balance has to come from the key's <b>general</b> chain. A {@code STOCK} candidate that
+	 * {@code StockCandidateService} created for a customer-reserved position carries that customer's id and
+	 * its {@code Qty} is the balance over that customer's rows plus the null-customer rows only - reading it
+	 * as "the stored balance" would compare it against an {@code expectedAtp} that is anchored on
+	 * {@code MD_Stock.QtyOnHand}, which has no customer dimension.
+	 */
+	@Test
+	public void youngestStockCandidateIsReservedForACustomer_storedAtpIsTakenFromTheGeneralChain()
+	{
+		createStockRecord(new BigDecimal("200"));
+		addShipmentDemand(BEFORE_D, new BigDecimal("30"), createShipmentSchedule(false /* processed */));
+		// the general chain's running balance, and the only STOCK candidate that may be read as "stored": 200 - 30
+		addStockCandidate(BEFORE_D, new BigDecimal("170"));
+		// ...younger than that, but a *customer's* reserved balance rather than the general one
+		addCustomerReservedStockCandidate(D, new BigDecimal("500"));
+
+		final AtpDivergence divergence = atpTargetCalculator.computeDivergence(KEY, D);
+
+		assertThat(divergence.getStoredAtp()).isEqualByComparingTo("170");
+		// the sum stays customer-agnostic: 200 - 30
+		assertThat(divergence.getExpectedAtp()).isEqualByComparingTo("170");
+		assertThat(divergence.getDifference()).isEqualByComparingTo("0");
+	}
+
+	private void createStockRecord(final BigDecimal qtyOnHand)
+	{
+		final I_MD_Stock record = InterfaceWrapperHelper.newInstance(I_MD_Stock.class);
+		// AD_Client_ID has no setter on the model interface
+		InterfaceWrapperHelper.setValue(record, I_MD_Stock.COLUMNNAME_AD_Client_ID, CLIENT_ID.getRepoId());
+		record.setAD_Org_ID(ORG_ID.getRepoId());
+		record.setM_Warehouse_ID(WAREHOUSE_ID.getRepoId());
+		record.setM_Product_ID(PRODUCT_ID.getRepoId());
+		record.setAttributesKey(AttributesKey.NONE.getAsString());
+		record.setQtyOnHand(qtyOnHand);
+		InterfaceWrapperHelper.save(record);
+	}
+
+	private int createShipmentSchedule(final boolean processed)
+	{
+		final I_M_ShipmentSchedule record = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule.class);
+		record.setProcessed(processed);
+		record.setIsActive(true);
+		InterfaceWrapperHelper.save(record);
+		return record.getM_ShipmentSchedule_ID();
+	}
+
+	private int createPPOrder(final DocStatus docStatus)
+	{
+		final I_PP_Order record = InterfaceWrapperHelper.newInstance(I_PP_Order.class);
+		record.setDocStatus(docStatus.getCode());
+		InterfaceWrapperHelper.save(record);
+		return record.getPP_Order_ID();
+	}
+
+	/**
+	 * {@code QtyFulfilled} is not part of {@link Candidate}, so it is set on the persisted record.
+	 */
+	private void setQtyFulfilled(final CandidateId candidateId, final BigDecimal qtyFulfilled)
+	{
+		final I_MD_Candidate record = InterfaceWrapperHelper.load(candidateId.getRepoId(), I_MD_Candidate.class);
+		record.setQtyFulfilled(qtyFulfilled);
+		InterfaceWrapperHelper.save(record);
+	}
+
+	private CandidateId addShipmentDemand(final Instant date, final BigDecimal qty, final int shipmentScheduleId)
+	{
+		return addCandidate(
+				CandidateType.DEMAND,
+				CandidateBusinessCase.SHIPMENT,
+				DemandDetail.forShipmentScheduleIdAndOrderLineId(shipmentScheduleId, -1, -1, qty),
+				date,
+				qty);
+	}
+
+	private CandidateId addProductionDemand(final Instant date, final BigDecimal qty, final int ppOrderId)
+	{
+		final ProductionDetail productionDetail = ProductionDetail.builder()
+				.plantId(ResourceId.ofRepoId(1))
+				.productBomLineId(1)
+				.description("test")
+				.ppOrderRef(PPOrderRef.ofPPOrderId(ppOrderId))
+				.ppOrderDocStatus(DocStatus.Completed) // deliberately NOT the live status; the service has to read the PP_Order
+				.advised(Flag.FALSE)
+				.pickDirectlyIfFeasible(Flag.FALSE)
+				.qty(qty)
+				.build();
+
+		return addCandidate(CandidateType.DEMAND, CandidateBusinessCase.PRODUCTION, productionDetail, date, qty);
+	}
+
+	private CandidateId addStockCandidate(final Instant date, final BigDecimal qty)
+	{
+		return addCandidate(CandidateType.STOCK, null, null, date, qty, null /* customerId */);
+	}
+
+	/**
+	 * A {@code STOCK} candidate as {@code StockCandidateService} writes it for a position reserved for a
+	 * customer: it carries {@code C_BPartner_Customer_ID} and {@code IsReservedForCustomer='Y'}.
+	 */
+	private CandidateId addCustomerReservedStockCandidate(final Instant date, final BigDecimal qty)
+	{
+		return addCandidate(CandidateType.STOCK, null, null, date, qty, CUSTOMER_ID);
+	}
+
+	private CandidateId addCandidate(
+			final CandidateType type,
+			@Nullable final CandidateBusinessCase businessCase,
+			@Nullable final BusinessCaseDetail businessCaseDetail,
+			final Instant date,
+			final BigDecimal qty)
+	{
+		return addCandidate(type, businessCase, businessCaseDetail, date, qty, null /* customerId */);
+	}
+
+	private CandidateId addCandidate(
+			final CandidateType type,
+			@Nullable final CandidateBusinessCase businessCase,
+			@Nullable final BusinessCaseDetail businessCaseDetail,
+			final Instant date,
+			final BigDecimal qty,
+			@Nullable final BPartnerId customerId)
+	{
+		final Candidate candidate = Candidate.builder()
+				.clientAndOrgId(ClientAndOrgId.ofClientAndOrg(CLIENT_ID.getRepoId(), ORG_ID.getRepoId()))
+				.type(type)
+				.businessCase(businessCase)
+				.businessCaseDetail(businessCaseDetail)
+				.materialDescriptor(MaterialDescriptor.builder()
+						.date(date)
+						.productDescriptor(ProductDescriptor.completeForProductIdAndEmptyAttribute(PRODUCT_ID.getRepoId()))
+						.warehouseId(WAREHOUSE_ID)
+						.customerId(customerId)
+						.reservedForCustomer(customerId != null)
+						.quantity(qty)
+						.build())
+				.build();
+
+		return candidateRepositoryWriteService.add(candidate).getCandidate().getId();
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/SourceDocumentLivenessServiceTest.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/SourceDocumentLivenessServiceTest.java
@@ -1,0 +1,220 @@
+package de.metas.material.dispo.reconcile;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.document.engine.DocStatus;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.material.dispo.commons.candidate.Candidate;
+import de.metas.material.dispo.commons.candidate.CandidateBusinessCase;
+import de.metas.material.dispo.commons.candidate.CandidateType;
+import de.metas.material.dispo.commons.candidate.businesscase.BusinessCaseDetail;
+import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
+import de.metas.material.dispo.commons.candidate.businesscase.Flag;
+import de.metas.material.dispo.commons.candidate.businesscase.ProductionDetail;
+import de.metas.material.dispo.commons.reconcile.SourceDocumentStatus;
+import de.metas.material.event.commons.MaterialDescriptor;
+import de.metas.material.event.commons.ProductDescriptor;
+import de.metas.material.event.pporder.PPOrderRef;
+import de.metas.organization.ClientAndOrgId;
+import de.metas.product.ResourceId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.util.Env;
+import org.compiere.model.I_M_Forecast;
+import org.compiere.model.I_M_ForecastLine;
+import org.eevolution.model.I_PP_Order;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SourceDocumentLivenessServiceTest
+{
+	private static final Instant DATE_OF_CANDIDATE = Instant.parse("2026-09-08T00:00:00Z");
+	private static final int PRODUCT_ID = 1000001;
+	private static final WarehouseId WAREHOUSE_ID = WarehouseId.ofRepoId(1000002);
+
+	private SourceDocumentLivenessService livenessService;
+
+	@BeforeEach
+	public void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		livenessService = SourceDocumentLivenessService.newInstanceForUnitTesting();
+	}
+
+	@Test
+	public void shipmentDemandWithOpenShipmentSchedule_isStillOpen()
+	{
+		final int shipmentScheduleId = createShipmentSchedule(false /* processed */, true /* active */);
+		final Candidate candidate = demandCandidate(
+				CandidateBusinessCase.SHIPMENT,
+				DemandDetail.forShipmentScheduleIdAndOrderLineId(shipmentScheduleId, -1, -1, BigDecimal.TEN));
+
+		assertThat(livenessService.getStatus(candidate)).isEqualTo(SourceDocumentStatus.STILL_OPEN);
+	}
+
+	@Test
+	public void shipmentDemandWithProcessedShipmentSchedule_isClosed()
+	{
+		final int shipmentScheduleId = createShipmentSchedule(true /* processed */, true /* active */);
+		final Candidate candidate = demandCandidate(
+				CandidateBusinessCase.SHIPMENT,
+				DemandDetail.forShipmentScheduleIdAndOrderLineId(shipmentScheduleId, -1, -1, BigDecimal.TEN));
+
+		assertThat(livenessService.getStatus(candidate)).isEqualTo(SourceDocumentStatus.CLOSED);
+	}
+
+	@Test
+	public void productionDemandWithClosedPPOrder_isClosed()
+	{
+		final int ppOrderId = createPPOrder(DocStatus.Closed);
+		final Candidate candidate = demandCandidate(CandidateBusinessCase.PRODUCTION, productionDetail(ppOrderId));
+
+		assertThat(livenessService.getStatus(candidate)).isEqualTo(SourceDocumentStatus.CLOSED);
+	}
+
+	@Test
+	public void productionDemandWithCompletedPPOrder_isStillOpen()
+	{
+		final int ppOrderId = createPPOrder(DocStatus.Completed);
+		final Candidate candidate = demandCandidate(CandidateBusinessCase.PRODUCTION, productionDetail(ppOrderId));
+
+		assertThat(livenessService.getStatus(candidate)).isEqualTo(SourceDocumentStatus.STILL_OPEN);
+	}
+
+	@Test
+	public void forecastDemandWithOpenForecast_isStillOpen()
+	{
+		final int forecastLineId = createForecastLine(DocStatus.Completed);
+		final Candidate candidate = demandCandidate(
+				CandidateBusinessCase.FORECAST,
+				DemandDetail.forForecastLineId(forecastLineId, -1 /* forecastId */, BigDecimal.TEN));
+
+		assertThat(livenessService.getStatus(candidate)).isEqualTo(SourceDocumentStatus.STILL_OPEN);
+	}
+
+	@Test
+	public void forecastDemandWithClosedForecast_isClosed()
+	{
+		final int forecastLineId = createForecastLine(DocStatus.Closed);
+		final Candidate candidate = demandCandidate(
+				CandidateBusinessCase.FORECAST,
+				DemandDetail.forForecastLineId(forecastLineId, -1 /* forecastId */, BigDecimal.TEN));
+
+		assertThat(livenessService.getStatus(candidate)).isEqualTo(SourceDocumentStatus.CLOSED);
+	}
+
+	@Test
+	public void candidateWithoutAnyDetail_hasNoSourceDocument()
+	{
+		final Candidate candidate = demandCandidate(CandidateBusinessCase.SHIPMENT, null);
+
+		assertThat(livenessService.getStatus(candidate)).isEqualTo(SourceDocumentStatus.NO_SOURCE_DOCUMENT);
+	}
+
+	@Test
+	public void openShipmentScheduleDatedBeforeTheLivenessCutoff_isClosed()
+	{
+		final int shipmentScheduleId = createShipmentSchedule(false /* processed */, true /* active */);
+		final Candidate candidate = demandCandidate(
+				CandidateBusinessCase.SHIPMENT,
+				DemandDetail.forShipmentScheduleIdAndOrderLineId(shipmentScheduleId, -1, -1, BigDecimal.TEN));
+		final Instant livenessCutoff = DATE_OF_CANDIDATE.plusSeconds(1);
+
+		assertThat(livenessService.getStatus(candidate, livenessCutoff)).isEqualTo(SourceDocumentStatus.CLOSED);
+		assertThat(livenessService.getStatus(candidate, DATE_OF_CANDIDATE)).isEqualTo(SourceDocumentStatus.STILL_OPEN);
+	}
+
+	private int createShipmentSchedule(final boolean processed, final boolean active)
+	{
+		final I_M_ShipmentSchedule record = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule.class);
+		record.setProcessed(processed);
+		record.setIsActive(active);
+		InterfaceWrapperHelper.save(record);
+		return record.getM_ShipmentSchedule_ID();
+	}
+
+	/**
+	 * Note that the created line's {@code M_Forecast_ID} is the ONLY way to reach the forecast document
+	 * here: the tests deliberately leave {@code DemandDetail.forecastId} unset, so the service has to walk
+	 * {@code M_ForecastLine.M_Forecast_ID} rather than short-cutting via the detail.
+	 */
+	private int createForecastLine(final DocStatus docStatus)
+	{
+		final I_M_Forecast forecast = InterfaceWrapperHelper.newInstance(I_M_Forecast.class);
+		forecast.setDocStatus(docStatus.getCode());
+		InterfaceWrapperHelper.save(forecast);
+
+		final I_M_ForecastLine forecastLine = InterfaceWrapperHelper.newInstance(I_M_ForecastLine.class);
+		forecastLine.setM_Forecast_ID(forecast.getM_Forecast_ID());
+		InterfaceWrapperHelper.save(forecastLine);
+
+		return forecastLine.getM_ForecastLine_ID();
+	}
+
+	private int createPPOrder(final DocStatus docStatus)
+	{
+		final I_PP_Order record = InterfaceWrapperHelper.newInstance(I_PP_Order.class);
+		record.setDocStatus(docStatus.getCode());
+		InterfaceWrapperHelper.save(record);
+		return record.getPP_Order_ID();
+	}
+
+	private static ProductionDetail productionDetail(final int ppOrderId)
+	{
+		return ProductionDetail.builder()
+				.plantId(ResourceId.ofRepoId(1))
+				.productBomLineId(1)
+				.description("test")
+				.ppOrderRef(PPOrderRef.ofPPOrderId(ppOrderId))
+				.ppOrderDocStatus(DocStatus.Completed)
+				.advised(Flag.FALSE)
+				.pickDirectlyIfFeasible(Flag.FALSE)
+				.qty(BigDecimal.TEN)
+				.build();
+	}
+
+	private static Candidate demandCandidate(
+			final CandidateBusinessCase businessCase,
+			@Nullable final BusinessCaseDetail businessCaseDetail)
+	{
+		return Candidate.builder()
+				.clientAndOrgId(ClientAndOrgId.ofClientAndOrg(Env.getAD_Client_ID(Env.getCtx()), 1000000))
+				.type(CandidateType.DEMAND)
+				.businessCase(businessCase)
+				.businessCaseDetail(businessCaseDetail)
+				.materialDescriptor(MaterialDescriptor.builder()
+						.date(DATE_OF_CANDIDATE)
+						.productDescriptor(ProductDescriptor.completeForProductIdAndEmptyAttribute(PRODUCT_ID))
+						.warehouseId(WAREHOUSE_ID)
+						.quantity(BigDecimal.TEN)
+						.build())
+				.build();
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/async/AtpReconciliationWorkpackageProcessorTest.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/async/AtpReconciliationWorkpackageProcessorTest.java
@@ -1,0 +1,295 @@
+package de.metas.material.dispo.reconcile.async;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableList;
+import de.metas.Profiles;
+import de.metas.async.model.I_C_Queue_WorkPackage;
+import de.metas.async.spi.IWorkpackageProcessor;
+import de.metas.material.cockpit.model.I_MD_Stock;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.cockpit.stock.StockRepository;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
+import de.metas.material.dispo.reconcile.AtpDivergence;
+import de.metas.material.dispo.reconcile.AtpReconciliationCommand;
+import de.metas.material.dispo.reconcile.AtpReconciliationRunLog;
+import de.metas.material.dispo.reconcile.AtpTargetCalculator;
+import de.metas.material.dispo.service.candidatechange.CandidateChangeService;
+import de.metas.material.event.commons.AttributesKey;
+import de.metas.organization.OrgId;
+import de.metas.product.ProductId;
+import de.metas.user.UserId;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.util.api.IParams;
+import org.adempiere.util.api.Params;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.SpringContextHolder;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+/**
+ * The consuming half of the write-path split: whatever {@code MD_Candidate_Reconcile_ATP} enqueued must be
+ * reconciled here, in the app server, through {@link AtpReconciliationCommand}.
+ * <p>
+ * Two behaviours are pinned, and they are the two ends of the same design decision:
+ * <ul>
+ * <li>{@link #enqueuedRun_isReconciledThroughTheReconciliationCommand()} - the work package's parameters are read
+ * back into the run the operator launched, every matching key goes through the command, and the command sees the
+ * <b>enqueued</b> run date rather than "whenever the queue got around to it".</li>
+ * <li>{@link #appServerWithoutTheMaterialDispoProfile_failsWithAnActionableMessage()} - the guard belongs here
+ * because this is where the scenario is real: a deployment whose <i>app server</i> does not list the
+ * material-disposition profile in {@code de.metas.spring.profiles.active}. Without it, that deployment fails the
+ * work package with Spring's bare {@code NoSuchBeanDefinitionException} naming only the type, buried in the queue
+ * where no operator is watching a process window.</li>
+ * </ul>
+ * {@link IWorkpackageProcessor#setParameters(IParams)} is public API, so the processor can be driven directly
+ * with a hand-built {@link Params} - no queue, no database.
+ */
+class AtpReconciliationWorkpackageProcessorTest
+{
+	private static final ClientId CLIENT_ID = ClientId.ofRepoId(1000000);
+	private static final OrgId ORG_ID = OrgId.ofRepoId(1000001);
+	private static final WarehouseId WAREHOUSE_ID = WarehouseId.ofRepoId(1000002);
+	private static final ProductId PRODUCT_ID = ProductId.ofRepoId(1000003);
+
+	private static final Instant RUN_DATE = Instant.parse("2024-09-25T06:00:00Z");
+	private static final Instant LIVENESS_CUTOFF = Instant.parse("2024-09-23T00:00:00Z");
+
+	private StockRepository stockRepository;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		Env.setLoggedUserId(Env.getCtx(), UserId.METASFRESH);
+
+		stockRepository = Mockito.mock(StockRepository.class);
+		SpringContextHolder.registerJUnitBean(StockRepository.class, stockRepository);
+	}
+
+	@Test
+	void enqueuedRun_isReconciledThroughTheReconciliationCommand()
+	{
+		final List<StockDataRecordIdentifier> keys = distinctKeys(2);
+		when(stockRepository.retrieveKeys(any(), any(), any(), anyInt(), anyInt()))
+				.thenAnswer(invocation -> (int)invocation.getArgument(4) == 0 ? ImmutableList.copyOf(keys) : ImmutableList.of());
+
+		// both keys come back with a non-zero divergence, so both must be reconciled and counted
+		final RecordingReconciliationCommand reconciliationCommand = new RecordingReconciliationCommand(
+				AtpReconciliationRunLog.empty(AtpDivergence.of(new BigDecimal("100"), BigDecimal.ZERO)));
+		SpringContextHolder.registerJUnitBean(AtpReconciliationCommand.class, reconciliationCommand);
+
+		final AtpReconciliationWorkpackageProcessor processor = new AtpReconciliationWorkpackageProcessor();
+		processor.setParameters(enqueuedParams());
+
+		final IWorkpackageProcessor.Result result = processor.processWorkPackage(newWorkPackage(), null);
+
+		assertThat(result).isEqualTo(IWorkpackageProcessor.Result.SUCCESS);
+
+		assertThat(reconciliationCommand.getKeysSeen())
+				.as("every key of the enqueued selection must be reconciled, exactly once")
+				.containsExactlyElementsOf(keys);
+
+		assertThat(reconciliationCommand.getDatesSeen())
+				.as("the run date has to be the one carried on the work package, not the time the queue drained it")
+				.containsOnly(RUN_DATE);
+		assertThat(reconciliationCommand.getLivenessCutoffsSeen())
+				.as("the operator's liveness cutoff must survive the trip through the queue")
+				.containsOnly(LIVENESS_CUTOFF);
+		assertThat(reconciliationCommand.getDryRunFlagsSeen())
+				.as("a dry run is previewed synchronously and is never enqueued, so this path never dry-runs")
+				.containsOnly(false);
+
+		// the selection filters must have been rebuilt from the work package's parameters and pushed into the
+		// repository query - a filter lost here would reconcile far more than the operator asked for
+		Mockito.verify(stockRepository).retrieveKeys(WAREHOUSE_ID, PRODUCT_ID, null, 500, 0);
+	}
+
+	/**
+	 * Reproducing the missing-bean branch needs a real, non-null {@code ApplicationContext} that genuinely lacks
+	 * {@link AtpReconciliationCommand}: {@code SpringContextHolder.getBean} only throws Spring's
+	 * {@code NoSuchBeanDefinitionException} - the exact exception the guard catches - when a context is registered
+	 * and does not have the bean; with no context at all it throws a plain {@code AdempiereException} that would
+	 * never reach the guard. So a profile-less context scanning the reconcile package stands in for such an app
+	 * server, exactly as {@code de.metas.material.dispo.AtpReconcileContextStartupTest} does for the webapi.
+	 */
+	@Test
+	void appServerWithoutTheMaterialDispoProfile_failsWithAnActionableMessage()
+	{
+		when(stockRepository.retrieveKeys(any(), any(), any(), anyInt(), anyInt()))
+				.thenReturn(ImmutableList.of());
+
+		try (final AnnotationConfigApplicationContext profileLessContext = newProfileLessReconcilePackageContext())
+		{
+			SpringContextHolder.instance.setApplicationContext(profileLessContext);
+			try
+			{
+				final AtpReconciliationWorkpackageProcessor processor = new AtpReconciliationWorkpackageProcessor();
+				processor.setParameters(enqueuedParams());
+
+				final I_C_Queue_WorkPackage workPackage = newWorkPackage();
+
+				assertThatThrownBy(() -> processor.processWorkPackage(workPackage, null))
+						.as("the operator must be told which profile is missing and where to switch it on - not"
+								+ " left with a bare NoSuchBeanDefinitionException in the queue")
+						.isInstanceOf(AdempiereException.class)
+						.hasMessageContaining(Profiles.PROFILE_MaterialDispo)
+						.hasMessageContaining("de.metas.spring.profiles.active")
+						.hasMessageContaining("app server");
+			}
+			finally
+			{
+				SpringContextHolder.instance.clearApplicationContext();
+			}
+		}
+	}
+
+	/**
+	 * @return a real, profile-less context scanning {@code de.metas.material.dispo.reconcile}. The collaborator
+	 * mocks are registered as plain (unannotated) singletons rather than through a {@code @Configuration} class of
+	 * this test's own: this test class sits <i>under</i> the scanned package, so an annotated config here would be
+	 * picked up by the recursive scan itself and could hand the context the very bean whose absence is the point -
+	 * the trap {@code AtpReconcileContextStartupTest}'s Javadoc records falling into once already.
+	 */
+	private AnnotationConfigApplicationContext newProfileLessReconcilePackageContext()
+	{
+		final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		context.getBeanFactory().registerSingleton("stockRepository", stockRepository);
+		context.getBeanFactory().registerSingleton("candidateRepositoryRetrieval", Mockito.mock(CandidateRepositoryRetrieval.class));
+		context.scan("de.metas.material.dispo.reconcile");
+		context.refresh();
+		return context;
+	}
+
+	/**
+	 * @return exactly the parameters {@link AtpReconciliationEnqueueService#enqueue} writes - built here by hand
+	 * from the same names, so this test also pins that wire format from the consuming side. The <i>value types</i>
+	 * are the ones a real {@code C_Queue_WorkPackage_Param} row hands back rather than the ones the producer put
+	 * in: {@code WorkpackageParamDAO} stores a date/time parameter in {@code P_Date} and an integer one in
+	 * {@code P_Number}, so the consumer sees a {@link Timestamp} and a {@link BigDecimal}. Reading back through
+	 * that conversion is part of what has to work.
+	 * <p>
+	 * The product-category filter is deliberately absent, matching an operator who left it empty: the enqueue
+	 * side omits an unset filter entirely, so "not restricted" must be read off the parameter's absence.
+	 */
+	private static IParams enqueuedParams()
+	{
+		final Map<String, Object> values = new LinkedHashMap<>();
+		values.put("RunDate", Timestamp.from(RUN_DATE));
+		values.put("LivenessCutoffDate", Timestamp.from(LIVENESS_CUTOFF));
+		values.put(I_MD_Stock.COLUMNNAME_M_Warehouse_ID, BigDecimal.valueOf(WAREHOUSE_ID.getRepoId()));
+		values.put(I_MD_Stock.COLUMNNAME_M_Product_ID, BigDecimal.valueOf(PRODUCT_ID.getRepoId()));
+		return Params.ofMap(values);
+	}
+
+	private static I_C_Queue_WorkPackage newWorkPackage()
+	{
+		final I_C_Queue_WorkPackage workPackage = InterfaceWrapperHelper.newInstance(I_C_Queue_WorkPackage.class);
+		InterfaceWrapperHelper.save(workPackage);
+		return workPackage;
+	}
+
+	private static List<StockDataRecordIdentifier> distinctKeys(final int count)
+	{
+		final List<StockDataRecordIdentifier> keys = new ArrayList<>(count);
+		for (int i = 0; i < count; i++)
+		{
+			keys.add(StockDataRecordIdentifier.builder()
+					.clientId(CLIENT_ID)
+					.orgId(ORG_ID)
+					.warehouseId(WAREHOUSE_ID)
+					.productId(ProductId.ofRepoId(2_000_000 + i))
+					.storageAttributesKey(AttributesKey.NONE)
+					.build());
+		}
+		return keys;
+	}
+
+	/**
+	 * A plain (non-Mockito) test double for {@link AtpReconciliationCommand} that records every argument it was
+	 * called with - the house device in this feature's tests (see {@code MD_Candidate_Reconcile_ATPTest} and
+	 * {@code MD_Candidate_ATP_Divergence_ReportTest}), chosen there because a Mockito mock retains every
+	 * invocation. The constructor args are never exercised, since {@link #reconcileAndLog} is fully overridden.
+	 */
+	private static final class RecordingReconciliationCommand extends AtpReconciliationCommand
+	{
+		private final AtpReconciliationRunLog resultToReturn;
+		private final List<StockDataRecordIdentifier> keysSeen = new ArrayList<>();
+		private final List<Instant> datesSeen = new ArrayList<>();
+		private final List<Instant> livenessCutoffsSeen = new ArrayList<>();
+		private final List<Boolean> dryRunFlagsSeen = new ArrayList<>();
+
+		RecordingReconciliationCommand(@NonNull final AtpReconciliationRunLog resultToReturn)
+		{
+			super(
+					AtpTargetCalculator.newInstanceForUnitTesting(),
+					Mockito.mock(CandidateChangeService.class),
+					Mockito.mock(CandidateRepositoryRetrieval.class));
+			this.resultToReturn = resultToReturn;
+		}
+
+		@Override
+		public AtpReconciliationRunLog reconcileAndLog(
+				@NonNull final StockDataRecordIdentifier key,
+				@NonNull final Instant date,
+				final boolean dryRun,
+				@Nullable final Instant livenessCutoff)
+		{
+			keysSeen.add(key);
+			datesSeen.add(date);
+			livenessCutoffsSeen.add(livenessCutoff);
+			dryRunFlagsSeen.add(dryRun);
+			return resultToReturn;
+		}
+
+		List<StockDataRecordIdentifier> getKeysSeen() {return keysSeen;}
+
+		List<Instant> getDatesSeen() {return datesSeen;}
+
+		List<Instant> getLivenessCutoffsSeen() {return livenessCutoffsSeen;}
+
+		List<Boolean> getDryRunFlagsSeen() {return dryRunFlagsSeen;}
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/process/MD_Candidate_ATP_Divergence_ReportTest.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/process/MD_Candidate_ATP_Divergence_ReportTest.java
@@ -1,0 +1,270 @@
+package de.metas.material.dispo.reconcile.process;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableList;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.cockpit.stock.StockRepository;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
+import de.metas.material.dispo.reconcile.AtpDivergence;
+import de.metas.material.dispo.reconcile.AtpTargetCalculator;
+import de.metas.material.dispo.reconcile.SourceDocumentLivenessService;
+import de.metas.material.dispo.reconcile.SourceDocumentRepository;
+import de.metas.material.dispo.reconcile.UncoveredSourceDocumentService;
+import de.metas.material.event.commons.AttributesKey;
+import de.metas.organization.OrgId;
+import de.metas.process.JavaProcess;
+import de.metas.process.ProcessInfo;
+import de.metas.product.ProductId;
+import de.metas.user.UserId;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.SpringContextHolder;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Exercises the batched-drain loops in {@link MD_Candidate_ATP_Divergence_Report#doIt()} directly, the same seam
+ * the sibling {@link MD_Candidate_Reconcile_ATPTest} exercises: {@code doIt()} is {@code protected}, callable
+ * directly from a test in this package, with every collaborator swapped for a test double registered via
+ * {@link SpringContextHolder#registerJUnitBean(Class, Object)} - no real DB or Spring context needed.
+ * <p>
+ * {@link #keySelectionThatNeverShrinksBelowAFullBatch_abortsAfterMaxLoops()} drives {@code computeDivergence}
+ * through {@code MAX_LOOPS * BATCH_SIZE} = 5,000,000 calls, so - exactly as documented on the sibling
+ * {@link MD_Candidate_Reconcile_ATPTest} - {@link AtpTargetCalculator} is faked with a plain subclass
+ * ({@link FakeAtpTargetCalculator}) there instead of a Mockito mock: a mock keeps every invocation in memory for
+ * potential verification, which reliably blows the test JVM's heap ("GC overhead limit exceeded", reproduced
+ * while writing this test). The other two tests stay well under any volume where that matters, so they use an
+ * ordinary Mockito mock.
+ * <p>
+ * Before this test existed, the {@code BATCH_SIZE}/{@code MAX_LOOPS} pagination logic of this brand-new process
+ * was exercised by nothing at any layer.
+ */
+class MD_Candidate_ATP_Divergence_ReportTest
+{
+	private static final ClientId CLIENT_ID = ClientId.ofRepoId(1000000);
+	private static final OrgId ORG_ID = OrgId.ofRepoId(1000001);
+	private static final WarehouseId WAREHOUSE_ID = WarehouseId.ofRepoId(1000002);
+
+	/** {@code MD_Candidate_ATP_Divergence_Report.BATCH_SIZE} - kept in lock-step with that private constant. */
+	private static final int BATCH_SIZE = 500;
+
+	/** {@code MD_Candidate_ATP_Divergence_Report.MAX_LOOPS} - kept in lock-step with that private constant. */
+	private static final int MAX_LOOPS = 10_000;
+
+	private StockRepository stockRepository;
+	private UncoveredSourceDocumentService uncoveredSourceDocumentService;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		Env.setLoggedUserId(Env.getCtx(), UserId.METASFRESH);
+
+		stockRepository = Mockito.mock(StockRepository.class);
+		SpringContextHolder.registerJUnitBean(StockRepository.class, stockRepository);
+
+		uncoveredSourceDocumentService = Mockito.mock(UncoveredSourceDocumentService.class);
+		SpringContextHolder.registerJUnitBean(UncoveredSourceDocumentService.class, uncoveredSourceDocumentService);
+
+		// the two uncovered-document selections are irrelevant to the key-pagination tests below; default them
+		// to empty so those tests only exercise the retrieveKeys/computeDivergence pagination
+		when(uncoveredSourceDocumentService.retrieveOpenShipmentScheduleIdsWithoutCandidate(any(), any(), any(), anyInt(), anyInt()))
+				.thenReturn(ImmutableList.of());
+		when(uncoveredSourceDocumentService.retrieveOpenReceiptScheduleIdsWithoutCandidate(any(), any(), any(), anyInt(), anyInt()))
+				.thenReturn(ImmutableList.of());
+	}
+
+	@Test
+	void keySelectionLargerThanOneBatch_computesDivergenceForEveryKeyExactlyOnce() throws Exception
+	{
+		// 750 = one full batch (BATCH_SIZE) plus a partial second page, so pagination MUST advance for the second
+		// page's 250 keys to be seen at all
+		final List<StockDataRecordIdentifier> allKeys = distinctKeys(BATCH_SIZE + 250);
+
+		when(stockRepository.retrieveKeys(any(), any(), any(), anyInt(), anyInt()))
+				.thenAnswer(invocation -> {
+					final int limit = invocation.getArgument(3);
+					final int offset = invocation.getArgument(4);
+					final int from = Math.min(offset, allKeys.size());
+					final int to = Math.min(offset + limit, allKeys.size());
+					return ImmutableList.copyOf(allKeys.subList(from, to));
+				});
+
+		// 750 calls - safe as an ordinary Mockito mock (see the class Javadoc for why the MAX_LOOPS test below
+		// cannot use one)
+		final AtpTargetCalculator atpTargetCalculator = Mockito.mock(AtpTargetCalculator.class);
+		SpringContextHolder.registerJUnitBean(AtpTargetCalculator.class, atpTargetCalculator);
+		when(atpTargetCalculator.computeDivergence(any(), any()))
+				.thenReturn(AtpDivergence.of(BigDecimal.ZERO, BigDecimal.ZERO));
+
+		final MD_Candidate_ATP_Divergence_Report process = newProcess();
+
+		final String result = process.doIt();
+
+		assertThat(result).isEqualTo(JavaProcess.MSG_OK);
+
+		// retrieveKeys must have been called for offset 0 (full batch) and offset BATCH_SIZE (the trailing partial
+		// batch, which is what actually stops the loop) - no more, no fewer
+		final ArgumentCaptor<Integer> offsetCaptor = ArgumentCaptor.forClass(Integer.class);
+		verify(stockRepository, times(2)).retrieveKeys(any(), any(), any(), anyInt(), offsetCaptor.capture());
+		assertThat(offsetCaptor.getAllValues()).containsExactly(0, BATCH_SIZE);
+
+		// every key handed out by the fake repository must have reached computeDivergence exactly once: nothing
+		// silently truncated
+		verify(atpTargetCalculator, times(allKeys.size())).computeDivergence(any(), any());
+	}
+
+	@Test
+	void keySelectionThatNeverShrinksBelowAFullBatch_abortsAfterMaxLoops() throws Exception
+	{
+		// a pagination bug that never advances (e.g. a stuck OFFSET): every page comes back full, so the drain loop
+		// never sees the batch.size() < BATCH_SIZE signal that would end it normally
+		final List<StockDataRecordIdentifier> fullBatch = distinctKeys(BATCH_SIZE);
+		when(stockRepository.retrieveKeys(any(), any(), any(), anyInt(), anyInt()))
+				.thenReturn(ImmutableList.copyOf(fullBatch));
+
+		// no key recording here: 10,000 rounds * 500 keys/round = 5,000,000 calls, and a Mockito mock would keep
+		// every one of those invocations in memory for potential verification - see the class Javadoc
+		final FakeAtpTargetCalculator atpTargetCalculator = new FakeAtpTargetCalculator();
+		SpringContextHolder.registerJUnitBean(AtpTargetCalculator.class, atpTargetCalculator);
+
+		final MD_Candidate_ATP_Divergence_Report process = newProcess();
+
+		assertThatThrownBy(process::doIt)
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("aborted after " + MAX_LOOPS)
+				.hasMessageContaining("never shrank below a full batch");
+
+		// exactly MAX_LOOPS rounds must have been drawn before the backstop fires - not one more, not one fewer
+		verify(stockRepository, times(MAX_LOOPS)).retrieveKeys(any(), any(), any(), anyInt(), anyInt());
+		assertThat(atpTargetCalculator.getCallCount()).isEqualTo(((long) MAX_LOOPS) * BATCH_SIZE);
+	}
+
+	@Test
+	void uncoveredDocumentSelectionLargerThanOneBatch_reportsEveryIdExactlyOnce() throws Exception
+	{
+		when(stockRepository.retrieveKeys(any(), any(), any(), anyInt(), anyInt()))
+				.thenReturn(ImmutableList.of());
+
+		final List<Integer> allShipmentScheduleIds = new ArrayList<>();
+		for (int i = 0; i < BATCH_SIZE + 250; i++)
+		{
+			allShipmentScheduleIds.add(2_000_000 + i);
+		}
+		when(uncoveredSourceDocumentService.retrieveOpenShipmentScheduleIdsWithoutCandidate(any(), any(), any(), anyInt(), anyInt()))
+				.thenAnswer(invocation -> {
+					final int limit = invocation.getArgument(3);
+					final int offset = invocation.getArgument(4);
+					final int from = Math.min(offset, allShipmentScheduleIds.size());
+					final int to = Math.min(offset + limit, allShipmentScheduleIds.size());
+					return ImmutableList.copyOf(allShipmentScheduleIds.subList(from, to));
+				});
+
+		final MD_Candidate_ATP_Divergence_Report process = newProcess();
+
+		final String result = process.doIt();
+
+		assertThat(result).isEqualTo(JavaProcess.MSG_OK);
+
+		final ArgumentCaptor<Integer> offsetCaptor = ArgumentCaptor.forClass(Integer.class);
+		verify(uncoveredSourceDocumentService, times(2))
+				.retrieveOpenShipmentScheduleIdsWithoutCandidate(any(), any(), any(), anyInt(), offsetCaptor.capture());
+		assertThat(offsetCaptor.getAllValues()).containsExactly(0, BATCH_SIZE);
+	}
+
+	private static MD_Candidate_ATP_Divergence_Report newProcess() throws Exception
+	{
+		final MD_Candidate_ATP_Divergence_Report process = new MD_Candidate_ATP_Divergence_Report();
+		process.init(ProcessInfo.builder().setCtx(Env.getCtx()).build());
+		return process;
+	}
+
+	private static List<StockDataRecordIdentifier> distinctKeys(final int count)
+	{
+		final List<StockDataRecordIdentifier> keys = new ArrayList<>(count);
+		for (int i = 0; i < count; i++)
+		{
+			keys.add(StockDataRecordIdentifier.builder()
+					.clientId(CLIENT_ID)
+					.orgId(ORG_ID)
+					.warehouseId(WAREHOUSE_ID)
+					.productId(ProductId.ofRepoId(2_000_000 + i))
+					.storageAttributesKey(AttributesKey.NONE)
+					.build());
+		}
+		return keys;
+	}
+
+	/**
+	 * A plain (non-Mockito) test double for {@link AtpTargetCalculator} - see the class Javadoc for why a Mockito
+	 * mock is unsuitable at the call volume {@link #keySelectionThatNeverShrinksBelowAFullBatch_abortsAfterMaxLoops()}
+	 * drives it through. The constructor args are never exercised, since {@link #computeDivergence} is fully
+	 * overridden below.
+	 */
+	private static final class FakeAtpTargetCalculator extends AtpTargetCalculator
+	{
+		private long callCount;
+
+		FakeAtpTargetCalculator()
+		{
+			super(
+					Mockito.mock(StockRepository.class),
+					Mockito.mock(CandidateRepositoryRetrieval.class),
+					new SourceDocumentLivenessService(Mockito.mock(SourceDocumentRepository.class)));
+		}
+
+		@Override
+		public AtpDivergence computeDivergence(
+				@NonNull final StockDataRecordIdentifier key,
+				@NonNull final Instant date)
+		{
+			callCount++;
+			return AtpDivergence.of(BigDecimal.ZERO, BigDecimal.ZERO);
+		}
+
+		long getCallCount()
+		{
+			return callCount;
+		}
+	}
+}

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/process/MD_Candidate_Reconcile_ATPTest.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/material/dispo/reconcile/process/MD_Candidate_Reconcile_ATPTest.java
@@ -1,0 +1,372 @@
+package de.metas.material.dispo.reconcile.process;
+
+/*
+ * #%L
+ * de.metas.fresh.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableList;
+import de.metas.Profiles;
+import de.metas.async.api.IWorkPackageBuilder;
+import de.metas.async.api.IWorkPackageQueue;
+import de.metas.async.model.I_C_Queue_WorkPackage;
+import de.metas.async.processor.IWorkPackageQueueFactory;
+import de.metas.async.spi.IWorkpackageProcessor;
+import de.metas.common.util.time.SystemTime;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.cockpit.stock.StockRepository;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
+import de.metas.material.dispo.reconcile.AtpDivergence;
+import de.metas.material.dispo.reconcile.AtpReconciliationCommand;
+import de.metas.material.dispo.reconcile.AtpTargetCalculator;
+import de.metas.material.dispo.reconcile.SourceDocumentLivenessService;
+import de.metas.material.dispo.reconcile.SourceDocumentRepository;
+import de.metas.material.event.commons.AttributesKey;
+import de.metas.organization.OrgId;
+import de.metas.process.JavaProcess;
+import de.metas.process.ProcessInfo;
+import de.metas.product.ProductCategoryId;
+import de.metas.product.ProductId;
+import de.metas.user.UserId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.SpringContextHolder;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the fork in {@link MD_Candidate_Reconcile_ATP#doIt()}: a dry run previews inline, a real run is enqueued -
+ * and neither path may ever need {@link AtpReconciliationCommand} in the JVM this process actually executes in.
+ * <p>
+ * {@code doIt()} is {@code protected}, which a test in the same package may call directly; the collaborators are
+ * supplied through {@link SpringContextHolder#registerJUnitBean(Class, Object)} and {@link Services}, so no real
+ * DB is needed. This mirrors the {@code JavaProcess} unit-test pattern already used in this codebase (see
+ * {@code de.metas.bpartner.process.CBPartnerUpdateMemoTest}: {@code process.init(ProcessInfo...)} then reflection
+ * onto the {@code @Param} field, then {@code doIt()} called directly).
+ * <p>
+ * <b>What moved out of this class with the split.</b> The batched key drain now lives in
+ * {@code AtpKeySelectionDrainer}, so its pagination and {@code MAX_LOOPS} coverage moved verbatim to
+ * {@code AtpKeySelectionDrainerTest}; and the "no material disposition engine" fail-fast moved to
+ * {@code AtpReconciliationWorkpackageProcessorTest}, because after the split that failure can only happen where
+ * the work package is drained - this process needs the bean on neither path.
+ */
+class MD_Candidate_Reconcile_ATPTest
+{
+	private static final ClientId CLIENT_ID = ClientId.ofRepoId(1000000);
+	private static final OrgId ORG_ID = OrgId.ofRepoId(1000001);
+	private static final WarehouseId WAREHOUSE_ID = WarehouseId.ofRepoId(1000002);
+	private static final ProductId PRODUCT_ID = ProductId.ofRepoId(1000003);
+	private static final ProductCategoryId PRODUCT_CATEGORY_ID = ProductCategoryId.ofRepoId(1000004);
+
+	/**
+	 * The frozen clock of the tests below, so the {@code RunDate} the process derives from {@link SystemTime} is
+	 * a value the test can name. Europe/Berlin, i.e. UTC+2 on that date.
+	 */
+	private static final ZonedDateTime RUN_TIME = ZonedDateTime.parse("2024-09-25T08:00:00+02:00[Europe/Berlin]");
+
+	private StockRepository stockRepository;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		Env.setLoggedUserId(Env.getCtx(), UserId.METASFRESH);
+
+		stockRepository = Mockito.mock(StockRepository.class);
+		SpringContextHolder.registerJUnitBean(StockRepository.class, stockRepository);
+	}
+
+	@AfterEach
+	void afterEach()
+	{
+		SystemTime.resetTimeSource();
+	}
+
+	/**
+	 * A <b>dry run</b> produces its whole preview in the JVM a WebUI-launched process actually executes in - the
+	 * webapi, which does not activate {@link Profiles#PROFILE_MaterialDispo} - and must therefore never touch
+	 * {@link AtpReconciliationCommand}, which only exists where that profile is active.
+	 * <p>
+	 * It needs nothing from that bean: {@link AtpTargetCalculator#computeDivergence} already returns expected,
+	 * stored and difference, and is deliberately un-{@code @Profile}-guarded, so the preview is computed inline
+	 * here. Resolving the command bean on this path would make the preview unavailable in exactly the JVM the
+	 * operator asks for it in, failing with "the spring profile material-dispo is not active here".
+	 * <p>
+	 * Reproducing the webapi's situation needs a real, scanned, profile-less
+	 * {@link AnnotationConfigApplicationContext} - see
+	 * {@code de.metas.material.dispo.AtpReconcileContextStartupTest}, which proves that same absence for the
+	 * package as a whole, and whose Javadoc records why a {@code @Configuration} class declared under the scanned
+	 * package silently blinds such a test.
+	 */
+	@Test
+	void dryRunInProfileLessJvm_reportsThePreviewWithoutTheReconciliationCommand() throws Exception
+	{
+		SystemTime.setFixedTimeSource(RUN_TIME);
+
+		final List<StockDataRecordIdentifier> keys = distinctKeys(1);
+		when(stockRepository.retrieveKeys(any(), any(), any(), anyInt(), anyInt()))
+				.thenAnswer(invocation -> (int)invocation.getArgument(4) == 0 ? ImmutableList.copyOf(keys) : ImmutableList.of());
+
+		// stored 0 against a target of 100, i.e. a key that diverges. Registered as a JUnit bean so it wins over
+		// the real, scanned calculator (SpringContextHolder#getBeanOrSupply consults the JUnit registry first),
+		// which would otherwise answer out of the mocked repositories with a meaningless 0.
+		final RecordingAtpTargetCalculator atpTargetCalculator =
+				new RecordingAtpTargetCalculator(AtpDivergence.of(new BigDecimal("100"), BigDecimal.ZERO));
+		SpringContextHolder.registerJUnitBean(AtpTargetCalculator.class, atpTargetCalculator);
+
+		// a real queue factory, so that "the dry run enqueued nothing" is asserted rather than merely implied by
+		// the absence of one
+		final IWorkPackageQueueFactory queueFactory = Mockito.mock(IWorkPackageQueueFactory.class);
+		Services.registerService(IWorkPackageQueueFactory.class, queueFactory);
+
+		try (final AnnotationConfigApplicationContext profileLessContext = newProfileLessReconcilePackageContext())
+		{
+			SpringContextHolder.instance.setApplicationContext(profileLessContext);
+			try
+			{
+				assertThat(profileLessContext.getBeanNamesForType(AtpReconciliationCommand.class))
+						.as("precondition: this context must genuinely lack the write-path bean, or it cannot"
+								+ " stand in for the webapi")
+						.isEmpty();
+
+				final ProcessInfo processInfo = ProcessInfo.builder().setCtx(Env.getCtx()).build();
+				final MD_Candidate_Reconcile_ATP process = newProcess(processInfo, true, LocalDate.of(2024, 9, 23));
+
+				// the preview must resolve nothing beyond AtpTargetCalculator: AtpReconciliationCommand does not
+				// exist in this profile-less context, so touching it here would throw
+				assertThat(process.doIt()).isEqualTo(JavaProcess.MSG_OK);
+			}
+			finally
+			{
+				SpringContextHolder.instance.clearApplicationContext();
+			}
+		}
+
+		assertThat(atpTargetCalculator.getKeysSeen())
+				.as("the preview must be computed off the un-@Profile-guarded target calculator, for every key of"
+						+ " the selection")
+				.containsExactlyElementsOf(keys);
+		assertThat(atpTargetCalculator.getDatesSeen())
+				.as("the preview date is the run date the process pinned to now")
+				.containsOnly(RUN_TIME.toInstant());
+		assertThat(atpTargetCalculator.getLivenessCutoffsSeen())
+				.as("the operator's liveness cutoff has to reach the preview too, or the preview would show a"
+						+ " different divergence from the run it previews")
+				.containsOnly(LocalDate.of(2024, 9, 23).atStartOfDay(SystemTime.zoneId()).toInstant());
+
+		verifyNoInteractions(queueFactory);
+	}
+
+	/**
+	 * The other half of the split: a <b>real</b> run does not reconcile in the webapi at all - it hands the run to
+	 * the async queue, which the app server drains, where {@link Profiles#PROFILE_MaterialDispo} <i>is</i> active.
+	 * So the process must enqueue exactly one work package carrying the whole run - every selection filter, the
+	 * liveness cutoff and the run date - and must itself read and write nothing.
+	 * <p>
+	 * The parameter names are asserted as plain string literals on purpose: they are the wire format between the
+	 * two JVMs, so a rename on the producing side that is not matched on the consuming side must fail here rather
+	 * than silently drop a filter and reconcile the whole database.
+	 */
+	@Test
+	void realRun_enqueuesExactlyOneWorkpackageCarryingTheRunsSelectionAndOptions() throws Exception
+	{
+		SystemTime.setFixedTimeSource(RUN_TIME);
+
+		final IWorkPackageQueueFactory queueFactory = Mockito.mock(IWorkPackageQueueFactory.class);
+		final IWorkPackageQueue queue = Mockito.mock(IWorkPackageQueue.class);
+		final IWorkPackageBuilder workPackageBuilder = Mockito.mock(IWorkPackageBuilder.class, Mockito.RETURNS_SELF);
+		final I_C_Queue_WorkPackage enqueuedWorkPackage = InterfaceWrapperHelper.newInstance(I_C_Queue_WorkPackage.class);
+		InterfaceWrapperHelper.save(enqueuedWorkPackage);
+
+		Services.registerService(IWorkPackageQueueFactory.class, queueFactory);
+		when(queueFactory.getQueueForEnqueuing(any(Properties.class), ArgumentMatchers.<Class<? extends IWorkpackageProcessor>>any()))
+				.thenReturn(queue);
+		when(queue.newWorkPackage()).thenReturn(workPackageBuilder);
+		when(workPackageBuilder.buildAndEnqueue()).thenReturn(enqueuedWorkPackage);
+
+		final ProcessInfo processInfo = ProcessInfo.builder().setCtx(Env.getCtx()).build();
+		final MD_Candidate_Reconcile_ATP process = newProcess(processInfo, false, LocalDate.of(2024, 9, 23));
+		setParamField(process, "p_M_Warehouse_ID", WAREHOUSE_ID.getRepoId());
+		setParamField(process, "p_M_Product_ID", PRODUCT_ID.getRepoId());
+		setParamField(process, "p_M_Product_Category_ID", PRODUCT_CATEGORY_ID.getRepoId());
+
+		assertThat(process.doIt()).isEqualTo(JavaProcess.MSG_OK);
+
+		verify(queue, times(1)).newWorkPackage();
+		verify(workPackageBuilder, times(1)).buildAndEnqueue();
+
+		verify(workPackageBuilder).parameter("M_Warehouse_ID", WAREHOUSE_ID.getRepoId());
+		verify(workPackageBuilder).parameter("M_Product_ID", PRODUCT_ID.getRepoId());
+		verify(workPackageBuilder).parameter("M_Product_Category_ID", PRODUCT_CATEGORY_ID.getRepoId());
+		verify(workPackageBuilder).parameter("LivenessCutoffDate", LocalDate.of(2024, 9, 23).atStartOfDay(SystemTime.zoneId()).toInstant());
+		verify(workPackageBuilder).parameter("RunDate", RUN_TIME.toInstant());
+
+		// the enqueuing JVM must not have touched the selection at all: draining it is the work package's job,
+		// in the JVM that can actually reconcile
+		verifyNoInteractions(stockRepository);
+	}
+
+	/**
+	 * @return a real, profile-less context scanning {@code de.metas.material.dispo.reconcile}. The collaborator
+	 * mocks are registered as plain (unannotated) singletons rather than through a {@code @Configuration} class of
+	 * this test's own: this test class sits in {@code de.metas.material.dispo.reconcile.process} - itself under
+	 * the scanned package, because {@code doIt()} is only callable from the same package - so a
+	 * {@code @Configuration}/{@code @Component} class declared here would be picked up by the recursive
+	 * {@link org.springframework.context.annotation.ComponentScan} and could supply the very bean whose absence
+	 * is the point.
+	 */
+	private AnnotationConfigApplicationContext newProfileLessReconcilePackageContext()
+	{
+		final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		// the very mock this test stubs: whatever bean of the scanned package the context builds must page
+		// through THIS test's selection, not an unstubbed second mock that always answers "no keys"
+		context.getBeanFactory().registerSingleton("stockRepository", stockRepository);
+		context.getBeanFactory().registerSingleton("candidateRepositoryRetrieval", Mockito.mock(CandidateRepositoryRetrieval.class));
+		context.scan("de.metas.material.dispo.reconcile");
+		context.refresh();
+		return context;
+	}
+
+	/**
+	 * @param processInfo kept by the caller so it can read the run's resolved process log afterwards via
+	 * {@link ProcessInfo#getResult()} - {@code JavaProcess.getResult()} itself is {@code protected}, hence
+	 * unreachable from a test outside {@code de.metas.process}
+	 * @param dryRun the value of the process's {@code IsDryRun} parameter
+	 * @param livenessCutoffDate the value of the process's optional {@code LivenessCutoffDate} parameter
+	 */
+	private static MD_Candidate_Reconcile_ATP newProcess(
+			@NonNull final ProcessInfo processInfo,
+			final boolean dryRun,
+			@Nullable final LocalDate livenessCutoffDate) throws Exception
+	{
+		final MD_Candidate_Reconcile_ATP process = new MD_Candidate_Reconcile_ATP();
+		process.init(processInfo);
+
+		setParamField(process, "p_IsDryRun", dryRun);
+		if (livenessCutoffDate != null)
+		{
+			setParamField(process, "p_LivenessCutoffDate", livenessCutoffDate);
+		}
+
+		return process;
+	}
+
+	private static void setParamField(
+			@NonNull final MD_Candidate_Reconcile_ATP process,
+			@NonNull final String fieldName,
+			@NonNull final Object value) throws Exception
+	{
+		final Field field = MD_Candidate_Reconcile_ATP.class.getDeclaredField(fieldName);
+		field.setAccessible(true);
+		field.set(process, value);
+	}
+
+	private static List<StockDataRecordIdentifier> distinctKeys(final int count)
+	{
+		final List<StockDataRecordIdentifier> keys = new ArrayList<>(count);
+		for (int i = 0; i < count; i++)
+		{
+			keys.add(StockDataRecordIdentifier.builder()
+					.clientId(CLIENT_ID)
+					.orgId(ORG_ID)
+					.warehouseId(WAREHOUSE_ID)
+					.productId(ProductId.ofRepoId(2_000_000 + i))
+					.storageAttributesKey(AttributesKey.NONE)
+					.build());
+		}
+		return keys;
+	}
+
+	/**
+	 * A plain (non-Mockito) test double for {@link AtpTargetCalculator} that returns one fixed divergence and
+	 * records what it was asked - the same device {@code MD_Candidate_ATP_Divergence_ReportTest} uses. The
+	 * constructor args are never exercised, since both {@code computeDivergence} overloads are fully overridden
+	 * below.
+	 */
+	private static final class RecordingAtpTargetCalculator extends AtpTargetCalculator
+	{
+		private final AtpDivergence divergenceToReturn;
+		private final List<StockDataRecordIdentifier> keysSeen = new ArrayList<>();
+		private final List<Instant> datesSeen = new ArrayList<>();
+		private final List<Instant> livenessCutoffsSeen = new ArrayList<>();
+
+		RecordingAtpTargetCalculator(@NonNull final AtpDivergence divergenceToReturn)
+		{
+			super(
+					Mockito.mock(StockRepository.class),
+					Mockito.mock(CandidateRepositoryRetrieval.class),
+					new SourceDocumentLivenessService(Mockito.mock(SourceDocumentRepository.class)));
+			this.divergenceToReturn = divergenceToReturn;
+		}
+
+		@Override
+		public AtpDivergence computeDivergence(
+				@NonNull final StockDataRecordIdentifier key,
+				@NonNull final Instant date)
+		{
+			return computeDivergence(key, date, null);
+		}
+
+		@Override
+		public AtpDivergence computeDivergence(
+				@NonNull final StockDataRecordIdentifier key,
+				@NonNull final Instant date,
+				@Nullable final Instant livenessCutoff)
+		{
+			keysSeen.add(key);
+			datesSeen.add(date);
+			livenessCutoffsSeen.add(livenessCutoff);
+			return divergenceToReturn;
+		}
+
+		List<StockDataRecordIdentifier> getKeysSeen() {return keysSeen;}
+
+		List<Instant> getDatesSeen() {return datesSeen;}
+
+		List<Instant> getLivenessCutoffsSeen() {return livenessCutoffsSeen;}
+	}
+}

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/StockDataUpdateRequestHandler.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/StockDataUpdateRequestHandler.java
@@ -8,9 +8,8 @@ import de.metas.material.event.commons.ProductDescriptor;
 import de.metas.material.event.stock.StockChangedEvent;
 import de.metas.material.event.stock.StockChangedEvent.StockChangeDetails;
 import de.metas.util.NumberUtils;
-import de.metas.util.Services;
 import lombok.NonNull;
-import org.adempiere.ad.dao.IQueryBL;
+import lombok.RequiredArgsConstructor;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.mm.attributes.keys.AttributesKeys;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -47,15 +46,13 @@ import static org.adempiere.model.InterfaceWrapperHelper.save;
  */
 
 @Component
+@RequiredArgsConstructor
 public class StockDataUpdateRequestHandler
 {
+	@NonNull
 	private final PostMaterialEventService postMaterialEventService;
-
-	public StockDataUpdateRequestHandler(
-			@NonNull final PostMaterialEventService postMaterialEventService)
-	{
-		this.postMaterialEventService = postMaterialEventService;
-	}
+	@NonNull
+	private final StockRepository stockRepository;
 
 	public void handleDataUpdateRequest(@NonNull final StockDataUpdateRequest dataUpdateRequest)
 	{
@@ -73,7 +70,9 @@ public class StockDataUpdateRequestHandler
 
 	private I_MD_Stock retrieveOrCreateDataRecord(@NonNull final StockDataRecordIdentifier identifier)
 	{
-		final IQuery<I_MD_Stock> query = createQueryForIdentifier(identifier);
+		// the five-column key query lives in StockRepository, so that this writer and the readers of the same
+		// key (e.g. the ATP reconciliation) cannot end up filtering MD_Stock differently
+		final IQuery<I_MD_Stock> query = stockRepository.createQueryForIdentifier(identifier);
 
 		final I_MD_Stock existingDataRecord = query.firstOnly(I_MD_Stock.class);
 		if (existingDataRecord != null)
@@ -90,22 +89,6 @@ public class StockDataUpdateRequestHandler
 		newDataRecord.setM_Warehouse_ID(identifier.getWarehouseId().getRepoId());
 
 		return newDataRecord;
-	}
-
-	private IQuery<I_MD_Stock> createQueryForIdentifier(@NonNull final StockDataRecordIdentifier identifier)
-	{
-		final AttributesKey attributesKey = identifier.getStorageAttributesKey();
-		attributesKey.assertNotAllOrOther();
-
-		return Services.get(IQueryBL.class)
-				.createQueryBuilder(I_MD_Stock.class)
-				.addOnlyActiveRecordsFilter()
-				.addEqualsFilter(I_MD_Stock.COLUMNNAME_AD_Client_ID, identifier.getClientId())
-				.addEqualsFilter(I_MD_Stock.COLUMNNAME_AD_Org_ID, identifier.getOrgId())
-				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, identifier.getProductId())
-				.addEqualsFilter(I_MD_Stock.COLUMN_AttributesKey, attributesKey.getAsString())
-				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Warehouse_ID, identifier.getWarehouseId())
-				.create();
 	}
 
 	private void fireStockChangedEvent(

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/StockRepository.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/StockRepository.java
@@ -7,6 +7,8 @@ import de.metas.material.cockpit.model.I_T_MD_Stock_WarehouseAndProduct;
 import org.adempiere.mm.attributes.keys.AttributesKeyPatternsUtil;
 import org.adempiere.mm.attributes.keys.AttributesKeyQueryHelper;
 import de.metas.material.event.commons.AttributesKey;
+import de.metas.organization.OrgId;
+import de.metas.product.ProductCategoryId;
 import de.metas.product.ProductId;
 import de.metas.util.Check;
 import de.metas.util.Loggables;
@@ -18,13 +20,16 @@ import org.adempiere.ad.dao.IQueryFilter;
 import org.adempiere.ad.dao.impl.TypedSqlQuery;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.service.ClientId;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.IQuery;
 import org.compiere.model.I_AD_Column;
 import org.compiere.model.I_AD_Table;
+import org.compiere.model.I_M_Product;
 import org.compiere.util.DB;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Set;
@@ -64,7 +69,7 @@ public class StockRepository
 	{
 		Check.assumeNotEmpty(warehouseIds, "warehouseIds is not empty");
 
-		final BigDecimal qtyOnHand = Services.get(IQueryBL.class)
+		final BigDecimal qtyOnHand = queryBL
 				.createQueryBuilder(I_MD_Stock.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, productId)
@@ -72,6 +77,120 @@ public class StockRepository
 				.create()
 				.aggregate(I_MD_Stock.COLUMN_QtyOnHand, IQuery.Aggregate.SUM, BigDecimal.class);
 		return qtyOnHand != null ? qtyOnHand : BigDecimal.ZERO;
+	}
+
+	/**
+	 * Reads the physical on-hand quantity of one exact stock key.
+	 *
+	 * @return the {@code QtyOnHand} of the one {@code MD_Stock} record the given identifier addresses, or
+	 * {@link BigDecimal#ZERO} if there is no such record. A missing record is not an error: a key only
+	 * acquires its {@code MD_Stock} row once something has moved into it.
+	 */
+	public BigDecimal getQtyOnHand(@NonNull final StockDataRecordIdentifier identifier)
+	{
+		final I_MD_Stock record = createQueryForIdentifier(identifier).firstOnly(I_MD_Stock.class);
+		return record != null ? record.getQtyOnHand() : BigDecimal.ZERO;
+	}
+
+	/**
+	 * Builds the exact-key {@code MD_Stock} query, filtering the five columns that are exactly that table's
+	 * unique key.
+	 * <p>
+	 * Deliberately public, and deliberately the ONLY place this key query is built: it is shared with
+	 * {@link StockDataUpdateRequestHandler}, which needs the record itself (to create or update it) rather
+	 * than just its quantity, and with {@link #getQtyOnHand(StockDataRecordIdentifier)}, whose caller is the
+	 * ATP reconciliation in {@code de.metas.material.dispo.reconcile} — a module downstream of this one.
+	 * Copying a five-column key filter into a second reader is how a table acquires two readers that
+	 * silently drift apart: the same failure family as the {@code MD_Candidate_Get_Stock_Impact} (SQL) versus
+	 * {@code Candidate#getStockImpactPlannedQuantity()} (Java) divergence that the ATP reconciliation exists
+	 * to clean up, where two formulas write one column and nothing compares them.
+	 * <p>
+	 * Note that the identifier's constructor already rules out {@code AttributesKey.ALL}/{@code .OTHER}; the
+	 * assertion below is kept from the caller this method was extracted from, as a guard for identifiers
+	 * that might one day be built by other means.
+	 *
+	 * @return a query matching the at most one {@code MD_Stock} record of the given key
+	 */
+	public IQuery<I_MD_Stock> createQueryForIdentifier(@NonNull final StockDataRecordIdentifier identifier)
+	{
+		final AttributesKey attributesKey = identifier.getStorageAttributesKey();
+		attributesKey.assertNotAllOrOther();
+
+		return queryBL
+				.createQueryBuilder(I_MD_Stock.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_MD_Stock.COLUMNNAME_AD_Client_ID, identifier.getClientId())
+				.addEqualsFilter(I_MD_Stock.COLUMNNAME_AD_Org_ID, identifier.getOrgId())
+				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, identifier.getProductId())
+				.addEqualsFilter(I_MD_Stock.COLUMN_AttributesKey, attributesKey.getAsString())
+				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Warehouse_ID, identifier.getWarehouseId())
+				.create();
+	}
+
+	/**
+	 * Selects the {@code MD_Stock} keys matching an optional warehouse/product/product-category filter, one page
+	 * at a time.
+	 * <p>
+	 * Extracted for the ATP reconciliation process ({@code de.metas.material.dispo.reconcile.process.MD_Candidate_Reconcile_ATP}),
+	 * which needs to drain a (possibly large) selection in bounded batches and, per {@code docs/REVIEW.md}, must not
+	 * hold the {@code IQueryBL}/{@code IQueryBuilder} persistence primitives itself.
+	 *
+	 * @param warehouseId       when given, only keys of this warehouse
+	 * @param productId         when given, only keys of this product
+	 * @param productCategoryId when given, only keys of a product in this category
+	 * @param limit             page size
+	 * @param offset            zero-based row offset of this page
+	 * @return at most {@code limit} keys, ordered by {@code MD_Stock_ID} so repeated calls with increasing
+	 * {@code offset} page through the same static selection without gaps or repeats
+	 */
+	public List<StockDataRecordIdentifier> retrieveKeys(
+			@Nullable final WarehouseId warehouseId,
+			@Nullable final ProductId productId,
+			@Nullable final ProductCategoryId productCategoryId,
+			final int limit,
+			final int offset)
+	{
+		final IQueryBuilder<I_MD_Stock> queryBuilder = queryBL.createQueryBuilder(I_MD_Stock.class)
+				.addOnlyActiveRecordsFilter();
+
+		if (warehouseId != null)
+		{
+			queryBuilder.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Warehouse_ID, warehouseId);
+		}
+		if (productId != null)
+		{
+			queryBuilder.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, productId);
+		}
+		if (productCategoryId != null)
+		{
+			queryBuilder.addInSubQueryFilter(
+					I_MD_Stock.COLUMNNAME_M_Product_ID,
+					I_M_Product.COLUMNNAME_M_Product_ID,
+					queryBL.createQueryBuilder(I_M_Product.class)
+							.addEqualsFilter(I_M_Product.COLUMNNAME_M_Product_Category_ID, productCategoryId)
+							.create());
+		}
+		queryBuilder.orderBy().addColumnAscending(I_MD_Stock.COLUMNNAME_MD_Stock_ID).endOrderBy();
+
+		final List<I_MD_Stock> stockRecords = queryBuilder
+				.create()
+				.setLimit(limit, offset)
+				.list();
+
+		return stockRecords.stream()
+				.map(StockRepository::toStockDataRecordIdentifier)
+				.collect(ImmutableList.toImmutableList());
+	}
+
+	private static StockDataRecordIdentifier toStockDataRecordIdentifier(@NonNull final I_MD_Stock stockRecord)
+	{
+		return StockDataRecordIdentifier.builder()
+				.clientId(ClientId.ofRepoId(stockRecord.getAD_Client_ID()))
+				.orgId(OrgId.ofRepoId(stockRecord.getAD_Org_ID()))
+				.warehouseId(WarehouseId.ofRepoId(stockRecord.getM_Warehouse_ID()))
+				.productId(ProductId.ofRepoId(stockRecord.getM_Product_ID()))
+				.storageAttributesKey(AttributesKey.ofString(stockRecord.getAttributesKey()))
+				.build();
 	}
 
 	/** Please use this stream within a try-with-resources statement, because it's supposed to do cleanup. */
@@ -173,7 +292,6 @@ public class StockRepository
 
 	private IQuery<I_MD_Stock_WarehouseAndProduct_v> createStockDataAggregateItemQuery(@NonNull final StockDataAggregateQuery query)
 	{
-		final IQueryBL queryBL = Services.get(IQueryBL.class);
 		final IQueryBuilder<I_MD_Stock_WarehouseAndProduct_v> queryBuilder = queryBL.createQueryBuilder(I_MD_Stock_WarehouseAndProduct_v.class);
 		if (!query.getProductCategoryIds().isEmpty())
 		{

--- a/backend/de.metas.material/dispo-commons/src/main/java-gen/de/metas/material/dispo/model/I_MD_ATP_Reconciliation_Backup.java
+++ b/backend/de.metas.material/dispo-commons/src/main/java-gen/de/metas/material/dispo/model/I_MD_ATP_Reconciliation_Backup.java
@@ -1,0 +1,344 @@
+package de.metas.material.dispo.model;
+
+import java.math.BigDecimal;
+import javax.annotation.Nullable;
+import org.adempiere.model.ModelColumn;
+
+/** Generated Interface for MD_ATP_Reconciliation_Backup
+ *  @author metasfresh (generated) 
+ */
+@SuppressWarnings("unused")
+public interface I_MD_ATP_Reconciliation_Backup 
+{
+
+	String Table_Name = "MD_ATP_Reconciliation_Backup";
+
+//	/** AD_Table_ID=542645 */
+//	int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
+
+
+	/**
+	 * Get Client.
+	 * Client/Tenant for this installation.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Client_ID();
+
+	String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+
+	/**
+	 * Set Organisation.
+	 * Organisational entity within client
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setAD_Org_ID (int AD_Org_ID);
+
+	/**
+	 * Get Organisation.
+	 * Organisational entity within client
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Org_ID();
+
+	String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/**
+	 * Get Created.
+	 * Date this record was created
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.sql.Timestamp getCreated();
+
+	ModelColumn<I_MD_ATP_Reconciliation_Backup, Object> COLUMN_Created = new ModelColumn<>(I_MD_ATP_Reconciliation_Backup.class, "Created", null);
+	String COLUMNNAME_Created = "Created";
+
+	/**
+	 * Get Created By.
+	 * User who created this records
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getCreatedBy();
+
+	String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/**
+	 * Set Date.
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setDateProjected (java.sql.Timestamp DateProjected);
+
+	/**
+	 * Get Date.
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.sql.Timestamp getDateProjected();
+
+	ModelColumn<I_MD_ATP_Reconciliation_Backup, Object> COLUMN_DateProjected = new ModelColumn<>(I_MD_ATP_Reconciliation_Backup.class, "DateProjected", null);
+	String COLUMNNAME_DateProjected = "DateProjected";
+
+	/**
+	 * Set Active.
+	 * The record is active in the system
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsActive (boolean IsActive);
+
+	/**
+	 * Get Active.
+	 * The record is active in the system
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isActive();
+
+	ModelColumn<I_MD_ATP_Reconciliation_Backup, Object> COLUMN_IsActive = new ModelColumn<>(I_MD_ATP_Reconciliation_Backup.class, "IsActive", null);
+	String COLUMNNAME_IsActive = "IsActive";
+
+	/**
+	 * Set This candidate's own ATP reconciliation detail.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsCandidateOwnDetail (boolean IsCandidateOwnDetail);
+
+	/**
+	 * Get This candidate's own ATP reconciliation detail.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isCandidateOwnDetail();
+
+	ModelColumn<I_MD_ATP_Reconciliation_Backup, Object> COLUMN_IsCandidateOwnDetail = new ModelColumn<>(I_MD_ATP_Reconciliation_Backup.class, "IsCandidateOwnDetail", null);
+	String COLUMNNAME_IsCandidateOwnDetail = "IsCandidateOwnDetail";
+
+	/**
+	 * Set MD_ATP_Reconciliation_Backup.
+	 *
+	 * <br>Type: ID
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setMD_ATP_Reconciliation_Backup_ID (int MD_ATP_Reconciliation_Backup_ID);
+
+	/**
+	 * Get MD_ATP_Reconciliation_Backup.
+	 *
+	 * <br>Type: ID
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getMD_ATP_Reconciliation_Backup_ID();
+
+	ModelColumn<I_MD_ATP_Reconciliation_Backup, Object> COLUMN_MD_ATP_Reconciliation_Backup_ID = new ModelColumn<>(I_MD_ATP_Reconciliation_Backup.class, "MD_ATP_Reconciliation_Backup_ID", null);
+	String COLUMNNAME_MD_ATP_Reconciliation_Backup_ID = "MD_ATP_Reconciliation_Backup_ID";
+
+	/**
+	 * Set Dispo Candidate.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setMD_Candidate_ID (int MD_Candidate_ID);
+
+	/**
+	 * Get Dispo Candidate.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getMD_Candidate_ID();
+
+	ModelColumn<I_MD_ATP_Reconciliation_Backup, de.metas.material.dispo.model.I_MD_Candidate> COLUMN_MD_Candidate_ID = new ModelColumn<>(I_MD_ATP_Reconciliation_Backup.class, "MD_Candidate_ID", de.metas.material.dispo.model.I_MD_Candidate.class);
+	String COLUMNNAME_MD_Candidate_ID = "MD_Candidate_ID";
+
+	/**
+	 * Set Product.
+	 * Product, Service, Item
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setM_Product_ID (int M_Product_ID);
+
+	/**
+	 * Get Product.
+	 * Product, Service, Item
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getM_Product_ID();
+
+	String COLUMNNAME_M_Product_ID = "M_Product_ID";
+
+	/**
+	 * Set Warehouse.
+	 * Storage Warehouse and Service Point
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setM_Warehouse_ID (int M_Warehouse_ID);
+
+	/**
+	 * Get Warehouse.
+	 * Storage Warehouse and Service Point
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getM_Warehouse_ID();
+
+	String COLUMNNAME_M_Warehouse_ID = "M_Warehouse_ID";
+
+	/**
+	 * Set Qty after change.
+	 * The candidate quantity after the ATP reconciliation changed it.
+	 *
+	 * <br>Type: Quantity
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setQtyAfter (BigDecimal QtyAfter);
+
+	/**
+	 * Get Qty after change.
+	 * The candidate quantity after the ATP reconciliation changed it.
+	 *
+	 * <br>Type: Quantity
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	BigDecimal getQtyAfter();
+
+	ModelColumn<I_MD_ATP_Reconciliation_Backup, Object> COLUMN_QtyAfter = new ModelColumn<>(I_MD_ATP_Reconciliation_Backup.class, "QtyAfter", null);
+	String COLUMNNAME_QtyAfter = "QtyAfter";
+
+	/**
+	 * Set Qty before change.
+	 * The candidate quantity immediately before the ATP reconciliation changed it.
+	 *
+	 * <br>Type: Quantity
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setQtyBefore (@Nullable BigDecimal QtyBefore);
+
+	/**
+	 * Get Qty before change.
+	 * The candidate quantity immediately before the ATP reconciliation changed it.
+	 *
+	 * <br>Type: Quantity
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	BigDecimal getQtyBefore();
+
+	ModelColumn<I_MD_ATP_Reconciliation_Backup, Object> COLUMN_QtyBefore = new ModelColumn<>(I_MD_ATP_Reconciliation_Backup.class, "QtyBefore", null);
+	String COLUMNNAME_QtyBefore = "QtyBefore";
+
+	/**
+	 * Set Reconciliation run id.
+	 * Unique identifier grouping every row a single ATP reconciliation run backed up.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setReconciliationRunUUID (java.lang.String ReconciliationRunUUID);
+
+	/**
+	 * Get Reconciliation run id.
+	 * Unique identifier grouping every row a single ATP reconciliation run backed up.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.lang.String getReconciliationRunUUID();
+
+	ModelColumn<I_MD_ATP_Reconciliation_Backup, Object> COLUMN_ReconciliationRunUUID = new ModelColumn<>(I_MD_ATP_Reconciliation_Backup.class, "ReconciliationRunUUID", null);
+	String COLUMNNAME_ReconciliationRunUUID = "ReconciliationRunUUID";
+
+	/**
+	 * Set StorageAttributesKey (technical).
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setStorageAttributesKey (java.lang.String StorageAttributesKey);
+
+	/**
+	 * Get StorageAttributesKey (technical).
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.lang.String getStorageAttributesKey();
+
+	ModelColumn<I_MD_ATP_Reconciliation_Backup, Object> COLUMN_StorageAttributesKey = new ModelColumn<>(I_MD_ATP_Reconciliation_Backup.class, "StorageAttributesKey", null);
+	String COLUMNNAME_StorageAttributesKey = "StorageAttributesKey";
+
+	/**
+	 * Get Updated.
+	 * Date this record was updated
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.sql.Timestamp getUpdated();
+
+	ModelColumn<I_MD_ATP_Reconciliation_Backup, Object> COLUMN_Updated = new ModelColumn<>(I_MD_ATP_Reconciliation_Backup.class, "Updated", null);
+	String COLUMNNAME_Updated = "Updated";
+
+	/**
+	 * Get Updated By.
+	 * User who updated this records
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getUpdatedBy();
+
+	String COLUMNNAME_UpdatedBy = "UpdatedBy";
+}

--- a/backend/de.metas.material/dispo-commons/src/main/java-gen/de/metas/material/dispo/model/X_MD_ATP_Reconciliation_Backup.java
+++ b/backend/de.metas.material/dispo-commons/src/main/java-gen/de/metas/material/dispo/model/X_MD_ATP_Reconciliation_Backup.java
@@ -1,0 +1,171 @@
+// Generated Model - DO NOT CHANGE
+package de.metas.material.dispo.model;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.util.Properties;
+import javax.annotation.Nullable;
+
+/** Generated Model for MD_ATP_Reconciliation_Backup
+ *  @author metasfresh (generated) 
+ */
+@SuppressWarnings("unused")
+public class X_MD_ATP_Reconciliation_Backup extends org.compiere.model.PO implements I_MD_ATP_Reconciliation_Backup, org.compiere.model.I_Persistent 
+{
+
+	private static final long serialVersionUID = -2016971931L;
+
+    /** Standard Constructor */
+    public X_MD_ATP_Reconciliation_Backup (final Properties ctx, final int MD_ATP_Reconciliation_Backup_ID, @Nullable final String trxName)
+    {
+      super (ctx, MD_ATP_Reconciliation_Backup_ID, trxName);
+    }
+
+    /** Load Constructor */
+    public X_MD_ATP_Reconciliation_Backup (final Properties ctx, final ResultSet rs, @Nullable final String trxName)
+    {
+      super (ctx, rs, trxName);
+    }
+
+
+	/** Load Meta Data */
+	@Override
+	protected org.compiere.model.POInfo initPO(final Properties ctx)
+	{
+		return org.compiere.model.POInfo.getPOInfo(Table_Name);
+	}
+
+	@Override
+	public void setDateProjected (final java.sql.Timestamp DateProjected)
+	{
+		set_ValueNoCheck (COLUMNNAME_DateProjected, DateProjected);
+	}
+
+	@Override
+	public java.sql.Timestamp getDateProjected() 
+	{
+		return get_ValueAsTimestamp(COLUMNNAME_DateProjected);
+	}
+
+	@Override
+	public void setIsCandidateOwnDetail (final boolean IsCandidateOwnDetail)
+	{
+		set_Value (COLUMNNAME_IsCandidateOwnDetail, IsCandidateOwnDetail);
+	}
+
+	@Override
+	public boolean isCandidateOwnDetail() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsCandidateOwnDetail);
+	}
+
+	@Override
+	public void setMD_ATP_Reconciliation_Backup_ID (final int MD_ATP_Reconciliation_Backup_ID)
+	{
+		if (MD_ATP_Reconciliation_Backup_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_MD_ATP_Reconciliation_Backup_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_MD_ATP_Reconciliation_Backup_ID, MD_ATP_Reconciliation_Backup_ID);
+	}
+
+	@Override
+	public int getMD_ATP_Reconciliation_Backup_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_MD_ATP_Reconciliation_Backup_ID);
+	}
+
+	@Override
+	public void setMD_Candidate_ID (final int MD_Candidate_ID)
+	{
+		if (MD_Candidate_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_MD_Candidate_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_MD_Candidate_ID, MD_Candidate_ID);
+	}
+
+	@Override
+	public int getMD_Candidate_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_MD_Candidate_ID);
+	}
+
+	@Override
+	public void setM_Product_ID (final int M_Product_ID)
+	{
+		if (M_Product_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_M_Product_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_M_Product_ID, M_Product_ID);
+	}
+
+	@Override
+	public int getM_Product_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_M_Product_ID);
+	}
+
+	@Override
+	public void setM_Warehouse_ID (final int M_Warehouse_ID)
+	{
+		if (M_Warehouse_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_M_Warehouse_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_M_Warehouse_ID, M_Warehouse_ID);
+	}
+
+	@Override
+	public int getM_Warehouse_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_M_Warehouse_ID);
+	}
+
+	@Override
+	public void setQtyAfter (final BigDecimal QtyAfter)
+	{
+		set_ValueNoCheck (COLUMNNAME_QtyAfter, QtyAfter);
+	}
+
+	@Override
+	public BigDecimal getQtyAfter() 
+	{
+		final BigDecimal bd = get_ValueAsBigDecimal(COLUMNNAME_QtyAfter);
+		return bd != null ? bd : BigDecimal.ZERO;
+	}
+
+	@Override
+	public void setQtyBefore (final @Nullable BigDecimal QtyBefore)
+	{
+		set_ValueNoCheck (COLUMNNAME_QtyBefore, QtyBefore);
+	}
+
+	@Override
+	public BigDecimal getQtyBefore() 
+	{
+		final BigDecimal bd = get_ValueAsBigDecimal(COLUMNNAME_QtyBefore);
+		return bd != null ? bd : BigDecimal.ZERO;
+	}
+
+	@Override
+	public void setReconciliationRunUUID (final java.lang.String ReconciliationRunUUID)
+	{
+		set_ValueNoCheck (COLUMNNAME_ReconciliationRunUUID, ReconciliationRunUUID);
+	}
+
+	@Override
+	public java.lang.String getReconciliationRunUUID() 
+	{
+		return get_ValueAsString(COLUMNNAME_ReconciliationRunUUID);
+	}
+
+	@Override
+	public void setStorageAttributesKey (final java.lang.String StorageAttributesKey)
+	{
+		set_ValueNoCheck (COLUMNNAME_StorageAttributesKey, StorageAttributesKey);
+	}
+
+	@Override
+	public java.lang.String getStorageAttributesKey() 
+	{
+		return get_ValueAsString(COLUMNNAME_StorageAttributesKey);
+	}
+}

--- a/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/candidate/CandidateAtpReconciliationDetailId.java
+++ b/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/candidate/CandidateAtpReconciliationDetailId.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * metasfresh-material-dispo-commons
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.material.dispo.commons.candidate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import de.metas.util.Check;
+import de.metas.util.lang.RepoIdAware;
+import lombok.Value;
+
+import javax.annotation.Nullable;
+
+@Value
+public class CandidateAtpReconciliationDetailId implements RepoIdAware
+{
+	@JsonCreator
+	public static CandidateAtpReconciliationDetailId ofRepoId(final int repoId)
+	{
+		return new CandidateAtpReconciliationDetailId(repoId);
+	}
+
+	@Nullable
+	public static CandidateAtpReconciliationDetailId ofRepoIdOrNull(final int repoId)
+	{
+		return repoId > 0 ? new CandidateAtpReconciliationDetailId(repoId) : null;
+	}
+
+	int repoId;
+
+	private CandidateAtpReconciliationDetailId(final int repoId)
+	{
+		this.repoId = Check.assumeGreaterThanZero(repoId, "MD_ATP_Reconciliation_Backup_ID");
+	}
+
+	@Override
+	@JsonValue
+	public int getRepoId()
+	{
+		return repoId;
+	}
+}

--- a/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/candidate/CandidateBusinessCase.java
+++ b/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/candidate/CandidateBusinessCase.java
@@ -1,5 +1,6 @@
 package de.metas.material.dispo.commons.candidate;
 
+import de.metas.material.dispo.commons.candidate.businesscase.AtpReconciliationDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.BusinessCaseDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.DistributionDetail;
@@ -50,6 +51,11 @@ public enum CandidateBusinessCase implements ReferenceListAwareEnum
 	FORECAST(X_MD_Candidate.MD_CANDIDATE_BUSINESSCASE_FORECAST, DemandDetail.class),
 	PURCHASE(X_MD_Candidate.MD_CANDIDATE_BUSINESSCASE_PURCHASE, PurchaseDetail.class),
 	STOCK_CHANGE(X_MD_Candidate.MD_CANDIDATE_BUSINESSCASE_STOCK_CHANGE, StockChangeDetail.class),
+	// literal, not X_MD_Candidate.MD_CANDIDATE_BUSINESSCASE_ATP_RECONCILE: matches migration 5823960's
+	// AD_Ref_List.Value as corrected by 5824020 (the original 'ATP_RECONCILIATION' was 18 characters -
+	// MD_Candidate_BusinessCase is varchar(15) and silently truncated it, breaking every read-back).
+	// X_MD_Candidate has not been regenerated against either migration yet.
+	ATP_RECONCILIATION("ATP_RECONCILE", AtpReconciliationDetail.class),
 	;
 
 	private static final ReferenceListAwareEnums.ValuesIndex<CandidateBusinessCase> index = ReferenceListAwareEnums.index(values());

--- a/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/candidate/businesscase/AtpReconciliationDetail.java
+++ b/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/candidate/businesscase/AtpReconciliationDetail.java
@@ -1,0 +1,86 @@
+/*
+ * #%L
+ * metasfresh-material-dispo-commons
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.material.dispo.commons.candidate.businesscase;
+
+import de.metas.material.dispo.commons.candidate.CandidateAtpReconciliationDetailId;
+import de.metas.material.dispo.commons.candidate.CandidateBusinessCase;
+import de.metas.material.dispo.commons.candidate.CandidateId;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+
+/**
+ * Marks a correction candidate as written by an ATP reconciliation run, backed by the same
+ * {@code MD_ATP_Reconciliation_Backup} row the run's audit trail uses - {@code qtyBefore} is {@code null} for this
+ * candidate (it did not exist before the run), matching the "new candidate" convention that table already has.
+ */
+@Value
+@Builder(toBuilder = true)
+public class AtpReconciliationDetail implements BusinessCaseDetail
+{
+	@Nullable
+	CandidateAtpReconciliationDetailId candidateAtpReconciliationDetailId;
+
+	@Nullable
+	CandidateId candidateId;
+
+	@NonNull
+	String reconciliationRunUUID;
+
+	@Nullable
+	BigDecimal qtyBefore;
+
+	@NonNull
+	BigDecimal qtyAfter;
+
+	@Override
+	public CandidateBusinessCase getCandidateBusinessCase()
+	{
+		return CandidateBusinessCase.ATP_RECONCILIATION;
+	}
+
+	@Override
+	public BigDecimal getQty()
+	{
+		return qtyAfter;
+	}
+
+	@Nullable
+	public static AtpReconciliationDetail castOrNull(@Nullable final BusinessCaseDetail businessCaseDetail)
+	{
+		if (!(businessCaseDetail instanceof AtpReconciliationDetail))
+		{
+			return null;
+		}
+		return cast(businessCaseDetail);
+	}
+
+	@NonNull
+	public static AtpReconciliationDetail cast(@NonNull final BusinessCaseDetail businessCaseDetail)
+	{
+		return (AtpReconciliationDetail)businessCaseDetail;
+	}
+}

--- a/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/reconcile/SourceDocumentStatus.java
+++ b/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/reconcile/SourceDocumentStatus.java
@@ -1,0 +1,44 @@
+package de.metas.material.dispo.commons.reconcile;
+
+/*
+ * #%L
+ * metasfresh-material-dispo-commons
+ * %%
+ * Copyright (C) 2017 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/** Result of the liveness test deciding whether a candidate's source document still contributes to ATP. */
+public enum SourceDocumentStatus
+{
+	/** The source document is open and contributes to ATP */
+	STILL_OPEN,
+
+	/** The source document is closed and no longer contributes to ATP */
+	CLOSED,
+
+	/** The candidate has no source document reference */
+	NO_SOURCE_DOCUMENT;
+
+	/**
+	 * @return true if this status indicates the source document is still contributing to ATP
+	 */
+	public boolean isContributingToAtp()
+	{
+		return this == STILL_OPEN;
+	}
+}

--- a/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/CandidateRepositoryRetrieval.java
+++ b/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/CandidateRepositoryRetrieval.java
@@ -3,6 +3,8 @@ package de.metas.material.dispo.commons.repository;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import de.metas.bpartner.BPartnerId;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.document.dimension.DimensionService;
@@ -14,6 +16,7 @@ import de.metas.material.dispo.commons.candidate.CandidateId;
 import de.metas.material.dispo.commons.candidate.CandidateType;
 import de.metas.material.dispo.commons.candidate.CandidatesGroup;
 import de.metas.material.dispo.commons.candidate.TransactionDetail;
+import de.metas.material.dispo.commons.candidate.businesscase.AtpReconciliationDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.BusinessCaseDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.DistributionDetail;
@@ -23,6 +26,7 @@ import de.metas.material.dispo.commons.candidate.businesscase.PurchaseDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.StockChangeDetail;
 import de.metas.material.dispo.commons.repository.query.CandidatesQuery;
 import de.metas.material.dispo.commons.repository.query.ProductionDetailsQuery;
+import de.metas.material.dispo.commons.repository.repohelpers.AtpReconciliationDetailRepo;
 import de.metas.material.dispo.commons.repository.repohelpers.DemandDetailRepoHelper;
 import de.metas.material.dispo.commons.repository.repohelpers.PurchaseDetailRepoHelper;
 import de.metas.material.dispo.commons.repository.repohelpers.RepositoryCommons;
@@ -46,17 +50,21 @@ import de.metas.product.ResourceId;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
+import org.adempiere.ad.dao.impl.TypedSqlQueryFilter;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.util.TimeUtil;
 import org.eevolution.api.PPOrderBOMLineId;
 import org.eevolution.api.PPOrderId;
 import org.eevolution.productioncandidate.model.PPOrderCandidateId;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.List;
@@ -88,19 +96,40 @@ import static org.adempiere.model.InterfaceWrapperHelper.isNew;
  * #L%
  */
 
+/**
+ * Repository Tables: MD_Candidate, MD_Candidate_Demand_Detail, MD_Candidate_Dist_Detail, MD_Candidate_Prod_Detail,
+ * MD_Candidate_Transaction_Detail
+ * Repository Cluster: CandidateRepositoryRetrieval, CandidateRepositoryWriteService
+ * <p>
+ * The read side of the {@code MD_Candidate} aggregate: loads {@link Candidate}s (and their business-case detail)
+ * by id, by natural-key query, by group, or by owning {@code PP_Order}. {@link CandidateRepositoryWriteService} is
+ * the write side of the same cluster; together they are the sole owners of {@code MD_Candidate} and the four
+ * detail tables listed above.
+ * <p>
+ * {@code MD_Candidate_Purchase_Detail}, {@code MD_Candidate_StockChange_Detail} and {@code MD_ATP_Reconciliation_Backup}
+ * (the correction candidate's own row only) are read here too, but only by delegating to their own repo helpers
+ * ({@link PurchaseDetailRepoHelper}, {@link StockChangeDetailRepo}, {@link AtpReconciliationDetailRepo}) - this
+ * class claims no ownership of those tables.
+ */
 @Service
+@RequiredArgsConstructor(onConstructor_ = @__(@Autowired))
 public class CandidateRepositoryRetrieval
 {
 	public static final IQueryBL queryBL = Services.get(IQueryBL.class);
-	private final DimensionService dimensionService;
-	private final StockChangeDetailRepo stockChangeDetailRepo;
+	@NonNull private final DimensionService dimensionService;
+	@NonNull private final StockChangeDetailRepo stockChangeDetailRepo;
+	@NonNull private final AtpReconciliationDetailRepo atpReconciliationDetailRepo;
 
+	/**
+	 * Legacy 2-arg shape, kept so the many existing test call sites that construct this class directly don't all
+	 * need touching for one new business-case detail repo - delegates with a bare {@code new}, harmless since
+	 * {@link AtpReconciliationDetailRepo} carries no state of its own (same as {@link StockChangeDetailRepo}).
+	 */
 	public CandidateRepositoryRetrieval(
 			@NonNull final DimensionService dimensionService,
 			@NonNull final StockChangeDetailRepo stockChangeDetailRepo)
 	{
-		this.dimensionService = dimensionService;
-		this.stockChangeDetailRepo = stockChangeDetailRepo;
+		this(dimensionService, stockChangeDetailRepo, new AtpReconciliationDetailRepo());
 	}
 
 	public Candidate retrieveById(@NonNull final CandidateId candidateId)
@@ -108,6 +137,70 @@ public class CandidateRepositoryRetrieval
 		candidateId.assertRegular();
 		return retrieveLatestMatch(CandidatesQuery.fromId(candidateId))
 				.orElseThrow(() -> new AdempiereException("No candidate found for " + candidateId));
+	}
+
+	/**
+	 * Reads {@code QtyFulfilled} for the given candidates in ONE query. That column is not part of the
+	 * {@link Candidate} value object, so a caller that needs it has to come back here for it; doing so per
+	 * candidate via {@link #retrieveById(CandidateId)} would turn one candidate chain into as many round
+	 * trips as it has positions.
+	 *
+	 * @return the {@code QtyFulfilled} per candidate id. An id without a matching record is simply absent
+	 * from the map, so callers have to decide themselves what a missing id means (usually
+	 * {@link BigDecimal#ZERO}).
+	 */
+	public ImmutableMap<CandidateId, BigDecimal> getQtyFulfilledByCandidateIds(@NonNull final Collection<CandidateId> candidateIds)
+	{
+		if (candidateIds.isEmpty())
+		{
+			// short-circuit *before* querying: an empty addInArrayFilter would be no filter at all, and the
+			// query would then select the whole MD_Candidate table
+			return ImmutableMap.of();
+		}
+
+		return queryBL.createQueryBuilder(I_MD_Candidate.class)
+				.addInArrayFilter(I_MD_Candidate.COLUMNNAME_MD_Candidate_ID, candidateIds)
+				.create()
+				.stream()
+				.collect(ImmutableMap.toImmutableMap(
+						record -> CandidateId.ofRepoId(record.getMD_Candidate_ID()),
+						I_MD_Candidate::getQtyFulfilled));
+	}
+
+	/**
+	 * Types whose candidates are <b>planned</b> movements: they move the chain's running balance before
+	 * anything physical has happened, which is why a chain that carries one legitimately disagrees with
+	 * {@code MD_Stock.QtyOnHand}.
+	 * <p>
+	 * Every other non-{@code STOCK} type is deliberately left out. {@code UNEXPECTED_INCREASE}/
+	 * {@code _DECREASE}, {@code INVENTORY_UP}/{@code _DOWN} and {@code ATTRIBUTES_CHANGED_FROM}/{@code _TO}
+	 * all record something that already happened physically, so they belong to the physical baseline rather
+	 * than to the positions - and the last four of them are known to keep a {@code Qty}/{@code QtyFulfilled}
+	 * gap regardless, so counting them would report a position on nearly every key. {@code STOCK_UP} creates
+	 * no stock candidate at all and therefore never moves the running balance.
+	 */
+	private static final ImmutableSet<String> PLANNED_POSITION_TYPES = ImmutableSet.of(
+			X_MD_Candidate.MD_CANDIDATE_TYPE_DEMAND,
+			X_MD_Candidate.MD_CANDIDATE_TYPE_SUPPLY);
+
+	/**
+	 * Does the queried part of the chain carry at least one planned position that has not been fully
+	 * realized yet, i.e. one whose {@code Qty} is not (yet) matched by its {@code QtyFulfilled}?
+	 * <p>
+	 * This is deliberately a coarse <b>quantity</b> test and says nothing about whether the position's
+	 * source document is still open - that question needs the document tables, which are owned by modules
+	 * downstream of this one. It answers only "is this chain's running balance carrying anything besides
+	 * the physical baseline?", and it answers it conservatively: a leftover position of a document that has
+	 * meanwhile been closed still counts. A caller may therefore use the {@code true} answer only to
+	 * <i>refrain</i> from treating the bare physical quantity as the chain's correct balance - never to
+	 * derive a balance from it.
+	 */
+	public boolean hasUnfulfilledPlannedPositions(@NonNull final CandidatesQuery query)
+	{
+		return RepositoryCommons.mkQueryBuilder(query)
+				.addInArrayFilter(I_MD_Candidate.COLUMNNAME_MD_Candidate_Type, PLANNED_POSITION_TYPES)
+				.filter(TypedSqlQueryFilter.of(I_MD_Candidate.COLUMNNAME_Qty + " <> COALESCE(" + I_MD_Candidate.COLUMNNAME_QtyFulfilled + ", 0)"))
+				.anyMatch();
 	}
 
 	/**
@@ -171,19 +264,21 @@ public class CandidateRepositoryRetrieval
 		final DistributionDetail distributionDetailOrNull = retrieveDistributionDetailOrNull(candidateId);
 		final PurchaseDetail purchaseDetailOrNull = PurchaseDetailRepoHelper.getSingleForCandidateRecordOrNull(candidateId);
 		final StockChangeDetail stockChangeDetailOrNull = stockChangeDetailRepo.getSingleForCandidateRecordOrNull(candidateId);
+		final AtpReconciliationDetail atpReconciliationDetailOrNull = atpReconciliationDetailRepo.getSingleForCandidateRecordOrNull(candidateId);
 
 		final int hasProductionDetail = productionDetailOrNull == null ? 0 : 1;
 		final int hasDistributionDetail = distributionDetailOrNull == null ? 0 : 1;
 		final int hasPurchaseDetail = purchaseDetailOrNull == null ? 0 : 1;
 		final int hasStockChangeDetail = stockChangeDetailOrNull == null ? 0 : 1;
+		final int hasAtpReconciliationDetail = atpReconciliationDetailOrNull == null ? 0 : 1;
 
-		Check.errorIf(hasProductionDetail + hasDistributionDetail + hasPurchaseDetail + hasStockChangeDetail > 1,
-				"A candidate may not have both a distribution, production, production detail and a hasStockChangeDetail; candidateRecord={}", candidateRecordOrNull);
+		Check.errorIf(hasProductionDetail + hasDistributionDetail + hasPurchaseDetail + hasStockChangeDetail + hasAtpReconciliationDetail > 1,
+				"A candidate may not have more than one of a distribution, production, purchase, stock-change or atp-reconciliation detail; candidateRecord={}", candidateRecordOrNull);
 
 		final DemandDetail demandDetailOrNull = retrieveDemandDetailOrNull(candidateId);
 
 		final BusinessCaseDetail businessCaseDetail = CoalesceUtil.coalesce(productionDetailOrNull, distributionDetailOrNull, purchaseDetailOrNull,
-				demandDetailOrNull, stockChangeDetailOrNull);
+				demandDetailOrNull, stockChangeDetailOrNull, atpReconciliationDetailOrNull);
 		builder.businessCaseDetail(businessCaseDetail);
 		if (hasProductionDetail > 0 || hasDistributionDetail > 0 || hasPurchaseDetail > 0)
 		{

--- a/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/CandidateRepositoryWriteService.java
+++ b/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/CandidateRepositoryWriteService.java
@@ -39,6 +39,7 @@ import de.metas.material.dispo.commons.candidate.CandidateQtyDetailsPersistMulti
 import de.metas.material.dispo.commons.candidate.CandidateQtyDetailsPersistRequest;
 import de.metas.material.dispo.commons.candidate.CandidateType;
 import de.metas.material.dispo.commons.candidate.TransactionDetail;
+import de.metas.material.dispo.commons.candidate.businesscase.AtpReconciliationDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.DistributionDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.ProductionDetail;
@@ -47,6 +48,7 @@ import de.metas.material.dispo.commons.candidate.businesscase.StockChangeDetail;
 import de.metas.material.dispo.commons.repository.query.CandidatesQuery;
 import de.metas.material.dispo.commons.repository.query.DeleteCandidatesQuery;
 import de.metas.material.dispo.commons.repository.query.MaterialDescriptorQuery;
+import de.metas.material.dispo.commons.repository.repohelpers.AtpReconciliationDetailRepo;
 import de.metas.material.dispo.commons.repository.repohelpers.PurchaseDetailRepoHelper;
 import de.metas.material.dispo.commons.repository.repohelpers.RepositoryCommons;
 import de.metas.material.dispo.commons.repository.repohelpers.StockChangeDetailRepo;
@@ -86,6 +88,7 @@ import org.compiere.util.TimeUtil;
 import org.eevolution.api.PPOrderBOMLineId;
 import org.eevolution.api.PPOrderId;
 import org.eevolution.productioncandidate.model.PPOrderCandidateId;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
@@ -108,7 +111,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.save;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 
 @Service
-@RequiredArgsConstructor
+@RequiredArgsConstructor(onConstructor_ = @__(@Autowired))
 public class CandidateRepositoryWriteService
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
@@ -117,6 +120,21 @@ public class CandidateRepositoryWriteService
 	@NonNull private final StockChangeDetailRepo stockChangeDetailRepo;
 	@NonNull private final CandidateRepositoryRetrieval candidateRepositoryRetrieval;
 	@NonNull private final CandidateQtyDetailsRepository candidateQtyDetailsRepository;
+	@NonNull private final AtpReconciliationDetailRepo atpReconciliationDetailRepo;
+
+	/**
+	 * Legacy 4-arg shape, kept so the many existing test call sites that construct this class directly don't all
+	 * need touching for one new business-case detail repo - delegates with a bare {@code new}, harmless since
+	 * {@link AtpReconciliationDetailRepo} carries no state of its own (same as {@link StockChangeDetailRepo}).
+	 */
+	public CandidateRepositoryWriteService(
+			@NonNull final DimensionService dimensionService,
+			@NonNull final StockChangeDetailRepo stockChangeDetailRepo,
+			@NonNull final CandidateRepositoryRetrieval candidateRepositoryRetrieval,
+			@NonNull final CandidateQtyDetailsRepository candidateQtyDetailsRepository)
+	{
+		this(dimensionService, stockChangeDetailRepo, candidateRepositoryRetrieval, candidateQtyDetailsRepository, new AtpReconciliationDetailRepo());
+	}
 
 	/**
 	 * Stores the given {@code candidate}.
@@ -207,6 +225,8 @@ public class CandidateRepositoryWriteService
 		addOrReplaceTransactionDetail(candidate, syncedRecord);
 
 		addOrReplaceStockChangeDetail(candidate, syncedRecord);
+
+		addOrReplaceAtpReconciliationDetail(candidate, syncedRecord);
 
 		final Candidate savedCandidate = createNewCandidateWithIdsFromRecord(candidate, syncedRecord);
 
@@ -618,6 +638,14 @@ public class CandidateRepositoryWriteService
 		stockChangeDetailRepo.saveOrUpdate(stockChangeDetail, synchedRecord);
 	}
 
+	private void addOrReplaceAtpReconciliationDetail(
+			@NonNull final Candidate candidate,
+			@NonNull final I_MD_Candidate synchedRecord)
+	{
+		final AtpReconciliationDetail atpReconciliationDetail = AtpReconciliationDetail.castOrNull(candidate.getBusinessCaseDetail());
+		atpReconciliationDetailRepo.saveOrUpdate(atpReconciliationDetail, synchedRecord);
+	}
+
 	private Candidate createNewCandidateWithIdsFromRecord(
 			@NonNull final Candidate candidate,
 			@NonNull final I_MD_Candidate candidateRecord)
@@ -833,6 +861,8 @@ public class CandidateRepositoryWriteService
 		deleteProdDetailsRecords(candidateId);
 		deletePurchaseDetailsRecords(candidateId);
 		deleteStockChangeDetailsRecords(candidateId);
+		// deliberately NOT deleting MD_ATP_Reconciliation_Backup rows here: that table is a durable audit trail
+		// (see its own migration header) and is meant to survive deletion of the candidate it describes.
 		deleteTransactionDetailsRecords(candidateId);
 		deleteQtyDetails(candidateId);
 	}

--- a/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/repohelpers/AtpReconciliationDetailRepo.java
+++ b/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/repohelpers/AtpReconciliationDetailRepo.java
@@ -1,0 +1,124 @@
+/*
+ * #%L
+ * metasfresh-material-dispo-commons
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.material.dispo.commons.repository.repohelpers;
+
+import de.metas.material.dispo.commons.candidate.CandidateAtpReconciliationDetailId;
+import de.metas.material.dispo.commons.candidate.CandidateId;
+import de.metas.material.dispo.commons.candidate.businesscase.AtpReconciliationDetail;
+import de.metas.material.dispo.model.I_MD_ATP_Reconciliation_Backup;
+import de.metas.material.dispo.model.I_MD_Candidate;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryBuilder;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Nullable;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+
+/**
+ * Persists the one {@link I_MD_ATP_Reconciliation_Backup} row that names a correction candidate's own creation.
+ * <p>
+ * Reuses the same table {@link de.metas.material.dispo.reconcile.AtpReconciliationBackupRepository}-equivalent
+ * classes back up the STOCK candidates a run touches - every query here filters on {@code IsCandidateOwnDetail}
+ * to stay disjoint from those rows (see migration {@code 5824060} for why that column exists).
+ */
+@Service
+public class AtpReconciliationDetailRepo
+{
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@Nullable
+	public AtpReconciliationDetail getSingleForCandidateRecordOrNull(@NonNull final CandidateId candidateId)
+	{
+		final I_MD_ATP_Reconciliation_Backup record = ownDetailQueryBuilder(candidateId)
+				.create()
+				.firstOnly(I_MD_ATP_Reconciliation_Backup.class);
+
+		return ofRecord(record);
+	}
+
+	public void saveOrUpdate(
+			@Nullable final AtpReconciliationDetail atpReconciliationDetail,
+			@NonNull final I_MD_Candidate candidateRecord)
+	{
+		if (atpReconciliationDetail == null)
+		{
+			return;
+		}
+
+		final CandidateId candidateId = CandidateId.ofRepoId(candidateRecord.getMD_Candidate_ID());
+		I_MD_ATP_Reconciliation_Backup recordToUpdate = ownDetailQueryBuilder(candidateId)
+				.create()
+				.firstOnly(I_MD_ATP_Reconciliation_Backup.class);
+
+		if (recordToUpdate == null)
+		{
+			recordToUpdate = newInstance(I_MD_ATP_Reconciliation_Backup.class, candidateRecord);
+			recordToUpdate.setMD_Candidate_ID(candidateId.getRepoId());
+			recordToUpdate.setM_Product_ID(candidateRecord.getM_Product_ID());
+			recordToUpdate.setM_Warehouse_ID(candidateRecord.getM_Warehouse_ID());
+			recordToUpdate.setStorageAttributesKey(candidateRecord.getStorageAttributesKey());
+			recordToUpdate.setDateProjected(candidateRecord.getDateProjected());
+			recordToUpdate.setReconciliationRunUUID(atpReconciliationDetail.getReconciliationRunUUID());
+			recordToUpdate.setIsCandidateOwnDetail(true);
+		}
+
+		if (atpReconciliationDetail.getQtyBefore() != null)
+		{
+			recordToUpdate.setQtyBefore(atpReconciliationDetail.getQtyBefore());
+		}
+		recordToUpdate.setQtyAfter(atpReconciliationDetail.getQtyAfter());
+
+		saveRecord(recordToUpdate);
+	}
+
+	private IQueryBuilder<I_MD_ATP_Reconciliation_Backup> ownDetailQueryBuilder(@NonNull final CandidateId candidateId)
+	{
+		return queryBL
+				.createQueryBuilder(I_MD_ATP_Reconciliation_Backup.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_MD_ATP_Reconciliation_Backup.COLUMNNAME_MD_Candidate_ID, candidateId.getRepoId())
+				.addEqualsFilter(I_MD_ATP_Reconciliation_Backup.COLUMNNAME_IsCandidateOwnDetail, true);
+	}
+
+	@Nullable
+	private AtpReconciliationDetail ofRecord(@Nullable final I_MD_ATP_Reconciliation_Backup record)
+	{
+		if (record == null)
+		{
+			return null;
+		}
+
+		return AtpReconciliationDetail.builder()
+				.candidateAtpReconciliationDetailId(CandidateAtpReconciliationDetailId.ofRepoId(record.getMD_ATP_Reconciliation_Backup_ID()))
+				.candidateId(CandidateId.ofRepoId(record.getMD_Candidate_ID()))
+				.reconciliationRunUUID(record.getReconciliationRunUUID())
+				.qtyBefore(InterfaceWrapperHelper.isNull(record, I_MD_ATP_Reconciliation_Backup.COLUMNNAME_QtyBefore) ? null : record.getQtyBefore())
+				.qtyAfter(record.getQtyAfter())
+				.build();
+	}
+}

--- a/backend/de.metas.material/dispo-commons/src/test/java/de/metas/material/dispo/commons/reconcile/SourceDocumentStatusTest.java
+++ b/backend/de.metas.material/dispo-commons/src/test/java/de/metas/material/dispo/commons/reconcile/SourceDocumentStatusTest.java
@@ -1,0 +1,71 @@
+package de.metas.material.dispo.commons.reconcile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+/*
+ * #%L
+ * metasfresh-material-dispo-commons
+ * %%
+ * Copyright (C) 2017 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+public class SourceDocumentStatusTest
+{
+	@Test
+	public void testStillOpenIsContributingToAtp()
+	{
+		assertThat(SourceDocumentStatus.STILL_OPEN.isContributingToAtp()).isTrue();
+	}
+
+	@Test
+	public void testClosedIsNotContributingToAtp()
+	{
+		assertThat(SourceDocumentStatus.CLOSED.isContributingToAtp()).isFalse();
+	}
+
+	@Test
+	public void testNoSourceDocumentIsNotContributingToAtp()
+	{
+		assertThat(SourceDocumentStatus.NO_SOURCE_DOCUMENT.isContributingToAtp()).isFalse();
+	}
+
+	/**
+	 * Guards the implicit default in {@link SourceDocumentStatus#isContributingToAtp()}, which is
+	 * {@code this == STILL_OPEN} — i.e. any NEW constant silently becomes non-contributing. Concrete
+	 * scenario this prevents: a fourth status is added for the unreliable-era date cutoff, nobody adds a
+	 * test for it, and it is silently treated as "does not contribute to ATP" with every other test green.
+	 * This test fails on any added or renamed constant, forcing an explicit decision for it.
+	 */
+	@Test
+	public void testEveryConstantIsClassifiedDeliberately()
+	{
+		assertThat(SourceDocumentStatus.values())
+				.containsExactly(
+						SourceDocumentStatus.STILL_OPEN,
+						SourceDocumentStatus.CLOSED,
+						SourceDocumentStatus.NO_SOURCE_DOCUMENT);
+
+		assertThat(Arrays.stream(SourceDocumentStatus.values())
+						.filter(SourceDocumentStatus::isContributingToAtp))
+				.containsExactly(SourceDocumentStatus.STILL_OPEN);
+	}
+}

--- a/backend/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/StockChangedEventHandler.java
+++ b/backend/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/StockChangedEventHandler.java
@@ -128,10 +128,11 @@ public class StockChangedEventHandler implements MaterialEventHandler<StockChang
 		}
 		else
 		{
-			// we work with the delta to the predecessor candidate, so that we can invoke our existing candidateChangeHandler implementation
-			final BigDecimal qtyDifference = event
-					.getQtyOnHand()
-					.subtract(latestStockRecord.getQuantity());
+			// we work with a delta, so that we can invoke our existing candidateChangeHandler implementation.
+			// WHICH delta depends on what the chain's running balance is made of: it equals the bare physical
+			// quantity only for a chain that carries no planned position, and legitimately differs from it for
+			// one that does.
+			final BigDecimal qtyDifference = computeQtyDifference(event, materialDescriptorQuery, latestStockRecord);
 
 			final CandidateType type = computeCandidateTypeOrNull(qtyDifference);
 			if (type == null)
@@ -155,6 +156,37 @@ public class StockChangedEventHandler implements MaterialEventHandler<StockChang
 					.build();
 		}
 		candidateChangeHandler.onCandidateNewOrChange(candidate);
+	}
+
+	/**
+	 * The reset-stock event says what {@code MD_Stock.QtyOnHand} now is and what it was before. The chain's
+	 * running balance is {@code physical quantity + the still-outstanding planned positions}, so:
+	 * <ul>
+	 * <li>for a chain that carries no unfulfilled planned position the correct balance <b>is</b> the bare
+	 * physical quantity, and re-baselining the chain onto it is exactly what the reset-stock process is for;
+	 * <li>for a chain that carries one, the bare physical quantity is <b>not</b> the correct balance. Deriving
+	 * the correct one would need each position's source-document status, which this module cannot read (the
+	 * document tables belong to modules downstream of it), so the event's own physical movement is applied
+	 * and the positions are left untouched. Repairing such a chain is the ATP reconciliation's job.
+	 * </ul>
+	 */
+	private BigDecimal computeQtyDifference(
+			@NonNull final StockChangedEvent event,
+			@NonNull final MaterialDescriptorQuery materialDescriptorQuery,
+			@NonNull final Candidate latestStockRecord)
+	{
+		final CandidatesQuery positionsQuery = CandidatesQuery.builder()
+				.materialDescriptorQuery(materialDescriptorQuery)
+				.matchExactStorageAttributesKey(true)
+				.build();
+
+		if (candidateRepository.hasUnfulfilledPlannedPositions(positionsQuery))
+		{
+			Loggables.withLogger(logger, Level.DEBUG).addLog("The chain carries unfulfilled planned positions;"
+					+ " -> applying the event's physical movement instead of re-baselining onto the physical qty");
+			return event.getQtyOnHand().subtract(event.getQtyOnHandOld());
+		}
+		return event.getQtyOnHand().subtract(latestStockRecord.getQuantity());
 	}
 
 	private BigDecimal extractQuantityIfPositive(@NonNull final StockChangedEvent event)

--- a/backend/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/stockchange/StockEstimateCreatedHandler.java
+++ b/backend/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/stockchange/StockEstimateCreatedHandler.java
@@ -33,7 +33,9 @@ import de.metas.material.event.MaterialEventHandler;
 import de.metas.material.event.stockestimate.AbstractStockEstimateEvent;
 import de.metas.material.event.stockestimate.StockEstimateCreatedEvent;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.adempiere.exceptions.AdempiereException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -42,18 +44,11 @@ import java.util.Collection;
 
 @Service
 @Profile(Profiles.PROFILE_MaterialDispo)
+@RequiredArgsConstructor(onConstructor_ = @__(@Autowired))
 public class StockEstimateCreatedHandler implements MaterialEventHandler<AbstractStockEstimateEvent>
 {
-	private final CandidateChangeService candidateChangeHandler;
-	private final StockEstimateEventService stockEstimateEventService;
-
-	public StockEstimateCreatedHandler(
-			@NonNull final CandidateChangeService candidateChangeHandler,
-			@NonNull final StockEstimateEventService stockEstimateEventService)
-	{
-		this.candidateChangeHandler = candidateChangeHandler;
-		this.stockEstimateEventService = stockEstimateEventService;
-	}
+	@NonNull private final CandidateChangeService candidateChangeHandler;
+	@NonNull private final StockEstimateEventService stockEstimateEventService;
 
 	@Override
 	public Collection<Class<? extends AbstractStockEstimateEvent>> getHandledEventType()
@@ -71,6 +66,14 @@ public class StockEstimateCreatedHandler implements MaterialEventHandler<Abstrac
 			throw new AdempiereException("No candidate should exist for event, but an actual candidate was returned")
 					.appendParametersToMessage()
 					.setParameter("StockEstimateCreatedEvent", event);
+		}
+
+		if (stockEstimateEventService.hasUnfulfilledPlannedPositions(event))
+		{
+			// re-baselining onto the bare counted qty would silently absorb it - unlike StockChangedEventHandler,
+			// this event carries no old/new pair to fall back to a physical-movement delta, so the safe choice is
+			// to write nothing and leave the correction to the ATP reconciliation process.
+			return;
 		}
 
 		final Candidate previousStockOrNull = stockEstimateEventService.retrievePreviousStockCandidateOrNull(event);

--- a/backend/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/stockchange/StockEstimateEventService.java
+++ b/backend/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/stockchange/StockEstimateEventService.java
@@ -33,20 +33,18 @@ import de.metas.material.dispo.commons.repository.query.MaterialDescriptorQuery;
 import de.metas.material.dispo.commons.repository.query.StockChangeDetailQuery;
 import de.metas.material.event.stockestimate.AbstractStockEstimateEvent;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
 
 @Service
+@RequiredArgsConstructor(onConstructor_ = @__(@Autowired))
 public class StockEstimateEventService
 {
 	@NonNull
 	private final CandidateRepositoryRetrieval candidateRepositoryRetrieval;
-
-	public StockEstimateEventService(@NonNull final CandidateRepositoryRetrieval candidateRepositoryRetrieval)
-	{
-		this.candidateRepositoryRetrieval = candidateRepositoryRetrieval;
-	}
 
 	@Nullable
 	public Candidate retrieveExistingStockEstimateCandidateOrNull(@NonNull final AbstractStockEstimateEvent event)
@@ -60,6 +58,31 @@ public class StockEstimateEventService
 	{
 		final CandidatesQuery query = createPreviousStockCandidatesQuery(event);
 		return candidateRepositoryRetrieval.retrieveLatestMatchOrNull(query);
+	}
+
+	/**
+	 * @return whether the chain carries a planned position (dated before the event) that isn't yet fully
+	 * realized - see {@link CandidateRepositoryRetrieval#hasUnfulfilledPlannedPositions} for what that answer may
+	 * and may not be used for. Mirrors {@code StockChangedEventHandler}'s guard against re-baselining a chain
+	 * that carries one: unlike that event, a stock estimate has no separate old/new pair to fall back to a pure
+	 * physical-movement delta, so the caller's only safe option on {@code true} is to write nothing at all.
+	 */
+	public boolean hasUnfulfilledPlannedPositions(@NonNull final AbstractStockEstimateEvent event)
+	{
+		final MaterialDescriptorQuery materialDescriptorQuery = MaterialDescriptorQuery.forDescriptor(event.getMaterialDescriptor())
+				.toBuilder()
+				.timeRangeEnd(DateAndSeqNo.builder()
+									  .date(event.getDate())
+									  .operator(DateAndSeqNo.Operator.EXCLUSIVE)
+									  .build())
+				.build();
+
+		final CandidatesQuery query = CandidatesQuery.builder()
+				.materialDescriptorQuery(materialDescriptorQuery)
+				.matchExactStorageAttributesKey(true)
+				.build();
+
+		return candidateRepositoryRetrieval.hasUnfulfilledPlannedPositions(query);
 	}
 
 	@NonNull

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5823240_MD_ATP_Reconciliation_Backup_table.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5823240_MD_ATP_Reconciliation_Backup_table.sql
@@ -1,0 +1,279 @@
+-- New table holding the durable backup + run log for the ATP reconciliation command: one row per STOCK
+-- candidate a reconciliation run touched, capturing its quantity immediately before the run (recoverable
+-- after the run ends) and, once known, the quantity after. Rows sharing a ReconciliationRunUUID belong to
+-- the same run.
+
+-- AD_Table
+INSERT INTO AD_Table (AccessLevel,ACTriggerLength,AD_Client_ID,AD_Org_ID,AD_Table_ID,CopyColumnsFromTable,Created,CreatedBy,EntityType,ImportTable,IsActive,IsAutocomplete,IsChangeLog,IsDeleteable,IsDLM,IsEnableRemoteCacheInvalidation,IsHighVolume,IsSecurityEnabled,IsView,LoadSeq,Name,PersonalDataCategory,ReplicationType,TableName,TooltipType,Updated,UpdatedBy)
+VALUES ('3',0,0,0,542645 /*From ID Server*/,'N',TO_TIMESTAMP('2026-09-09 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.material.dispo','N','Y','N','N','N','Y','N','N','N','N',0,'MD_ATP_Reconciliation_Backup','NP','L','MD_ATP_Reconciliation_Backup','DTI',TO_TIMESTAMP('2026-09-09 10:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Table_Trl (AD_Language,AD_Table_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Table_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Table t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Table_ID=542645
+  AND NOT EXISTS (SELECT 1 FROM AD_Table_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Table_ID=t.AD_Table_ID)
+;
+
+-- Primary key column, its own new AD_Element
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585438 /*From ID Server*/,0,'MD_ATP_Reconciliation_Backup_ID',TO_TIMESTAMP('2026-09-09 10:01:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.material.dispo','Y','MD_ATP_Reconciliation_Backup','MD_ATP_Reconciliation_Backup',TO_TIMESTAMP('2026-09-09 10:01:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID,CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning, t.Description, t.Help, t.Name, t.PO_Description, t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName, t.WEBUI_NameBrowse, t.WEBUI_NameNew, t.WEBUI_NameNewBreadcrumb, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585438
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593513 /*From ID Server*/,585438,0,13,542645,'MD_ATP_Reconciliation_Backup_ID',TO_TIMESTAMP('2026-09-09 10:01:10','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',10,'Y','Y','N','N','N','N','N','Y','Y','N','N','Y','N','N','MD_ATP_Reconciliation_Backup','NP',10,TO_TIMESTAMP('2026-09-09 10:01:10','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593513
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+SELECT update_Column_Translation_From_AD_Element(585438);
+
+-- Standard columns (shared elements: AD_Client_ID=102, AD_Org_ID=113, Created=245, CreatedBy=246, Updated=607, UpdatedBy=608, IsActive=348)
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593514 /*From ID Server*/,102,0,19,542645,'AD_Client_ID',TO_TIMESTAMP('2026-09-09 10:02:00','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',10,'Y','Y','N','N','N','N','N','N','Y','N','N','Y','N','N','Mandant','NP',20,TO_TIMESTAMP('2026-09-09 10:02:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593514
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(102);
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593515 /*From ID Server*/,113,0,30,542645,'AD_Org_ID',TO_TIMESTAMP('2026-09-09 10:02:10','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',10,'Y','Y','N','N','N','N','N','N','Y','N','Y','Y','N','N','Sektion','NP',30,TO_TIMESTAMP('2026-09-09 10:02:10','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593515
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(113);
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593516 /*From ID Server*/,245,0,16,542645,'Created',TO_TIMESTAMP('2026-09-09 10:02:20','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',29,'Y','N','N','N','N','N','N','N','Y','N','N','Y','N','N','Erstellt','NP',40,TO_TIMESTAMP('2026-09-09 10:02:20','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593516
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(245);
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593517 /*From ID Server*/,246,0,18,110,542645,'CreatedBy',TO_TIMESTAMP('2026-09-09 10:02:30','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',10,'Y','N','N','N','N','N','N','N','Y','N','N','Y','N','N','Erstellt durch','NP',50,TO_TIMESTAMP('2026-09-09 10:02:30','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593517
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(246);
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593518 /*From ID Server*/,607,0,16,542645,'Updated',TO_TIMESTAMP('2026-09-09 10:02:40','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',29,'Y','N','N','N','N','N','N','N','Y','N','N','Y','N','N','Aktualisiert','NP',60,TO_TIMESTAMP('2026-09-09 10:02:40','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593518
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(607);
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593519 /*From ID Server*/,608,0,18,110,542645,'UpdatedBy',TO_TIMESTAMP('2026-09-09 10:02:50','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',10,'Y','N','N','N','N','N','N','N','Y','N','N','Y','N','N','Aktualisiert durch','NP',70,TO_TIMESTAMP('2026-09-09 10:02:50','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593519
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(608);
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593520 /*From ID Server*/,348,0,20,542645,'IsActive',TO_TIMESTAMP('2026-09-09 10:03:00','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',1,'Y','Y','N','N','N','N','N','N','Y','N','N','Y','N','Y','Aktiv','NP',80,TO_TIMESTAMP('2026-09-09 10:03:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593520
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(348);
+
+-- Run identity: new element
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,Description,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585439 /*From ID Server*/,0,'ReconciliationRunUUID',TO_TIMESTAMP('2026-09-09 10:04:00','YYYY-MM-DD HH24:MI:SS'),100,'Eindeutige Kennung, die alle bei einem ATP-Abstimmungslauf gesicherten Zeilen gruppiert.','de.metas.material.dispo','Y','Abstimmungslauf-Kennung','Abstimmungslauf-Kennung',TO_TIMESTAMP('2026-09-09 10:04:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID,CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning, t.Description, t.Help, t.Name, t.PO_Description, t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName, t.WEBUI_NameBrowse, t.WEBUI_NameNew, t.WEBUI_NameNewBreadcrumb, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585439
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+UPDATE AD_Element_Trl SET Name='Reconciliation run id', Description='Unique identifier grouping every row a single ATP reconciliation run backed up.', PrintName='Reconciliation run id', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 10:04:10','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585439 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585439,'en_US');
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593521 /*From ID Server*/,585439,0,10,542645,'ReconciliationRunUUID',TO_TIMESTAMP('2026-09-09 10:04:20','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',36,'Y','Y','N','N','N','N','N','N','Y','N','Y','Y','N','N','Abstimmungslauf-Kennung','NP',90,TO_TIMESTAMP('2026-09-09 10:04:20','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593521
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(585439);
+
+-- Reused elements from MD_Candidate: MD_Candidate_ID=543308, DateProjected=543309, M_Warehouse_ID=459, M_Product_ID=454, StorageAttributesKey=543463
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593522 /*From ID Server*/,543308,0,19,542645,'MD_Candidate_ID',TO_TIMESTAMP('2026-09-09 10:05:00','YYYY-MM-DD HH24:MI:SS'),100,'Y','de.metas.material.dispo',10,'Y','Y','N','N','N','N','N','N','Y','N','N','Y','N','N','Dispositionskandidat','NP',100,TO_TIMESTAMP('2026-09-09 10:05:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593522
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(543308);
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593523 /*From ID Server*/,543309,0,16,542645,'DateProjected',TO_TIMESTAMP('2026-09-09 10:05:10','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',7,'Y','Y','N','N','N','N','N','N','Y','N','N','Y','N','N','Datum','NP',110,TO_TIMESTAMP('2026-09-09 10:05:10','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593523
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(543309);
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593524 /*From ID Server*/,459,0,30,542645,'M_Warehouse_ID',TO_TIMESTAMP('2026-09-09 10:05:20','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',10,'Y','Y','N','N','N','N','N','N','Y','N','N','Y','N','N','Lager','NP',120,TO_TIMESTAMP('2026-09-09 10:05:20','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593524
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(459);
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593525 /*From ID Server*/,454,0,30,542645,'M_Product_ID',TO_TIMESTAMP('2026-09-09 10:05:30','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',10,'Y','Y','N','N','N','N','N','N','Y','N','N','Y','N','N','Produkt','NP',130,TO_TIMESTAMP('2026-09-09 10:05:30','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593525
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(454);
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593526 /*From ID Server*/,543463,0,10,542645,'StorageAttributesKey',TO_TIMESTAMP('2026-09-09 10:05:40','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',1024,'Y','Y','N','N','N','N','N','N','Y','N','N','Y','N','N','Lagerattribute','NP',140,TO_TIMESTAMP('2026-09-09 10:05:40','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593526
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(543463);
+
+-- QtyBefore: new element, nullable (a run that CREATES a candidate has nothing to back up for it)
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,Description,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585440 /*From ID Server*/,0,'ATPReconciliationBackupQtyBefore',TO_TIMESTAMP('2026-09-09 10:06:00','YYYY-MM-DD HH24:MI:SS'),100,'Menge des Bestandskandidaten unmittelbar vor der Aenderung durch die ATP-Abstimmung.','de.metas.material.dispo','Y','Menge vor Aenderung','Menge vor Aenderung',TO_TIMESTAMP('2026-09-09 10:06:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID,CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning, t.Description, t.Help, t.Name, t.PO_Description, t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName, t.WEBUI_NameBrowse, t.WEBUI_NameNew, t.WEBUI_NameNewBreadcrumb, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585440
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+UPDATE AD_Element_Trl SET Name='Qty before change', Description='The candidate quantity immediately before the ATP reconciliation changed it.', PrintName='Qty before change', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 10:06:10','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585440 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585440,'en_US');
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593527 /*From ID Server*/,585440,0,29,542645,'QtyBefore',TO_TIMESTAMP('2026-09-09 10:06:20','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',10,'Y','Y','N','N','N','N','N','N','N','N','N','Y','N','N','Menge vor Aenderung','NP',150,TO_TIMESTAMP('2026-09-09 10:06:20','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593527
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(585440);
+
+-- QtyAfter: new element, mandatory (only ever written once the change is known, together with QtyBefore's row)
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,Description,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585441 /*From ID Server*/,0,'ATPReconciliationBackupQtyAfter',TO_TIMESTAMP('2026-09-09 10:07:00','YYYY-MM-DD HH24:MI:SS'),100,'Menge des Bestandskandidaten nach der Aenderung durch die ATP-Abstimmung.','de.metas.material.dispo','Y','Menge nach Aenderung','Menge nach Aenderung',TO_TIMESTAMP('2026-09-09 10:07:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID,CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning, t.Description, t.Help, t.Name, t.PO_Description, t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName, t.WEBUI_NameBrowse, t.WEBUI_NameNew, t.WEBUI_NameNewBreadcrumb, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585441
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+UPDATE AD_Element_Trl SET Name='Qty after change', Description='The candidate quantity after the ATP reconciliation changed it.', PrintName='Qty after change', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 10:07:10','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585441 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585441,'en_US');
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593528 /*From ID Server*/,585441,0,29,542645,'QtyAfter',TO_TIMESTAMP('2026-09-09 10:07:20','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.material.dispo',10,'Y','Y','N','N','N','N','N','N','Y','N','N','Y','N','N','Menge nach Aenderung','NP',160,TO_TIMESTAMP('2026-09-09 10:07:20','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593528
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(585441);
+
+-- Physical table
+CREATE TABLE public.MD_ATP_Reconciliation_Backup
+(
+	MD_ATP_Reconciliation_Backup_ID NUMERIC(10) NOT NULL,
+	AD_Client_ID NUMERIC(10) NOT NULL,
+	AD_Org_ID NUMERIC(10) NOT NULL,
+	Created TIMESTAMP WITH TIME ZONE NOT NULL,
+	CreatedBy NUMERIC(10) NOT NULL,
+	Updated TIMESTAMP WITH TIME ZONE NOT NULL,
+	UpdatedBy NUMERIC(10) NOT NULL,
+	IsActive CHAR(1) DEFAULT 'Y' CHECK (IsActive IN ('Y','N')) NOT NULL,
+	ReconciliationRunUUID VARCHAR(36) NOT NULL,
+	MD_Candidate_ID NUMERIC(10) NOT NULL,
+	DateProjected TIMESTAMP WITH TIME ZONE NOT NULL,
+	M_Warehouse_ID NUMERIC(10) NOT NULL,
+	M_Product_ID NUMERIC(10) NOT NULL,
+	StorageAttributesKey VARCHAR(1024) NOT NULL,
+	QtyBefore NUMERIC,
+	QtyAfter NUMERIC NOT NULL,
+	CONSTRAINT MD_ATP_Reconciliation_Backup_Key PRIMARY KEY (MD_ATP_Reconciliation_Backup_ID)
+)
+;
+
+CREATE INDEX MD_ATP_Reconciliation_Backup_RunUUID_idx ON public.MD_ATP_Reconciliation_Backup (ReconciliationRunUUID);
+CREATE INDEX MD_ATP_Reconciliation_Backup_Candidate_idx ON public.MD_ATP_Reconciliation_Backup (MD_Candidate_ID);

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5823290_MD_Candidate_Reconcile_ATP_process.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5823290_MD_Candidate_Reconcile_ATP_process.sql
@@ -1,0 +1,215 @@
+-- Registers AD_Process MD_Candidate_Reconcile_ATP: an operator-invocable run of
+-- AtpReconciliationCommand over an optional warehouse/product/product-category filter,
+-- with a dry-run mode and an optional liveness-cutoff date.
+-- IDs allocated from idserver.metas.de on 2026-09-09.
+
+-- Process registration for MD_Candidate_Reconcile_ATP -- an operator-invocable run of
+-- AtpReconciliationCommand restricted by an optional warehouse/product/product-category
+-- filter, with a dry-run mode and an optional liveness-cutoff date.
+INSERT INTO AD_Process (AccessLevel,AD_Client_ID,AD_Org_ID,AD_Process_ID,AllowProcessReRun,Classname,CopyFromProcess,Created,CreatedBy,Description,Help,EntityType,IsActive,IsApplySecuritySettings,IsBetaFunctionality,IsDirectPrint,IsNotifyUserAfterExecution,IsOneInstanceOnly,IsReport,IsTranslateExcelHeaders,IsUseBPartnerLanguage,LockWaitTimeout,Name,PostgrestResponseFormat,RefreshAllAfterExecution,ShowHelp,Type,Updated,UpdatedBy,Value)
+VALUES ('3',0,0,585674 /*From ID Server*/,'Y','de.metas.material.dispo.reconcile.process.MD_Candidate_Reconcile_ATP','N',TO_TIMESTAMP('2026-09-09 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Gleicht das gespeicherte Zusagbare (ATP) mit dem physischen Bestand und offenen Positionen ab, ohne den Bestand zu verändern.','Ein Testlauf wird sofort ausgeführt und zeigt nur an, was sich ändern würde. Ein echter Lauf wird stattdessen als Arbeitspaket zur Verarbeitung im Application-Server eingeplant - das Ergebnis steht deshalb nicht in diesem Prozessprotokoll, sondern am Arbeitspaket.','de.metas.material.dispo','Y','Y','N','N','Y','Y','N','Y','Y',0,'ATP abgleichen','json','Y','Y','Java',TO_TIMESTAMP('2026-09-09 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,'MD_Candidate_Reconcile_ATP')
+;
+
+INSERT INTO AD_Process_Trl (AD_Language,AD_Process_ID,Description,Help,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Process t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_ID=585674
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_ID=t.AD_Process_ID)
+;
+
+UPDATE AD_Process_Trl SET IsTranslated='Y', Name='Reconcile ATP', Description='Reconciles the stored Available-to-Promise (ATP) with physical stock and still-open positions, without moving stock.', Help='A dry run is carried out immediately and only reports what would change. A real run is instead queued as a work package for processing in the application server - so its result is reported on that work package, not in this process log.', Updated=TO_TIMESTAMP('2026-09-09 09:00:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Process_ID=585674
+;
+
+UPDATE AD_Process_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 09:00:03','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Process_ID=585674
+;
+
+UPDATE AD_Process_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 09:00:04','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Process_ID=585674
+;
+
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,Description,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585443 /*From ID Server*/,0,'IsDryRun',TO_TIMESTAMP('2026-09-09 09:00:05','YYYY-MM-DD HH24:MI:SS'),100,'Führt den Abgleich nur simulierend aus - es wird nichts geschrieben, nur die Ergebnisse werden angezeigt. Standardmäßig deaktiviert: ein Lauf ohne explizite Aktivierung schreibt echte Änderungen.','de.metas.material.dispo','Y','Testlauf','Testlauf',TO_TIMESTAMP('2026-09-09 09:00:05','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID,Description,Help,Name,PrintName,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.Description, t.Help, t.Name, t.PrintName, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585443
+AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Dry Run', PrintName='Dry Run', Description='Runs the reconciliation in preview mode only - nothing is written, only the values that would change are reported. Off by default: a run performs a real, data-writing reconciliation unless this option is explicitly enabled.', Updated=TO_TIMESTAMP('2026-09-09 09:00:07','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Element_ID=585443
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 09:00:08','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Element_ID=585443
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 09:00:09','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Element_ID=585443
+;
+
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,Description,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585444 /*From ID Server*/,0,'LivenessCutoffDate',TO_TIMESTAMP('2026-09-09 09:00:10','YYYY-MM-DD HH24:MI:SS'),100,'Positionen vor diesem Datum gelten als abgeschlossen, unabhängig vom Status ihres Quellbelegs.','de.metas.material.dispo','Y','Aktualitäts-Stichtag','Aktualitäts-Stichtag',TO_TIMESTAMP('2026-09-09 09:00:10','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID,Description,Help,Name,PrintName,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.Description, t.Help, t.Name, t.PrintName, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585444
+AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Liveness Cutoff Date', PrintName='Liveness Cutoff Date', Description='Positions dated before this date are treated as closed, regardless of their source document''s status.', Updated=TO_TIMESTAMP('2026-09-09 09:00:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Element_ID=585444
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 09:00:13','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Element_ID=585444
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 09:00:14','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Element_ID=585444
+;
+
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,Updated,UpdatedBy)
+VALUES (0,459,0,585674,543311 /*From ID Server*/,19,'M_Warehouse_ID',TO_TIMESTAMP('2026-09-09 09:00:15','YYYY-MM-DD HH24:MI:SS'),100,'Lager oder Ort für Dienstleistung','de.metas.material.dispo',0,'Y','N','Y','N','N','N','Lager',10,TO_TIMESTAMP('2026-09-09 09:00:15','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID,Description,Help,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Process_Para t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543311
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(459,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(459,'de_CH')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(459,'en_US')
+;
+
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,Updated,UpdatedBy)
+VALUES (0,454,0,585674,543312 /*From ID Server*/,19,'M_Product_ID',TO_TIMESTAMP('2026-09-09 09:00:17','YYYY-MM-DD HH24:MI:SS'),100,'Produkt, Leistung, Artikel','de.metas.material.dispo',0,'Y','N','Y','N','N','N','Produkt',20,TO_TIMESTAMP('2026-09-09 09:00:17','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID,Description,Help,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Process_Para t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543312
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(454,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(454,'de_CH')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(454,'en_US')
+;
+
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,Updated,UpdatedBy)
+VALUES (0,453,0,585674,543313 /*From ID Server*/,19,'M_Product_Category_ID',TO_TIMESTAMP('2026-09-09 09:00:19','YYYY-MM-DD HH24:MI:SS'),100,'Kategorie eines Produktes','de.metas.material.dispo',0,'Y','N','Y','N','N','N','Produkt Kategorie',30,TO_TIMESTAMP('2026-09-09 09:00:19','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID,Description,Help,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Process_Para t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543313
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(453,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(453,'de_CH')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(453,'en_US')
+;
+
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,DefaultValue,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,Updated,UpdatedBy)
+VALUES (0,585443,0,585674,543314 /*From ID Server*/,20,'IsDryRun',TO_TIMESTAMP('2026-09-09 09:00:21','YYYY-MM-DD HH24:MI:SS'),100,'Führt den Abgleich nur simulierend aus - es wird nichts geschrieben, nur die Ergebnisse werden angezeigt. Standardmäßig deaktiviert: ein Lauf ohne explizite Aktivierung schreibt echte Änderungen.','de.metas.material.dispo',0,'N','Y','N','Y','N','Y','N','Testlauf',40,TO_TIMESTAMP('2026-09-09 09:00:21','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID,Description,Help,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Process_Para t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543314
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585443,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585443,'de_CH')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585443,'en_US')
+;
+
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,Updated,UpdatedBy)
+VALUES (0,585444,0,585674,543315 /*From ID Server*/,15,'LivenessCutoffDate',TO_TIMESTAMP('2026-09-09 09:00:23','YYYY-MM-DD HH24:MI:SS'),100,'Positionen vor diesem Datum gelten als abgeschlossen, unabhängig vom Status ihres Quellbelegs.','de.metas.material.dispo',0,'Y','N','Y','N','N','N','Aktualitäts-Stichtag',50,TO_TIMESTAMP('2026-09-09 09:00:23','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID,Description,Help,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Process_Para t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543315
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585444,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585444,'de_CH')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585444,'en_US')
+;
+
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,Description,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585445 /*From ID Server*/,0,NULL,TO_TIMESTAMP('2026-09-09 09:00:25','YYYY-MM-DD HH24:MI:SS'),100,'Gleicht das gespeicherte Zusagbare (ATP) mit dem physischen Bestand und offenen Positionen ab, ohne den Bestand zu verändern.','de.metas.material.dispo','Y','ATP abgleichen','ATP abgleichen',TO_TIMESTAMP('2026-09-09 09:00:25','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID,Description,Help,Name,PrintName,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.Description, t.Help, t.Name, t.PrintName, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585445
+AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Reconcile ATP', PrintName='Reconcile ATP', Description='Reconciles the stored Available-to-Promise (ATP) with physical stock and still-open positions, without moving stock.', Updated=TO_TIMESTAMP('2026-09-09 09:00:27','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Element_ID=585445
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 09:00:28','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Element_ID=585445
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 09:00:29','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Element_ID=585445
+;
+
+INSERT INTO AD_Menu (AD_Client_ID,AD_Element_ID,AD_Menu_ID,AD_Org_ID,AD_Process_ID,Action,Created,CreatedBy,EntityType,IsActive,IsCreateNew,IsReadOnly,IsSOTrx,IsSummary,InternalName,Name,Updated,UpdatedBy)
+VALUES (0,585445,542360 /*From ID Server*/,0,585674,'P',TO_TIMESTAMP('2026-09-09 09:00:30','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.material.dispo','Y','N','N','N','N','MD_Candidate_Reconcile_ATP','ATP abgleichen',TO_TIMESTAMP('2026-09-09 09:00:30','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Menu_Trl (AD_Language,AD_Menu_ID,Name,Description,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Menu_ID, t.Name, t.Description, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Menu t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Menu_ID=542360
+AND NOT EXISTS (SELECT 1 FROM AD_Menu_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Menu_ID=t.AD_Menu_ID)
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585445,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585445,'de_CH')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585445,'en_US')
+;
+
+INSERT INTO AD_TreeNodeMM (AD_Tree_ID,Node_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Parent_ID,SeqNo)
+VALUES (10,542360,0,0,'Y',TO_TIMESTAMP('2026-09-09 09:00:32','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-09 09:00:32','YYYY-MM-DD HH24:MI:SS'),100,1000069,3)
+;

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5823400_MD_Candidate_ATP_Divergence_Report_process.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5823400_MD_Candidate_ATP_Divergence_Report_process.sql
@@ -1,0 +1,132 @@
+-- Registers AD_Process MD_Candidate_ATP_Divergence_Report: a read-only run reporting, per reconciliation
+-- key, the divergence between the stored and the expected Available-to-Promise (ATP), and every open
+-- M_ShipmentSchedule / M_ReceiptSchedule referenced by no candidate at all. Writes nothing.
+-- IDs allocated from idserver.metas.de on 2026-09-09.
+
+-- Process registration for MD_Candidate_ATP_Divergence_Report -- a read-only run over an optional
+-- warehouse/product/product-category filter.
+INSERT INTO AD_Process (AccessLevel,AD_Client_ID,AD_Org_ID,AD_Process_ID,AllowProcessReRun,Classname,CopyFromProcess,Created,CreatedBy,Description,EntityType,IsActive,IsApplySecuritySettings,IsBetaFunctionality,IsDirectPrint,IsNotifyUserAfterExecution,IsOneInstanceOnly,IsReport,IsTranslateExcelHeaders,IsUseBPartnerLanguage,LockWaitTimeout,Name,PostgrestResponseFormat,RefreshAllAfterExecution,ShowHelp,Type,Updated,UpdatedBy,Value)
+VALUES ('3',0,0,585676 /*From ID Server*/,'Y','de.metas.material.dispo.reconcile.process.MD_Candidate_ATP_Divergence_Report','N',TO_TIMESTAMP('2026-09-09 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Meldet je Schlüssel die Abweichung zwischen gespeichertem und erwartetem Zusagbaren (ATP) sowie jeden offenen Beleg ohne Kandidat. Schreibt nichts.','de.metas.material.dispo','Y','Y','N','N','Y','Y','N','Y','Y',0,'ATP Abweichungsbericht','json','N','Y','Java',TO_TIMESTAMP('2026-09-09 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'MD_Candidate_ATP_Divergence_Report')
+;
+
+INSERT INTO AD_Process_Trl (AD_Language,AD_Process_ID,Description,Help,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Process t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_ID=585676
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_ID=t.AD_Process_ID)
+;
+
+UPDATE AD_Process_Trl SET IsTranslated='Y', Name='ATP Divergence Report', Description='Reports, per reconciliation key, the divergence between the stored and the expected Available-to-Promise (ATP), and every open source document referenced by no candidate at all. Writes nothing.', Updated=TO_TIMESTAMP('2026-09-09 10:00:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Process_ID=585676
+;
+
+UPDATE AD_Process_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 10:00:03','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Process_ID=585676
+;
+
+UPDATE AD_Process_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 10:00:04','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Process_ID=585676
+;
+
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,Updated,UpdatedBy)
+VALUES (0,459,0,585676,543317 /*From ID Server*/,19,'M_Warehouse_ID',TO_TIMESTAMP('2026-09-09 10:00:05','YYYY-MM-DD HH24:MI:SS'),100,'Lager oder Ort für Dienstleistung','de.metas.material.dispo',0,'Y','N','Y','N','N','N','Lager',10,TO_TIMESTAMP('2026-09-09 10:00:05','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID,Description,Help,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Process_Para t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543317
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(459,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(459,'de_CH')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(459,'en_US')
+;
+
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,Updated,UpdatedBy)
+VALUES (0,454,0,585676,543318 /*From ID Server*/,19,'M_Product_ID',TO_TIMESTAMP('2026-09-09 10:00:07','YYYY-MM-DD HH24:MI:SS'),100,'Produkt, Leistung, Artikel','de.metas.material.dispo',0,'Y','N','Y','N','N','N','Produkt',20,TO_TIMESTAMP('2026-09-09 10:00:07','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID,Description,Help,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Process_Para t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543318
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(454,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(454,'de_CH')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(454,'en_US')
+;
+
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,Updated,UpdatedBy)
+VALUES (0,453,0,585676,543319 /*From ID Server*/,19,'M_Product_Category_ID',TO_TIMESTAMP('2026-09-09 10:00:09','YYYY-MM-DD HH24:MI:SS'),100,'Kategorie eines Produktes','de.metas.material.dispo',0,'Y','N','Y','N','N','N','Produkt Kategorie',30,TO_TIMESTAMP('2026-09-09 10:00:09','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID,Description,Help,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Process_Para t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543319
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(453,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(453,'de_CH')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(453,'en_US')
+;
+
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,Description,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585447 /*From ID Server*/,0,NULL,TO_TIMESTAMP('2026-09-09 10:00:11','YYYY-MM-DD HH24:MI:SS'),100,'Meldet je Schlüssel die Abweichung zwischen gespeichertem und erwartetem Zusagbaren (ATP) sowie jeden offenen Beleg ohne Kandidat. Schreibt nichts.','de.metas.material.dispo','Y','ATP Abweichungsbericht','ATP Abweichungsbericht',TO_TIMESTAMP('2026-09-09 10:00:11','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID,Description,Help,Name,PrintName,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.Description, t.Help, t.Name, t.PrintName, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585447
+AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='ATP Divergence Report', PrintName='ATP Divergence Report', Description='Reports, per reconciliation key, the divergence between the stored and the expected Available-to-Promise (ATP), and every open source document referenced by no candidate at all. Writes nothing.', Updated=TO_TIMESTAMP('2026-09-09 10:00:13','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Element_ID=585447
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 10:00:14','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Element_ID=585447
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-09 10:00:15','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Element_ID=585447
+;
+
+INSERT INTO AD_Menu (AD_Client_ID,AD_Element_ID,AD_Menu_ID,AD_Org_ID,AD_Process_ID,Action,Created,CreatedBy,EntityType,IsActive,IsCreateNew,IsReadOnly,IsSOTrx,IsSummary,InternalName,Name,Updated,UpdatedBy)
+VALUES (0,585447,542362 /*From ID Server*/,0,585676,'P',TO_TIMESTAMP('2026-09-09 10:00:16','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.material.dispo','Y','N','N','N','N','MD_Candidate_ATP_Divergence_Report','ATP Abweichungsbericht',TO_TIMESTAMP('2026-09-09 10:00:16','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Menu_Trl (AD_Language,AD_Menu_ID,Name,Description,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Menu_ID, t.Name, t.Description, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Menu t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Menu_ID=542362
+AND NOT EXISTS (SELECT 1 FROM AD_Menu_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Menu_ID=t.AD_Menu_ID)
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585447,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585447,'de_CH')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585447,'en_US')
+;
+
+INSERT INTO AD_TreeNodeMM (AD_Tree_ID,Node_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Parent_ID,SeqNo)
+VALUES (10,542362,0,0,'Y',TO_TIMESTAMP('2026-09-09 10:00:18','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-09 10:00:18','YYYY-MM-DD HH24:MI:SS'),100,1000069,4)
+;

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5823510_MD_Candidate_Remove_From_ATP_fix_error_branches.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5823510_MD_Candidate_Remove_From_ATP_fix_error_branches.sql
@@ -1,19 +1,14 @@
--- Function: de_metas_material.MD_Candidate_Remove_From_ATP
--- Purpose: Remove an MD_Candidate record from ATP (Available to Promise) calculations
---
--- This function:
--- 1. Calculates the candidate's stock impact based on type, business case, qty, and qtyFulfilled
--- 2. Negates this impact to remove it from ATP
--- 3. Sets the candidate's Qty to 0
--- 4. Updates the associated STOCK candidate's ATP value
--- 5. Propagates changes through the entire MD_Candidate_QtyDetails chain chronologically
--- 6. Creates QtyDetails if they don't exist (looking up previous STOCK record)
---
--- Stock Impact Formula (uses helper function MD_Candidate_Get_Stock_Impact):
--- - DEMAND, STOCK_UP, INVENTORY_DOWN (STOCK_CHANGE): -qty
--- - SUPPLY, INVENTORY_UP (STOCK_CHANGE): qty
--- - UNEXPECTED_DECREASE, INVENTORY_DOWN, ATTRIBUTES_CHANGED_FROM: -qtyFulfilled
--- - UNEXPECTED_INCREASE, INVENTORY_UP, ATTRIBUTES_CHANGED_TO: qtyFulfilled
+-- Source DDL: backend/de.metas.material/dispo-service/src/main/sql/postgresql/ddl/de_metas_material/MD_Candidate_Remove_From_ATP.sql
+-- Re-creates de_metas_material.MD_Candidate_Remove_From_ATP with the two error branches
+-- ("MD_Candidate not found or not active" and "No STOCK candidate found for this record")
+-- padded to the function's declared 6-column RETURNS TABLE shape. Both previously returned
+-- only 4 values, so the message text landed in the numeric qty_adjustment column and
+-- PostgreSQL raised "structure of query does not match function result type" instead of
+-- returning a well-formed error row. This migration supersedes the STOCK-type-branch fix
+-- already present in this DDL file but not yet reflected in the earlier migration copy
+-- 5794721_MD_Candidate_Remove_From_ATP_function.sql (which still returns only 4 values
+-- there, plus carries a debug RAISE NOTICE not present in the current DDL) -- CREATE OR
+-- REPLACE here re-applies the full current DDL, including that already-fixed branch.
 
 DROP FUNCTION IF EXISTS de_metas_material.MD_Candidate_Remove_From_ATP(numeric)
 ;

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5823680_MD_Candidate_Reconcile_ATP_workpackage_processor.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5823680_MD_Candidate_Reconcile_ATP_workpackage_processor.sql
@@ -1,0 +1,34 @@
+-- Registers the async workpackage processor that performs the real (writing) ATP reconciliation.
+--
+-- Why a work package at all: MD_Candidate_Reconcile_ATP runs in the webapi JVM, which never activates the
+-- material-dispo spring profile, so it cannot call AtpReconciliationCommand directly (IsServerProcess doesn't
+-- help - it only affects Swing class loading). A real run is enqueued and drained here by the app server
+-- instead; a dry run needs none of this, previewed synchronously off the unguarded AtpTargetCalculator.
+--
+-- All three rows are required: a C_Queue_Processor only drains packages assigned to it via
+-- C_Queue_Processor_Assign, so a registered classname with no assignment row just accumulates forever.
+--
+-- IDs allocated from idserver.metas.de on 2026-09-09:
+--   C_Queue_PackageProcessor 540116
+--   C_Queue_Processor        540086
+--   C_Queue_Processor_Assign 540130
+
+INSERT INTO C_Queue_PackageProcessor (AD_Client_ID,AD_Org_ID,Classname,C_Queue_PackageProcessor_ID,Created,CreatedBy,EntityType,InternalName,IsActive,Updated,UpdatedBy)
+VALUES (0,0,'de.metas.material.dispo.reconcile.async.AtpReconciliationWorkpackageProcessor',540116 /*From ID Server*/,TO_TIMESTAMP('2026-09-09 22:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.material.dispo','AtpReconciliationWorkpackageProcessor','Y',TO_TIMESTAMP('2026-09-09 22:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- Own queue processor (not an assignment to an existing one) with PoolSize 1: this must not compete for
+-- threads with the high-volume queues (invoice candidates, printing), and two concurrent reconciliations of
+-- overlapping selections would each compute a target from a chain the other is rewriting.
+--
+-- PoolSize 1 only serialises WITHIN one app server - deliberately no cross-replica lock, because a second
+-- app-server replica activating @Profile(material-dispo) would already be double-processing every material
+-- event, long before two reconciliations could overlap. That topology can't exist without the engine already
+-- being broken, so guarding against it here would be redundant.
+INSERT INTO C_Queue_Processor (AD_Client_ID,AD_Org_ID,C_Queue_Processor_ID,Created,CreatedBy,IsActive,KeepAliveTimeMillis,Name,PoolSize,Updated,UpdatedBy)
+VALUES (0,0,540086 /*From ID Server*/,TO_TIMESTAMP('2026-09-09 22:00:01','YYYY-MM-DD HH24:MI:SS'),100,'Y',1000,'AtpReconciliationWorkpackageProcessor',1,TO_TIMESTAMP('2026-09-09 22:00:01','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO C_Queue_Processor_Assign (AD_Client_ID,AD_Org_ID,C_Queue_PackageProcessor_ID,C_Queue_Processor_Assign_ID,C_Queue_Processor_ID,Created,CreatedBy,IsActive,Updated,UpdatedBy)
+VALUES (0,0,540116,540130 /*From ID Server*/,540086,TO_TIMESTAMP('2026-09-09 22:00:02','YYYY-MM-DD HH24:MI:SS'),100,'Y',TO_TIMESTAMP('2026-09-09 22:00:02','YYYY-MM-DD HH24:MI:SS'),100)
+;

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5823960_MD_Candidate_BusinessCase_ATP_Reconciliation.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5823960_MD_Candidate_BusinessCase_ATP_Reconciliation.sql
@@ -1,0 +1,17 @@
+-- New MD_Candidate_BusinessCase value for the correction candidate an ATP reconciliation run writes, so it is
+-- identifiable on the MD_Candidate window instead of looking like any other INVENTORY_UP/DOWN row.
+
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Ref_List_ID,AD_Reference_ID,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,544366 /*From ID Server*/,540709,TO_TIMESTAMP('2026-09-10 21:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Korrekturkandidat, den ein ATP-Abgleich-Lauf geschrieben hat.','de.metas.material.dispo','Y','ATP-Abgleich',TO_TIMESTAMP('2026-09-10 21:00:00','YYYY-MM-DD HH24:MI:SS'),100,'ATP_RECONCILIATION','ATP-Abgleich')
+;
+
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID,Description,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Ref_List_ID=544366
+  AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+UPDATE AD_Ref_List_Trl SET Description='Correction candidate that an ATP reconciliation run wrote.', Name='ATP reconciliation', Updated=TO_TIMESTAMP('2026-09-10 21:00:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Ref_List_ID=544366
+;

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5824000_MD_Candidate_ATP_process_fix_de_translation_flags.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5824000_MD_Candidate_ATP_process_fix_de_translation_flags.sql
@@ -1,0 +1,45 @@
+-- Corrects the AD_Element_Trl.IsTranslated flag on the de_DE / de_CH rows of the elements added by
+-- 5823290_MD_Candidate_Reconcile_ATP_process.sql (AD_Element_ID 585443 IsDryRun, 585444
+-- LivenessCutoffDate, 585445 the process element) and 5823400_MD_Candidate_ATP_Divergence_Report_process.sql
+-- (AD_Element_ID 585447 the process element). Those two already-integrated scripts UPDATEd the
+-- de_DE / de_CH AD_Element_Trl rows to IsTranslated='Y', which deviates from the base-language
+-- convention followed elsewhere in this same PR (see 5823240_MD_ATP_Reconciliation_Backup_table.sql,
+-- which never touches the de_DE/de_CH _Trl rows it seeds): base-language (German) translation rows
+-- stay IsTranslated='N' -- only the actual en_US override is marked 'Y'. Text is unaffected here
+-- (identical to base either way); this corrects the flag only, and re-cascades the correction to the
+-- AD_Process_Para_Trl / AD_Menu_Trl rows that had already copied the wrong flag via
+-- update_TRL_Tables_On_AD_Element_TRL_Update in the original scripts.
+-- Per the Migration Script Immutability rule, the two original scripts are already committed and
+-- integrated on this branch, so they are left untouched and this follow-up script carries the fix.
+
+UPDATE AD_Element_Trl SET IsTranslated='N', Updated=TO_TIMESTAMP('2026-09-10 12:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='de_DE' AND AD_Element_ID IN (585443,585444,585445,585447)
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='N', Updated=TO_TIMESTAMP('2026-09-10 12:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='de_CH' AND AD_Element_ID IN (585443,585444,585445,585447)
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585443,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585443,'de_CH')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585444,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585444,'de_CH')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585445,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585445,'de_CH')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585447,'de_DE')
+;
+
+select update_TRL_Tables_On_AD_Element_TRL_Update(585447,'de_CH')
+;

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5824020_MD_Candidate_BusinessCase_ATP_Reconciliation_fix_value_length.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5824020_MD_Candidate_BusinessCase_ATP_Reconciliation_fix_value_length.sql
@@ -1,0 +1,8 @@
+-- MD_Candidate.MD_Candidate_BusinessCase is varchar(15) (AD_Column_ID 556485). Script 5823960 (already
+-- integrated on this branch) inserted Value='ATP_RECONCILIATION' - 18 characters, silently truncated to
+-- 'ATP_RECONCILIAT' on write, so CandidateBusinessCase.ofCode() throws on every read-back. Per Migration
+-- Script Immutability, 5823960 is left untouched; this follow-up corrects the value to fit the column.
+
+UPDATE AD_Ref_List SET Value='ATP_RECONCILE', Updated=TO_TIMESTAMP('2026-09-10 22:10:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544366
+;

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5824060_MD_ATP_Reconciliation_Backup_IsCandidateOwnDetail.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5824060_MD_ATP_Reconciliation_Backup_IsCandidateOwnDetail.sql
@@ -1,0 +1,51 @@
+-- MD_ATP_Reconciliation_Backup legitimately holds MULTIPLE rows per MD_Candidate_ID over time - one per
+-- reconciliation run that ever touched that candidate (its own migration header: "one row per STOCK
+-- candidate a reconciliation run touched"). AtpReconciliationDetailRepo (added by an earlier commit on this
+-- branch, reusing this same table as the ATP_RECONCILIATION business-case detail) looked a candidate up by
+-- MD_Candidate_ID alone and called firstOnly(), which throws once a second reconciliation run backs up the
+-- same candidate a second time - breaking the normal, expected case of reconciling the same key repeatedly.
+--
+-- This column marks the ONE row (out of however many accumulate for a given candidate) that is the
+-- correction candidate's OWN detail - written only by AtpReconciliationDetailRepo.saveOrUpdate at the
+-- candidate's creation, never by the audit-trail writes in AtpReconciliationBackupRepositoryImpl. The
+-- partial unique index below enforces "at most one such row per candidate" at the database level, the same
+-- way this codebase enforces "at most one active row per X" elsewhere.
+
+-- New column: AD_Element + AD_Column
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585454 /*From ID Server*/,0,'IsCandidateOwnDetail',TO_TIMESTAMP('2026-09-10 22:40:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.material.dispo','Y','Eigenes Korrekturdetail','Eigenes Korrekturdetail',TO_TIMESTAMP('2026-09-10 22:40:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID,Description,Help,Name,PrintName,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.Description, t.Help, t.Name, t.PrintName, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585454
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl SET Name='This candidate''s own ATP reconciliation detail', PrintName='This candidate''s own ATP reconciliation detail', Updated=TO_TIMESTAMP('2026-09-10 22:40:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Element_ID=585454
+;
+
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,DefaultValue,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,593551 /*From ID Server*/,585454,0,20,542645,'IsCandidateOwnDetail',TO_TIMESTAMP('2026-09-10 22:41:00','YYYY-MM-DD HH24:MI:SS'),100,'N','N','de.metas.material.dispo',1,'Y','Y','N','N','N','N','N','N','Y','N','N','Y','N','Y','Eigenes Korrekturdetail','NP',90,TO_TIMESTAMP('2026-09-10 22:41:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID,Name,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=593551
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(585454);
+
+-- Physical column: brand new, so ADD COLUMN (t_alter_column only works on columns that already exist).
+-- Non-volatile DEFAULT 'N' populates every existing row without a table rewrite; backup first since this
+-- table already carries real audit data on any instance the earlier ATP-reconciliation commits reached.
+SELECT backup_table('md_atp_reconciliation_backup', '_29675_IsCandidateOwnDetail');
+ALTER TABLE MD_ATP_Reconciliation_Backup ADD COLUMN IF NOT EXISTS IsCandidateOwnDetail CHAR(1) DEFAULT 'N';
+UPDATE MD_ATP_Reconciliation_Backup SET IsCandidateOwnDetail='N' WHERE IsCandidateOwnDetail IS NULL;
+ALTER TABLE MD_ATP_Reconciliation_Backup ALTER COLUMN IsCandidateOwnDetail SET NOT NULL;
+
+-- Enforce "at most one own-detail row per candidate" at the database level.
+CREATE UNIQUE INDEX md_atp_reconciliation_backup_owndetail_uidx ON MD_ATP_Reconciliation_Backup (MD_Candidate_ID) WHERE IsCandidateOwnDetail='Y';

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5824070_MD_Candidate_BusinessCase_ATP_Reconciliation_fix_en_translated_flag.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5824070_MD_Candidate_BusinessCase_ATP_Reconciliation_fix_en_translated_flag.sql
@@ -1,0 +1,7 @@
+-- 5823960 (already integrated) inserted the en_US AD_Ref_List_Trl row with IsTranslated left at 'N' (the
+-- seed default) and only overrode Description/Name - never flipping IsTranslated to 'Y' for the actual
+-- override language, unlike every other AD_Ref_List value in this PR. Text is unaffected; flag only.
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-10 22:45:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Ref_List_ID=544366
+;

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5824090_MD_ATP_Reconciliation_Backup_IsCandidateOwnDetail_fix_en_translated_flag.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5824090_MD_ATP_Reconciliation_Backup_IsCandidateOwnDetail_fix_en_translated_flag.sql
@@ -1,0 +1,12 @@
+-- 5824060 (already integrated) inserted the en_US AD_Element_Trl override for IsCandidateOwnDetail (585454)
+-- with IsTranslated left at 'N' - the identical defect 5824070 fixed for AD_Ref_List_Trl, reintroduced here
+-- in the same PR. update_Column_Translation_From_AD_Element then copied that wrong flag straight onto the
+-- AD_Column_Trl row (593551) too. Text is unaffected; flags only.
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-10 23:20:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Element_ID=585454
+;
+
+UPDATE AD_Column_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-09-10 23:20:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Column_ID=593551
+;

--- a/backend/de.metas.material/dispo-service/src/test/java/de/metas/material/dispo/service/event/handler/StockChangedEventHandlerTest.java
+++ b/backend/de.metas.material/dispo-service/src/test/java/de/metas/material/dispo/service/event/handler/StockChangedEventHandlerTest.java
@@ -9,11 +9,13 @@ import static java.math.BigDecimal.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.Instant;
 
+import lombok.NonNull;
 import org.adempiere.test.AdempiereTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -129,6 +131,130 @@ public class StockChangedEventHandlerTest
 		assertInvocationCandidateCommons(candidate);
 		assertThat(candidate.getType()).isEqualTo(CandidateType.INVENTORY_DOWN);
 		assertThat(candidate.getQuantity()).isEqualByComparingTo("5");
+	}
+
+	/**
+	 * A key that was never reconciled: its chain carries no unfulfilled planned position, but its running
+	 * balance (15) has drifted away from the physical quantity.<br>
+	 * StockChangedEvent with qtyOnHandOld=20, qtyOnHand=10;<br>
+	 * <p>
+	 * => Expect an "INVENTORY_DOWN" of 5, i.e. the chain is re-baselined onto the physical 10. Applying the
+	 * event's physical movement (-10) instead would have produced an "INVENTORY_DOWN" of 10 and left the chain
+	 * at 5. Re-baselining such a chain is the reset-stock process's original purpose, and it has to survive
+	 * the change that stops the refresh from discarding still-open positions.
+	 */
+	@Test
+	public void handleEvent_noPlannedPositions_reBaselinesOntoThePhysicalQty()
+	{
+		final StockChangedEvent event = createStockChangedEvent(new BigDecimal("20"), TEN);
+
+		when(candidateRepositoryRetrieval.retrieveLatestMatchOrNull(any()))
+				.thenReturn(stockCandidateWithQuantity("15"));
+		// no stubbing of hasUnfulfilledPlannedPositions: the chain carries none
+
+		// invoke the method under test
+		stockChangedEventHandler.handleEvent(event);
+
+		final ArgumentCaptor<Candidate> candidateCaptor = ArgumentCaptor.forClass(Candidate.class);
+		verify(candidateChangeService)
+				.onCandidateNewOrChange(candidateCaptor.capture());
+		final Candidate candidate = candidateCaptor.getValue();
+		//
+		assertThat(candidate.getType()).isEqualTo(CandidateType.INVENTORY_DOWN);
+		assertThat(candidate.getQuantity()).isEqualByComparingTo("5");
+	}
+
+	/**
+	 * A chain whose running balance (170) is deliberately not the physical quantity, because it carries an
+	 * unfulfilled planned position of 30.<br>
+	 * StockChangedEvent with qtyOnHandOld=200, qtyOnHand=205, i.e. the physical quantity moved by +5;<br>
+	 * <p>
+	 * => Expect an "INVENTORY_UP" of 5, so the chain lands on 175 and keeps the position. Re-baselining onto
+	 * the bare physical 205 would silently absorb the 30 - the reset-stock process is a repeatable batch, so
+	 * that used to undo a reconciliation on every run.
+	 */
+	@Test
+	public void handleEvent_unfulfilledPlannedPositions_appliesOnlyThePhysicalMovement()
+	{
+		final StockChangedEvent event = createStockChangedEvent(new BigDecimal("200"), new BigDecimal("205"));
+
+		when(candidateRepositoryRetrieval.retrieveLatestMatchOrNull(any()))
+				.thenReturn(stockCandidateWithQuantity("170"));
+		when(candidateRepositoryRetrieval.hasUnfulfilledPlannedPositions(any()))
+				.thenReturn(true);
+
+		// invoke the method under test
+		stockChangedEventHandler.handleEvent(event);
+
+		final ArgumentCaptor<Candidate> candidateCaptor = ArgumentCaptor.forClass(Candidate.class);
+		verify(candidateChangeService)
+				.onCandidateNewOrChange(candidateCaptor.capture());
+		final Candidate candidate = candidateCaptor.getValue();
+		//
+		assertThat(candidate.getType()).isEqualTo(CandidateType.INVENTORY_UP);
+		assertThat(candidate.getQuantity()).isEqualByComparingTo("5");
+	}
+
+	/**
+	 * The same chain as above, but the refresh finds the physical quantity unchanged (200 -> 200).<br>
+	 * <p>
+	 * => Expect no candidate at all: nothing physical happened, so there is nothing to apply. Before the
+	 * change, the delta was taken against the running balance and came out as 200 - 170 = +30, which pushed
+	 * the projection back onto the bare physical stock.
+	 * <p>
+	 * <b>Defensive test - no production producer emits this event.</b> The only producer,
+	 * {@code StockDataUpdateRequestHandler.fireStockChangedEvent}, returns early when the old and new
+	 * quantities are equal, and its reset-stock caller {@code MD_Stock_Update_From_M_HUs.retrieveHuData}
+	 * additionally filters on {@code QtyOnHandChange <> 0}. So this pins the handler's own arithmetic at
+	 * the zero-movement boundary and nothing more; the production-reachable regression is the sibling
+	 * {@link #handleEvent_unfulfilledPlannedPositions_appliesOnlyThePhysicalMovement()}, which is where a
+	 * behaviour change would actually surface for a customer.
+	 */
+	@Test
+	public void handleEvent_unfulfilledPlannedPositions_andUnchangedPhysicalQty_createsNoCandidate()
+	{
+		final BigDecimal twoHundred = new BigDecimal("200");
+		final StockChangedEvent event = createStockChangedEvent(twoHundred, twoHundred);
+
+		when(candidateRepositoryRetrieval.retrieveLatestMatchOrNull(any()))
+				.thenReturn(stockCandidateWithQuantity("170"));
+		when(candidateRepositoryRetrieval.hasUnfulfilledPlannedPositions(any()))
+				.thenReturn(true);
+
+		// invoke the method under test
+		stockChangedEventHandler.handleEvent(event);
+
+		verify(candidateChangeService, never()).onCandidateNewOrChange(any());
+	}
+
+	private static Candidate stockCandidateWithQuantity(@NonNull final String quantity)
+	{
+		return Candidate.builder()
+				.type(CandidateType.STOCK)
+				.clientAndOrgId(CLIENT_AND_ORG_ID)
+				.materialDescriptor(newMaterialDescriptor().withQuantity(new BigDecimal(quantity)))
+				.build();
+	}
+
+	private StockChangedEvent createStockChangedEvent(
+			@NonNull final BigDecimal qtyOnHandOld,
+			@NonNull final BigDecimal qtyOnHand)
+	{
+		final StockChangedEvent event = StockChangedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(10, 20))
+				.changeDate(Instant.parse("2018-11-19T10:15:30.00Z"))
+				.productDescriptor(createProductDescriptor())
+				.qtyOnHand(qtyOnHand)
+				.qtyOnHandOld(qtyOnHandOld)
+				.stockChangeDetails(StockChangeDetails.builder()
+						.stockId(30)
+						.resetStockPInstanceId(ResetStockPInstanceId.ofRepoId(40))
+						.transactionId(50)
+						.build())
+				.warehouseId(WAREHOUSE_ID)
+				.build();
+		event.validate(); // guard
+		return event;
 	}
 
 	private StockChangedEvent createCommonStockChangedEvent()

--- a/backend/de.metas.material/dispo-service/src/test/java/de/metas/material/dispo/service/event/handler/stockchange/StockEstimateCreatedHandlerTest.java
+++ b/backend/de.metas.material/dispo-service/src/test/java/de/metas/material/dispo/service/event/handler/stockchange/StockEstimateCreatedHandlerTest.java
@@ -1,0 +1,139 @@
+package de.metas.material.dispo.service.event.handler.stockchange;
+
+/*
+ * #%L
+ * metasfresh-material-dispo-service
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.material.dispo.commons.candidate.Candidate;
+import de.metas.material.dispo.commons.candidate.CandidateType;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
+import de.metas.material.dispo.service.candidatechange.CandidateChangeService;
+import de.metas.material.event.commons.EventDescriptor;
+import de.metas.material.event.stockestimate.StockEstimateCreatedEvent;
+import lombok.NonNull;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static de.metas.material.event.EventTestHelper.CLIENT_AND_ORG_ID;
+import static de.metas.material.event.EventTestHelper.newMaterialDescriptor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Mirrors {@link de.metas.material.dispo.service.event.handler.StockChangedEventHandlerTest}'s
+ * unfulfilled-planned-position coverage - see that class for why re-baselining onto a bare counted qty is unsafe.
+ */
+public class StockEstimateCreatedHandlerTest
+{
+	private StockEstimateCreatedHandler stockEstimateCreatedHandler;
+	private CandidateChangeService candidateChangeService;
+	private CandidateRepositoryRetrieval candidateRepositoryRetrieval;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		candidateRepositoryRetrieval = Mockito.mock(CandidateRepositoryRetrieval.class);
+		candidateChangeService = Mockito.mock(CandidateChangeService.class);
+
+		final StockEstimateEventService stockEstimateEventService = new StockEstimateEventService(candidateRepositoryRetrieval);
+		stockEstimateCreatedHandler = new StockEstimateCreatedHandler(candidateChangeService, stockEstimateEventService);
+	}
+
+	/**
+	 * No existing stock candidate, no planned positions: counted qty 10 -> INVENTORY_UP of 10, unchanged behaviour.
+	 */
+	@Test
+	public void handleEvent_noPlannedPositions_reBaselinesOntoTheCountedQty()
+	{
+		final StockEstimateCreatedEvent event = createEvent(new BigDecimal("10"));
+
+		// retrieveLatestMatchOrNull defaults to null for every query (both the "existing candidate for this
+		// event" check and the "previous STOCK candidate" lookup) - no stubbing needed for this scenario.
+		// no stubbing of hasUnfulfilledPlannedPositions either: the chain carries none
+
+		stockEstimateCreatedHandler.handleEvent(event);
+
+		final ArgumentCaptor<Candidate> candidateCaptor = ArgumentCaptor.forClass(Candidate.class);
+		verify(candidateChangeService).onCandidateNewOrChange(candidateCaptor.capture());
+		final Candidate candidate = candidateCaptor.getValue();
+		assertThat(candidate.getType()).isEqualTo(CandidateType.INVENTORY_UP);
+		assertThat(candidate.getQuantity()).isEqualByComparingTo("10");
+	}
+
+	/**
+	 * A chain whose running balance (170) carries an unfulfilled planned position of 30 on top of a physical 140.
+	 * A Zählbestand count of 140 (the correct physical qty) must NOT re-baseline the chain onto 140 - that would
+	 * silently absorb the still-open 30. Unlike {@code StockChangedEvent}, this event carries no separate
+	 * old/new pair to fall back to a pure physical-movement delta, so the safe behaviour is to write nothing at
+	 * all and leave the correction to the ATP reconciliation process.
+	 */
+	@Test
+	public void handleEvent_unfulfilledPlannedPositions_writesNoCandidate()
+	{
+		final StockEstimateCreatedEvent event = createEvent(new BigDecimal("140"));
+
+		// only the "previous STOCK candidate" query returns a match; the "existing candidate for this event"
+		// check must still see null, or the handler's own guard against a duplicate candidate fires instead.
+		when(candidateRepositoryRetrieval.retrieveLatestMatchOrNull(argThat(q -> q != null && q.getType() == CandidateType.STOCK)))
+				.thenReturn(stockCandidateWithQuantity("170"));
+		when(candidateRepositoryRetrieval.hasUnfulfilledPlannedPositions(any()))
+				.thenReturn(true);
+
+		stockEstimateCreatedHandler.handleEvent(event);
+
+		verify(candidateChangeService, never()).onCandidateNewOrChange(any());
+	}
+
+	private static Candidate stockCandidateWithQuantity(@NonNull final String quantity)
+	{
+		return Candidate.builder()
+				.type(CandidateType.STOCK)
+				.clientAndOrgId(CLIENT_AND_ORG_ID)
+				.materialDescriptor(newMaterialDescriptor().withQuantity(new BigDecimal(quantity)))
+				.build();
+	}
+
+	private StockEstimateCreatedEvent createEvent(@NonNull final BigDecimal countedQty)
+	{
+		return StockEstimateCreatedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(10, 20))
+				.materialDescriptor(newMaterialDescriptor().withQuantity(countedQty))
+				.date(Instant.parse("2018-11-19T10:15:30.00Z"))
+				.plantId(0)
+				.freshQtyOnHandId(60)
+				.freshQtyOnHandLineId(70)
+				.qtyStockEstimateSeqNo(null)
+				.eventDate(Instant.parse("2018-11-19T10:15:30.00Z"))
+				.build();
+	}
+}

--- a/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
+++ b/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
@@ -7,9 +7,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class HttpCallSchedulerTest
 {
@@ -113,10 +115,18 @@ class HttpCallSchedulerTest
 			throw new RuntimeException("test error");
 		}));
 
-		// Should complete exceptionally
-		assertThat(failingFuture).isCompletedExceptionally();
+		// Should complete exceptionally.
+		// The supplier throws on the scheduler's pool thread, so completion happens
+		// asynchronously. Block until the future settles (up to 5s) instead of checking
+		// isCompletedExceptionally() synchronously: that check was racy and failed
+		// intermittently on CPU-contended CI runners where the pool thread had not yet
+		// run the throwing supplier at the instant the assertion was evaluated.
+		assertThatThrownBy(() -> failingFuture.get(5, TimeUnit.SECONDS))
+				.isInstanceOf(ExecutionException.class)
+				.hasCauseInstanceOf(RuntimeException.class);
 
-		// Wait a bit for scheduler to settle
+		// Wait a bit for scheduler to settle (let the pool thread finish run() and
+		// complete executorFuture, so the next schedule() re-submits run() for the queue)
 		Thread.sleep(500);
 
 		// Second request should still succeed


### PR DESCRIPTION
Rolling merge-through carrying `modus_operandi_release` into `new_dawn_uat` — propagates the ATP reconciliation work (transaction-detail lookup + write-path fix, material-events queue-drain fix, mobile-webui TOCTOU fix) up to the main line.

Had real merge conflicts (not auto-mergeable) because `new_dawn_uat` carries independent, unrelated work touching the same files: a warehouse-exclusion guard rollout across material-dispo event handlers, a `DemandCandiateHandler` → `DemandCandidateHandler` rename with new required constructor parameters, an FK-violation regression test, and a generalized RabbitMQ queue-draining refactor. Resolved by keeping both sides' functionality everywhere rather than picking one over the other — verified with a full reactor build after resolution (all touched modules test-compile clean; the one unrelated failure, in a JDK17 service module neither side touches, is a documented bad local JDK Temurin patch, not a code issue).

Also fixed two pre-existing test-compile breaks that only a full reactor build surfaces (neither branch's own CI job catches them): `StockDataUpdateRequestHandlerTest` / `AttributesChangedEventHandlerForStockRecordsTest` were never updated for a constructor signature change, and the two ATP reconciliation unit tests needed updating for the class rename inherited from `new_dawn_uat`.
